### PR TITLE
修复图像生成后缀识别及路径纠正问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@
 ### 从源码构建
 ```bash
 # 克隆仓库
-git clone https://github.com/limcode/limcode.git
-cd limcode
+git clone https://github.com/Lianues/Lim-Code.git
+cd Lim-Code
 
 # 安装依赖
 npm install


### PR DESCRIPTION
这次改动主要解决 AI 调用工具时指定的 output_path 后缀与实际图片格式不符的问题。

### 改动内容
1. **引入文件头探测（Magic Number）**
增加对生成图片二进制头信息的嗅探逻辑，用于识别图片的真实格式。目前支持 PNG、JPEG、GIF 和 WebP 的识别，作为后续路径校验的依据。

2. **自动纠正输出路径后缀**
如果 AI 指定的 output_path 后缀与图片真实格式不符（比如明明生成了 jpeg 却要保存成 .png），程序会自动修正后缀名，确保保存的文件可以正常打开。

3. **同义后缀过滤**
考虑到 .jpg、.jpeg、.jfif 属于同类格式，增加了 areSynonyms 判断。如果只是这类同义后缀的差异，则不再触发重命名，减少不必要的路径变动。

4. **修正 README 中的地址错误**
将 https://github.com/limcode/limcode.git 改为实际的项目路径 https://github.com/Lianues/Lim-Code.git。

### 为什么这么改
在使用 Godot 游戏引擎自动生成素材时，偶然发现如果文件扩展名与真实格式不符，引擎会报错导致资源无法导入。为了规避此类兼容性问题，通过识别二进制头确认真实格式并自动修正路径，使生成的图片文件更具确定性。改动仅局限于 generate_image.ts 内部，顺带修改了偶然发现的 readme 中的瑕疵。