### PR TITLE
feat: 为 Skills 面板添加刷新按钮，支持手动重新扫描技能列表

### DIFF
--- a/backend/i18n/index.ts
+++ b/backend/i18n/index.ts
@@ -32,7 +32,7 @@ let detectedLanguage: string = 'zh-CN';
 /**
  * 获取实际使用的语言
  */
-function getActualLanguage(): string {
+export function getActualLanguage(): string {
     if (currentLanguage === 'auto') {
         // 尝试匹配检测到的语言
         if (detectedLanguage && messages[detectedLanguage]) {

--- a/backend/modules/skills/types.ts
+++ b/backend/modules/skills/types.ts
@@ -54,7 +54,7 @@ export interface SkillsState {
  */
 export interface SkillsChangeEvent {
     /** 变更类型 */
-    type: 'enabled' | 'disabled' | 'refresh';
+    type: 'enabled' | 'disabled' | 'refresh' | 'update';
     
     /** 变更的 skill IDs */
     skillIds: string[];

--- a/frontend/src/i18n/langs/en.ts
+++ b/frontend/src/i18n/langs/en.ts
@@ -273,12 +273,13 @@ const en: LanguageMessages = {
                 title: 'Skills',
                 description: 'Skills are user-defined knowledge modules. Checkbox: enable in conversation. Switch: send detailed content to AI.',
                 loading: 'Loading...',
-                empty: 'No skills available. Create skills in the skills folder.',
+                empty: 'No skills available. Click the folder icon in the top right to open the directory. Create a folder containing a SKILL.md file to add a skill.',
                 notExists: 'Does not exist',
                 enableTooltip: 'Enable this skill in current conversation',
                 sendContentTooltip: 'Send skill content to AI when enabled',
                 hint: 'AI can also decide whether to send skill content via toggle_skills tool',
-                openDirectory: 'Open Skills Directory'
+                openDirectory: 'Open Skills Directory',
+                refresh: 'Refresh Skills list'
             },
             promptContext: {
                 title: 'Prompt Context',

--- a/frontend/src/i18n/langs/ja.ts
+++ b/frontend/src/i18n/langs/ja.ts
@@ -273,12 +273,13 @@ const ja: LanguageMessages = {
                 title: 'Skills',
                 description: 'Skills はユーザー定義のナレッジモジュールです。チェックボックス：会話で有効化。スイッチ：詳細内容を AI に送信。',
                 loading: '読み込み中...',
-                empty: '利用可能な Skills がありません。skills フォルダーで作成してください。',
+                empty: '利用可能な Skills がありません。右上のフォルダーアイコンでディレクトリを開き、SKILL.md ファイルを含むフォルダーを作成すると追加できます。',
                 notExists: '存在しません',
                 enableTooltip: '現在の会話でこの Skill を有効にする',
                 sendContentTooltip: '有効時に Skill の内容を AI に送信する',
                 hint: 'AI も toggle_skills ツールで Skill 内容を送信するかどうかを決定できます',
-                openDirectory: 'Skills ディレクトリを開く'
+                openDirectory: 'Skills ディレクトリを開く',
+                refresh: 'Skills リストを更新'
             },
             promptContext: {
                 title: 'プロンプトコンテキスト',

--- a/frontend/src/i18n/langs/zh-CN.ts
+++ b/frontend/src/i18n/langs/zh-CN.ts
@@ -273,12 +273,13 @@ const zhCN: LanguageMessages = {
                 title: 'Skills',
                 description: 'Skills 是用户自定义的知识模块。勾选框：在对话中启用。开关：发送详细内容给 AI。',
                 loading: '加载中...',
-                empty: '暂无可用的 Skills。请在 skills 文件夹中创建。',
+                empty: '暂无可用的 Skills。点击右上角文件夹图标打开目录，创建一个文件夹并包含 SKILL.md 文件即可添加。',
                 notExists: '不存在',
                 enableTooltip: '在当前对话中启用此 Skill',
                 sendContentTooltip: '启用时发送 Skill 内容给 AI',
                 hint: 'AI 也可以通过 toggle_skills 工具来决定是否发送某个 Skill 内容',
-                openDirectory: '打开 Skills 存储目录'
+                openDirectory: '打开 Skills 存储目录',
+                refresh: '刷新 Skills 列表'
             },
             promptContext: {
                 title: '提示词上下文',

--- a/frontend/src/i18n/types.ts
+++ b/frontend/src/i18n/types.ts
@@ -379,6 +379,7 @@ export interface LanguageMessages {
                 sendContentTooltip: string;
                 hint: string;
                 openDirectory: string;
+                refresh: string;
             };
             promptContext: {
                 title: string;

--- a/frontend/src/services/skills.ts
+++ b/frontend/src/services/skills.ts
@@ -32,6 +32,10 @@ export async function removeSkillConfig(id: string) {
   return await sendToExtension('removeSkillConfig', { id })
 }
 
+export async function refreshSkills() {
+  return await sendToExtension('refreshSkills', {})
+}
+
 export async function getSkillsDirectory(): Promise<{ path: string | null }> {
   return await sendToExtension('getSkillsDirectory', {}) as { path: string | null }
 }

--- a/webview/ChatViewProvider.ts
+++ b/webview/ChatViewProvider.ts
@@ -27,7 +27,7 @@ import type { CreateMcpServerInput, UpdateMcpServerInput, McpServerInfo } from '
 import { DependencyManager, type InstallProgressEvent } from '../backend/modules/dependencies';
 import { toolRegistry, registerAllTools, onTerminalOutput, onImageGenOutput, TaskManager, setSubAgentExecutorContext } from '../backend/tools';
 import type { TerminalOutputEvent, ImageGenOutputEvent, TaskEvent } from '../backend/tools';
-import { createSkillsManager } from '../backend/modules/skills';
+import { createSkillsManager, getSkillsManager } from '../backend/modules/skills';
 import {
     setGlobalSettingsManager,
     setGlobalConfigManager,
@@ -636,6 +636,9 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         
         // 释放 MCP 管理器资源（断开所有连接）
         this.mcpManager?.dispose();
+
+        // 释放 Skills 管理器资源
+        getSkillsManager()?.dispose();
 
         console.log('ChatViewProvider disposed');
     }


### PR DESCRIPTION
## 功能描述
为 Skills 管理面板添加了刷新按钮，允许用户手动重新扫描 skills 目录，检测新添加或删除的 skill 文件，无需重启插件。

## 变更内容

### 前端 (Frontend)
- SkillsWidget.vue: 添加刷新按钮（带 loading 旋转动画）
- skills.ts: 新增 efreshSkills() API 调用
- i18n 翻译: 添加 skillsPanel.refresh 字段（中/英/日）

### 后端 (Backend)
- SkillsHandlers.ts: 新增 efreshSkills 消息处理器
- SkillsManager.ts: 暴露 efresh() 方法重新扫描目录

## 测试步骤
1. 打开 Skills 面板（点击输入框旁的 💡 图标）
2. 在 skills 目录添加/删除一个 skill 文件夹
3. 点击面板右上角的刷新按钮（🔄）
4. 验证 skill 列表已更新

## 检查清单
- [x] 代码符合项目规范
- [x] 已添加 i18n 翻译（zh-CN/en/ja）
- [x] 已测试正常刷新流程
- [x] 已测试 loading 状态显示
- [x] 无 breaking changes