### PR TITLE
feat(history): 支持配置 history_search 检索范围 (全部/仅总结)

### DIFF
--- a/backend/i18n/langs/en.ts
+++ b/backend/i18n/langs/en.ts
@@ -401,10 +401,11 @@ Output content directly without any prefix.`
         
         history: {
             noSummarizedHistory: 'No summarized history found. Context summarization has not been triggered yet in this conversation.',
-            searchResultHeader: 'Found {count} match(es) for "{query}" in summarized history ({totalLines} total lines)',
-            noMatchesFound: 'No matches found for "{query}" in summarized history ({totalLines} total lines). Try different keywords.',
+            noHistory: 'No conversation history found.',
+            searchResultHeader: 'Found {count} match(es) for "{query}" in history ({totalLines} total lines)',
+            noMatchesFound: 'No matches found for "{query}" in history ({totalLines} total lines). Try different keywords.',
             resultsLimited: '[Results limited to {max} matches. Try a more specific query to narrow results.]',
-            readResultHeader: 'Lines {start}-{end} of {totalLines} total lines in summarized history',
+            readResultHeader: 'Lines {start}-{end} of {totalLines} total lines in history',
             readTruncated: '[Output limited to {max} lines. Use start_line={nextStart} to continue reading.]',
             invalidRegex: 'Invalid regular expression: {error}',
             invalidRange: 'Invalid line range: {start}-{end} (document has {totalLines} lines)',

--- a/backend/i18n/langs/ja.ts
+++ b/backend/i18n/langs/ja.ts
@@ -401,10 +401,11 @@ const ja: BackendLanguageMessages = {
         
         history: {
             noSummarizedHistory: '要約された履歴が見つかりません。この会話ではまだコンテキスト要約がトリガーされていません。',
-            searchResultHeader: '要約済み履歴で "{query}" の一致が {count} 件見つかりました（全 {totalLines} 行）',
-            noMatchesFound: '要約済み履歴で "{query}" の一致は見つかりませんでした（全 {totalLines} 行）。別のキーワードをお試しください。',
+            noHistory: '会話履歴が見つかりません。',
+            searchResultHeader: '履歴で "{query}" の一致が {count} 件見つかりました（全 {totalLines} 行）',
+            noMatchesFound: '履歴で "{query}" の一致は見つかりませんでした（全 {totalLines} 行）。別のキーワードをお試しください。',
             resultsLimited: '[結果は {max} 件に制限されています。より具体的なクエリをお試しください。]',
-            readResultHeader: '要約済み履歴の {start}-{end} 行目（全 {totalLines} 行）',
+            readResultHeader: '履歴の {start}-{end} 行目（全 {totalLines} 行）',
             readTruncated: '[出力は {max} 行に制限されています。start_line={nextStart} で続きを読んでください。]',
             invalidRegex: '無効な正規表現：{error}',
             invalidRange: '無効な行範囲：{start}-{end}（ドキュメントは全 {totalLines} 行）',

--- a/backend/i18n/langs/zh-CN.ts
+++ b/backend/i18n/langs/zh-CN.ts
@@ -401,10 +401,11 @@ const zhCN: BackendLanguageMessages = {
         
         history: {
             noSummarizedHistory: '没有找到已总结的历史记录。当前对话尚未触发上下文总结。',
-            searchResultHeader: '在已总结历史中找到 {count} 个匹配项，关键词："{query}"（共 {totalLines} 行）',
-            noMatchesFound: '在已总结历史中未找到 "{query}" 的匹配项（共 {totalLines} 行）。请尝试其他关键词。',
+            noHistory: '未找到对话历史记录。',
+            searchResultHeader: '在历史记录中找到 {count} 个匹配项，关键词："{query}"（共 {totalLines} 行）',
+            noMatchesFound: '在历史记录中未找到 "{query}" 的匹配项（共 {totalLines} 行）。请尝试其他关键词。',
             resultsLimited: '[结果限制为 {max} 个匹配项。请使用更具体的关键词。]',
-            readResultHeader: '已总结历史的第 {start}-{end} 行（共 {totalLines} 行）',
+            readResultHeader: '历史记录的第 {start}-{end} 行（共 {totalLines} 行）',
             readTruncated: '[输出限制为 {max} 行。使用 start_line={nextStart} 继续读取。]',
             invalidRegex: '无效的正则表达式：{error}',
             invalidRange: '无效的行范围：{start}-{end}（文档共 {totalLines} 行）',

--- a/backend/i18n/types.ts
+++ b/backend/i18n/types.ts
@@ -400,6 +400,7 @@ export interface BackendLanguageMessages {
         /** 历史检索工具 */
         history: {
             noSummarizedHistory: string;
+            noHistory: string;
             searchResultHeader: string;
             noMatchesFound: string;
             resultsLimited: string;

--- a/backend/modules/settings/types.ts
+++ b/backend/modules/settings/types.ts
@@ -147,6 +147,9 @@ export interface HistorySearchToolConfig {
     /** 输出时单行的最大显示字符数（超出部分省略，可通过单行 read 获取完整内容） */
     lineDisplayLimit: number;
 
+    /** 检索范围 */
+    searchScope?: 'all' | 'summarized';
+
     [key: string]: unknown;
 }
 
@@ -1561,7 +1564,8 @@ export const DEFAULT_HISTORY_SEARCH_CONFIG: HistorySearchToolConfig = {
     searchContextLines: 3,
     maxReadLines: 300,
     maxResultChars: 30000,
-    lineDisplayLimit: 500
+    lineDisplayLimit: 500,
+    searchScope: 'all'
 };
 
 /**

--- a/frontend/src/components/settings/tools/history/history_search.vue
+++ b/frontend/src/components/settings/tools/history/history_search.vue
@@ -15,6 +15,7 @@ import { sendToExtension } from '@/utils/vscode'
 import { t } from '@/i18n'
 
 // 配置数据
+const searchScope = ref<'all' | 'summarized'>('all')
 const maxSearchMatches = ref(30)
 const searchContextLines = ref(3)
 const maxReadLines = ref(300)
@@ -34,6 +35,7 @@ async function loadConfig() {
       {}
     )
     if (response?.config) {
+      searchScope.value = response.config.searchScope ?? 'all'
       maxSearchMatches.value = response.config.maxSearchMatches ?? 30
       searchContextLines.value = response.config.searchContextLines ?? 3
       maxReadLines.value = response.config.maxReadLines ?? 300
@@ -53,6 +55,7 @@ async function saveConfig() {
   try {
     await sendToExtension('tools.updateHistorySearchConfig', {
       config: {
+        searchScope: searchScope.value,
         maxSearchMatches: maxSearchMatches.value,
         searchContextLines: searchContextLines.value,
         maxReadLines: maxReadLines.value,
@@ -95,6 +98,12 @@ function updateNumber(event: Event, field: 'maxSearchMatches' | 'searchContextLi
   saveConfig()
 }
 
+// 选择框更新
+function updateSelect(event: Event) {
+  searchScope.value = (event.target as HTMLSelectElement).value as 'all' | 'summarized'
+  saveConfig()
+}
+
 onMounted(() => {
   loadConfig()
 })
@@ -117,6 +126,24 @@ onMounted(() => {
         </div>
 
         <div class="section-content">
+          <div class="config-item">
+            <div class="item-info">
+              <span class="item-label">{{ t('components.settings.toolSettings.history.searchScope') }}</span>
+              <span class="item-description">{{ t('components.settings.toolSettings.history.searchScopeDesc') }}</span>
+            </div>
+            <div class="select-wrapper">
+              <select
+                :value="searchScope"
+                :disabled="isSaving"
+                class="config-select"
+                @change="updateSelect($event)"
+              >
+                <option value="all">{{ t('components.settings.toolSettings.history.scopeAll') }}</option>
+                <option value="summarized">{{ t('components.settings.toolSettings.history.scopeSummarized') }}</option>
+              </select>
+            </div>
+          </div>
+
           <div class="config-item">
             <div class="item-info">
               <span class="item-label">{{ t('components.settings.toolSettings.history.maxSearchMatches') }}</span>
@@ -363,5 +390,20 @@ onMounted(() => {
 @keyframes spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
+}
+
+.select-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.config-select {
+  padding: 4px 8px;
+  background: var(--vscode-dropdown-background);
+  color: var(--vscode-dropdown-foreground);
+  border: 1px solid var(--vscode-dropdown-border, var(--vscode-panel-border));
+  border-radius: 4px;
+  font-size: 12px;
+  outline: none;
 }
 </style>

--- a/frontend/src/i18n/langs/en.ts
+++ b/frontend/src/i18n/langs/en.ts
@@ -1527,6 +1527,10 @@ const en: LanguageMessages = {
                 },
                 history: {
                     searchSection: 'Search Mode',
+                    searchScope: 'Search Scope',
+                    searchScopeDesc: 'Select the range of history records the tool can search',
+                    scopeAll: 'All conversation history (Default)',
+                    scopeSummarized: 'Summarized content only',
                     maxSearchMatches: 'Max Matches',
                     maxSearchMatchesDesc: 'Maximum number of matching lines returned per search',
                     searchContextLines: 'Context Lines',

--- a/frontend/src/i18n/langs/ja.ts
+++ b/frontend/src/i18n/langs/ja.ts
@@ -1527,6 +1527,10 @@ const ja: LanguageMessages = {
                 },
                 history: {
                     searchSection: '検索モード',
+                    searchScope: '検索範囲',
+                    searchScopeDesc: 'ツールが検索できる履歴の範囲を選択します',
+                    scopeAll: 'すべての会話履歴（デフォルト）',
+                    scopeSummarized: '要約された内容のみ',
                     maxSearchMatches: '最大一致数',
                     maxSearchMatchesDesc: '検索ごとに返される最大一致行数',
                     searchContextLines: 'コンテキスト行数',

--- a/frontend/src/i18n/langs/zh-CN.ts
+++ b/frontend/src/i18n/langs/zh-CN.ts
@@ -1527,6 +1527,10 @@ const zhCN: LanguageMessages = {
                 },
                 history: {
                     searchSection: '搜索模式',
+                    searchScope: '搜索范围',
+                    searchScopeDesc: '选择工具能够检索的历史记录范围',
+                    scopeAll: '全部对话历史（默认）',
+                    scopeSummarized: '仅已总结的内容',
                     maxSearchMatches: '最大匹配数',
                     maxSearchMatchesDesc: '每次搜索返回的最大匹配行数',
                     searchContextLines: '上下文行数',

--- a/frontend/src/i18n/types.ts
+++ b/frontend/src/i18n/types.ts
@@ -590,6 +590,10 @@ export interface LanguageMessages {
                 /** 历史工具设置 */
                 history: {
                     searchSection: string;
+                    searchScope: string;
+                    searchScopeDesc: string;
+                    scopeAll: string;
+                    scopeSummarized: string;
                     maxSearchMatches: string;
                     maxSearchMatchesDesc: string;
                     searchContextLines: string;


### PR DESCRIPTION
## 改动
- \HistorySearchToolConfig\ 新增 \searchScope\ 配置项，默认允许搜索全部历史
- 前端新增对应的配置下拉面板与多语言 (zh-CN, en, ja) 翻译
- \historySearchHandler\ 支持根据设置在全部历史和已总结历史中切换截断范围
- 优化工具的描述 getter，每次提供基于当前配置的准确提示词

## 原因
默认情况下，历史记录工具不应隐蔽性地过滤近期产生的聊天内容。提供范围设置可以给予用户更大自由度，在 token 或性能受限的场景下只搜压缩后的历史文档，或在需要通盘查阅时全量检索近期记录。