### PR TITLE
fix(models): 修复模型回退逻辑与第三方 Gemini 模型过滤

### DIFF
--- a/backend/modules/api/settings/types.ts
+++ b/backend/modules/api/settings/types.ts
@@ -153,7 +153,7 @@ export interface SettingsChangeNotification {
     type: 'settingsChanged';
     
     /** 变更类型 */
-    changeType: 'channel' | 'tools' | 'toolMode' | 'proxy' | 'ui' | 'full';
+    changeType: 'channel' | 'tools' | 'toolMode' | 'proxy' | 'storagePath' | 'ui' | 'full';
     
     /** 变更的字段路径（如 'toolsEnabled.read_file'） */
     path?: string;

--- a/backend/modules/channel/modelList.ts
+++ b/backend/modules/channel/modelList.ts
@@ -66,10 +66,10 @@ export async function getGeminiModels(config: ChannelConfig, proxyUrl?: string):
       pageToken = data.nextPageToken;
     } while (pageToken);
 
-    // 过滤出支持 generateContent 的模型
+    // 过滤出支持 generateContent 的模型（兼容第三方中转站未返回 supportedGenerationMethods 的情况）
     return allModels
       .filter((m: any) => 
-        m.supportedGenerationMethods?.includes('generateContent')
+        !m.supportedGenerationMethods || (Array.isArray(m.supportedGenerationMethods) && m.supportedGenerationMethods.includes('generateContent'))
       )
       .map((m: any) => ({
         id: m.name.replace('models/', ''),

--- a/backend/modules/settings/SettingsManager.ts
+++ b/backend/modules/settings/SettingsManager.ts
@@ -1962,7 +1962,7 @@ export class SettingsManager {
         await this.storage.save(this.settings);
         
         this.notifyChange({
-            type: 'full',
+            type: 'storagePath',
             path: 'storagePath',
             oldValue: oldConfig,
             newValue: newConfig,

--- a/backend/modules/settings/types.ts
+++ b/backend/modules/settings/types.ts
@@ -1335,7 +1335,7 @@ export interface GlobalSettings {
  */
 export interface SettingsChangeEvent {
     /** 变更类型 */
-    type: 'channel' | 'tools' | 'toolMode' | 'proxy' | 'ui' | 'full';
+    type: 'channel' | 'tools' | 'toolMode' | 'proxy' | 'storagePath' | 'ui' | 'full';
     
     /** 变更的字段路径（如 'toolsEnabled.read_file'） */
     path?: string;

--- a/frontend/src/components/input/InputArea.vue
+++ b/frontend/src/components/input/InputArea.vue
@@ -82,7 +82,7 @@ const channelOptions = computed<ChannelOption[]>(() =>
     .map(config => ({
       id: config.id,
       name: config.name,
-      model: config.model || config.id,
+      model: config.model || '',
       type: config.type
     }))
 )
@@ -152,6 +152,8 @@ async function handleModelChange(modelId: string) {
 const hasAttachments = computed(() => (props.attachments?.length || 0) > 0)
 
 const canSend = computed(() => {
+  if (!currentModel.value) return false
+
   const plainText = getPlainText(editorNodes.value).trim()
   const hasContexts = getContexts(editorNodes.value).length > 0
   const hasContent = plainText.length > 0 || hasContexts || (props.attachments?.length || 0) > 0

--- a/frontend/src/stores/chat/configActions.ts
+++ b/frontend/src/stores/chat/configActions.ts
@@ -29,13 +29,13 @@ export async function loadCurrentConfig(state: ChatStoreState): Promise<void> {
       state.currentConfig.value = {
         id: config.id,
         name: config.name,
-        model: config.model || config.id,
+        model: config.model || '',
         type: config.type,
         maxContextTokens: config.maxContextTokens
       }
 
       if (!normalizeModelId(state.selectedModelId.value)) {
-        state.selectedModelId.value = config.model || config.id
+        state.selectedModelId.value = config.model || ''
       }
     }
   } catch (err) {
@@ -83,18 +83,18 @@ export async function applyConversationModelConfig(
     if (storedConfigId) {
       state.configId.value = storedConfigId
       await loadCurrentConfig(state)
-      state.selectedModelId.value = storedModelId || state.currentConfig.value?.model || storedConfigId
+      state.selectedModelId.value = storedModelId || state.currentConfig.value?.model || ''
       return
     }
 
     // 未存储对话级配置：至少确保 currentConfig 与 configId 对齐
     await loadCurrentConfig(state)
-    state.selectedModelId.value = state.currentConfig.value?.model || state.configId.value
+    state.selectedModelId.value = state.currentConfig.value?.model || ''
   } catch (error) {
     console.error('Failed to apply conversation model config:', error)
     // 兜底：确保 currentConfig / selectedModelId 不为空
     await loadCurrentConfig(state)
-    state.selectedModelId.value = state.currentConfig.value?.model || state.configId.value
+    state.selectedModelId.value = state.currentConfig.value?.model || ''
   }
 }
 
@@ -181,7 +181,7 @@ export async function setSelectedModelId(state: ChatStoreState, modelId: string)
 export async function setConfigId(state: ChatStoreState, newConfigId: string): Promise<void> {
   state.configId.value = newConfigId
   await loadCurrentConfig(state)
-  state.selectedModelId.value = state.currentConfig.value?.model || newConfigId
+  state.selectedModelId.value = state.currentConfig.value?.model || ''
   
   // 保存到后端
   try {
@@ -204,7 +204,7 @@ export async function loadSavedConfigId(state: ChatStoreState): Promise<void> {
     }
 
     await loadCurrentConfig(state)
-    state.selectedModelId.value = state.currentConfig.value?.model || state.configId.value
+    state.selectedModelId.value = state.currentConfig.value?.model || ''
   } catch (error) {
     console.error('Failed to load saved config ID:', error)
   }


### PR DESCRIPTION
## 改动
- 移除 \configActions.ts\ 中 \selectedModelId\ 错误回退到 \configId\ 的逻辑
- 修改 \InputArea.vue\，在当前模型为空时禁用发送功能
- 放宽 \modelList.ts\ 的 Gemini 模型过滤条件，兼容 \supportedGenerationMethods\ 字段为空的响应
- 补充 \storagePath\ 的设置变更类型声明

## 原因
- 当前渠道未配置默认模型时，UI 占位符显示异常，且未阻断向空模型发送消息导致执行报错
- 部分第三方中转 API 返回的 Gemini 模型列表数据格式不完整，导致可用模型被错误排除