### PR TITLE
输入框UI的微调

### DIFF
--- a/frontend/src/components/input/InputBox.vue
+++ b/frontend/src/components/input/InputBox.vue
@@ -66,7 +66,7 @@ const emit = defineEmits<{
 }>()
 
 const editorRef = ref<HTMLDivElement>()
-const currentRows = ref(props.minRows || 2)
+const currentRows = ref(props.minRows || 4)
 
 // 调整高度时的检测状态
 const cachedLineHeight = ref(0)
@@ -152,8 +152,8 @@ function adjustHeight() {
   if (!editorRef.value) return
 
   const editor = editorRef.value
-  const minRows = props.minRows || 2
-  const maxRows = props.maxRows || 6
+  const minRows = props.minRows || 4
+  const maxRows = props.maxRows || 8
 
   if (!cachedLineHeight.value) {
     cachedLineHeight.value = parseInt(getComputedStyle(editor).lineHeight) || 20
@@ -444,6 +444,12 @@ function handlePaste(e: ClipboardEvent) {
     const cleaned = text.replace(/\u200B/g, '')
     insertPlainTextWithLineBreaksAtCaret(editorRef.value, cleaned)
     handleInput()
+    // 粘贴后滚动到末尾
+    nextTick(() => {
+      if (editorRef.value) {
+        editorRef.value.scrollTop = editorRef.value.scrollHeight
+      }
+    })
   }
 }
 
@@ -713,7 +719,7 @@ defineExpose({
 /* contenteditable 编辑器 */
 .input-editor {
   width: 100%;
-  min-height: 56px; /* 至少两行视觉高度 */
+  min-height: 80px; /* 至少四行视觉高度 */
   max-height: 160px;
   padding: var(--spacing-sm, 8px);
   background: var(--vscode-input-background);


### PR DESCRIPTION
## 改动

### 1. 增大输入框最大行数
- 将 `maxRows` 默认值从 6 调整为 8
- 配合之前 `minRows` 从 2 调整为 4 的改动，提供更宽敞的编辑空间
- 减少用户在编写较长内容时的滚动频率

### 2. 修复粘贴后视图问题
- 在 `handlePaste` 中添加粘贴完成后的自动滚动逻辑
- 使用 `nextTick` 确保 DOM 更新后再执行滚动
- 将滚动位置设置为 `scrollHeight`，确保新粘贴的内容始终可见