### PR TITLE
fix(mcp): resolve auto-connect not triggering on initialization

### DIFF
--- a/backend/modules/mcp/McpManager.ts
+++ b/backend/modules/mcp/McpManager.ts
@@ -63,9 +63,6 @@ export class McpManager {
 
     /**
      * 初始化管理器
-     *
-     * 注意：初始化时不进行自动连接，自动连接由前端控制
-     * 这样可以确保前端 UI 能够正确显示连接状态
      */
     async initialize(): Promise<void> {
         if (this.initialized) {
@@ -76,6 +73,15 @@ export class McpManager {
         await this.reloadFromStorage();
 
         this.initialized = true;
+
+        // 触发自动连接
+        const serversToConnect = this.getServersToAutoConnect();
+        for (const serverId of serversToConnect) {
+            // 异步连接，不阻塞初始化流程
+            this.connect(serverId).catch(e => {
+                console.error(`[MCP] Auto-connect failed for ${serverId}:`, e);
+            });
+        }
     }
     
     /**


### PR DESCRIPTION
## 改动
- 将 MCP 服务器的自动连接逻辑从前端 UI (McpSettings.vue) 迁移到后端 (McpManager.ts)
- 在 McpManager.ts 的 initialize 方法结束时，异步触发已启用且配置了自动连接的服务器的连接
- 修正了后端误导性的注释
- 清理了前端的冗余触发代码，让前端专心负责状态展示和用户手动干预

## 原因
在此前架构中，MCP 的自动连接强依赖前端控制面板。导致除非用户主动点开 MCP 设置页面进行渲染，否则带有 `autoConnect` 的配置永远不会开始自动连接。为了让服务器在后台能静默自动启动，需要将职责移至后端。

## 关联
- 解决 MCP 自动连接依赖 UI 的 Bug