### PR TITLE
fix: 收敛 prompt 工具解析链路并修复流式工具展示一致性

### DIFF
--- a/backend/modules/api/chat/handlers/StreamResponseProcessor.ts
+++ b/backend/modules/api/chat/handlers/StreamResponseProcessor.ts
@@ -12,6 +12,8 @@ import type { Content, ContentPart } from '../../../conversation/types';
 import type { StreamChunk, GenerateResponse } from '../../../channel/types';
 import { StreamAccumulator } from '../../../channel/StreamAccumulator';
 import { ChannelError, ErrorType } from '../../../channel/types';
+import type { ToolMode } from '../../../config/configs/base';
+import { generateToolCallId } from '../utils';
 
 /**
  * 流式处理配置
@@ -21,6 +23,8 @@ export interface StreamProcessorConfig {
     requestStartTime: number;
     /** 渠道类型 */
     providerType: 'gemini' | 'openai' | 'anthropic' | 'openai-responses' | 'custom';
+    /** 当前请求的工具模式 */
+    toolMode: ToolMode;
     /** 取消信号 */
     abortSignal?: AbortSignal;
     /** 对话 ID */
@@ -62,12 +66,12 @@ export interface CancelledData {
 export class StreamResponseProcessor {
     private accumulator: StreamAccumulator;
     private config: StreamProcessorConfig;
-    private lastPartsLength: number = 0;
     private cancelled: boolean = false;
+    private previousContent?: Content;
 
     constructor(config: StreamProcessorConfig) {
         this.config = config;
-        this.accumulator = new StreamAccumulator();
+        this.accumulator = new StreamAccumulator(config.toolMode, generateToolCallId);
         this.accumulator.setRequestStartTime(config.requestStartTime);
         this.accumulator.setProviderType(config.providerType);
     }
@@ -91,27 +95,29 @@ export class StreamResponseProcessor {
                     break;
                 }
 
-                this.accumulator.add(chunk);
+                const normalizedDelta = this.accumulator.add(chunk);
 
                 // 获取累加器处理后的 parts（实时转换工具调用标记）
                 const currentContent = this.accumulator.getContent();
-                const currentParts = currentContent.parts;
-
-                // 计算增量 delta
-                const newDelta = currentParts.slice(this.lastPartsLength);
-                this.lastPartsLength = currentParts.length;
+                const shouldSendSnapshot = this.shouldSendContentSnapshot(this.previousContent, currentContent);
 
                 // 构建处理后的 chunk
                 const processedChunk: StreamChunk & { thinkingStartTime?: number } = {
                     ...chunk,
-                    delta: newDelta.length > 0 ? newDelta : chunk.delta
+                    delta: normalizedDelta
                 };
+
+                if (shouldSendSnapshot) {
+                    processedChunk.contentSnapshot = currentContent;
+                }
 
                 // 如果有思考开始时间，添加到 chunk
                 const thinkingStartTime = currentContent.thinkingStartTime;
                 if (thinkingStartTime !== undefined) {
                     processedChunk.thinkingStartTime = thinkingStartTime;
                 }
+
+                this.previousContent = currentContent;
 
                 yield {
                     conversationId: this.config.conversationId,
@@ -197,6 +203,64 @@ export class StreamResponseProcessor {
         };
 
         return { content, chunkData };
+    }
+
+    private shouldSendContentSnapshot(previousContent: Content | undefined, currentContent: Content): boolean {
+        if (!previousContent) {
+            return false;
+        }
+
+        const previousParts = previousContent.parts || [];
+        const currentParts = currentContent.parts || [];
+
+        if (currentParts.length < previousParts.length) {
+            return true;
+        }
+
+        for (let i = 0; i < previousParts.length; i++) {
+            const previousPart = previousParts[i];
+            const currentPart = currentParts[i];
+
+            if (!currentPart) {
+                return true;
+            }
+
+            if (this.arePartsEqual(previousPart, currentPart)) {
+                continue;
+            }
+
+            if (i !== previousParts.length - 1) {
+                return true;
+            }
+
+            if (this.isSafeTextAppend(previousPart, currentPart)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private isSafeTextAppend(previousPart: ContentPart, currentPart: ContentPart): boolean {
+        if (!('text' in previousPart) || !('text' in currentPart)) {
+            return false;
+        }
+        if (previousPart.functionCall || currentPart.functionCall) {
+            return false;
+        }
+        if (previousPart.thought !== currentPart.thought) {
+            return false;
+        }
+        if (typeof previousPart.text !== 'string' || typeof currentPart.text !== 'string') {
+            return false;
+        }
+        return currentPart.text.startsWith(previousPart.text);
+    }
+
+    private arePartsEqual(a: ContentPart, b: ContentPart): boolean {
+        return JSON.stringify(a) === JSON.stringify(b);
     }
 }
 

--- a/backend/modules/api/chat/services/ToolCallParserService.ts
+++ b/backend/modules/api/chat/services/ToolCallParserService.ts
@@ -8,9 +8,28 @@
  */
 
 import type { Content, ContentPart } from '../../../conversation/types';
-import { parseXMLToolCalls } from '../../../../tools/xmlFormatter';
-import { parseJSONToolCalls, TOOL_CALL_START } from '../../../../tools/jsonFormatter';
+import type { ToolMode } from '../../../config/configs/base';
+import {
+    detectPromptToolMode,
+    extractPromptToolParts,
+    type PromptToolMode
+} from '../../../../tools/promptToolParser';
 import { generateToolCallId, type FunctionCallInfo } from '../utils';
+
+function assignFunctionCallIds(parts: ContentPart[]): ContentPart[] {
+    return parts.map(part => {
+        if (!part.functionCall) {
+            return part;
+        }
+        return {
+            ...part,
+            functionCall: {
+                ...part.functionCall,
+                id: part.functionCall.id || generateToolCallId()
+            }
+        };
+    });
+}
 
 /**
  * 工具调用解析服务
@@ -23,178 +42,82 @@ import { generateToolCallId, type FunctionCallInfo } from '../utils';
 export class ToolCallParserService {
     /**
      * 从 Content 中提取函数调用
-     *
-     * 支持三种模式：
-     * 1. Function Call 模式：从 part.functionCall 提取
-     * 2. XML 模式：从 part.text 中解析 <tool_use> XML 标签
-     * 3. JSON 边界标记模式：从 part.text 中解析 <<<TOOL_CALL>>> 标记
-     *
-     * @param content 消息内容
-     * @returns 函数调用列表
      */
-    extractFunctionCalls(content: Content): FunctionCallInfo[] {
+    extractFunctionCalls(content: Content, toolMode: ToolMode = 'function_call'): FunctionCallInfo[] {
         const calls: FunctionCallInfo[] = [];
-        
+
         for (const part of content.parts) {
-            // Function Call 模式
             if (part.functionCall) {
                 calls.push({
                     name: part.functionCall.name,
                     args: part.functionCall.args,
                     id: part.functionCall.id || generateToolCallId()
                 });
+                continue;
             }
-            
-            // XML 模式：从文本中解析工具调用（支持多个调用）
-            if (part.text && part.text.includes('<tool_use>')) {
-                const xmlCalls = parseXMLToolCalls(part.text);
-                for (const xmlCall of xmlCalls) {
-                    calls.push({
-                        name: xmlCall.name,
-                        args: xmlCall.args,
-                        id: generateToolCallId()
-                    });
-                }
+
+            if (!part.text || part.thought || toolMode === 'function_call') {
+                continue;
             }
-            
-            // JSON 边界标记模式：从文本中解析工具调用（支持多个调用）
-            if (part.text && part.text.includes(TOOL_CALL_START)) {
-                const jsonCalls = parseJSONToolCalls(part.text);
-                for (const jsonCall of jsonCalls) {
-                    calls.push({
-                        name: jsonCall.tool,
-                        args: jsonCall.parameters,
-                        id: generateToolCallId()
-                    });
+
+            const parsedParts = this.parsePromptText(part.text, toolMode);
+            for (const parsedPart of parsedParts) {
+                if (!parsedPart.functionCall) {
+                    continue;
                 }
+                calls.push({
+                    name: parsedPart.functionCall.name,
+                    args: parsedPart.functionCall.args,
+                    id: parsedPart.functionCall.id || generateToolCallId()
+                });
             }
         }
-        
+
         return calls;
     }
-    
+
     /**
-     * 将 XML/JSON 工具调用转换为 functionCall 格式
-     *
-     * 当使用 XML 或 JSON 模式时，模型返回的文本中包含工具调用标记。
-     * 此方法将文本中的工具调用解析出来，并转换为 functionCall 格式的 parts。
-     * 这样存储和前端显示都使用统一的 functionCall 格式。
+     * 将 prompt 模式工具调用转换为 functionCall 格式
      *
      * 注意：此方法会直接修改传入的 content 对象
-     *
-     * @param content 消息内容（会被修改）
      */
-    convertXMLToolCallsToFunctionCalls(content: Content): void {
-        const newParts: ContentPart[] = [];
-        
-        for (const part of content.parts) {
-            // 检查文本中是否包含 XML 工具调用（支持多个调用）
-            if (part.text && part.text.includes('<tool_use>')) {
-                const xmlCalls = parseXMLToolCalls(part.text);
-                if (xmlCalls.length > 0) {
-                    // 提取所有工具调用，并分离前后文本
-                    let remainingText = part.text;
-                    
-                    for (const xmlCall of xmlCalls) {
-                        // 查找当前工具调用的位置
-                        const startMarkerIdx = remainingText.indexOf('<tool_use>');
-                        const endMarkerIdx = remainingText.indexOf('</tool_use>');
-                        
-                        if (startMarkerIdx !== -1 && endMarkerIdx !== -1) {
-                            // 添加工具调用前的文本
-                            const textBefore = remainingText.substring(0, startMarkerIdx).trim();
-                            if (textBefore) {
-                                newParts.push({ text: textBefore });
-                            }
-                            
-                            // 添加 functionCall
-                            newParts.push({
-                                functionCall: {
-                                    name: xmlCall.name,
-                                    args: xmlCall.args,
-                                    id: generateToolCallId()
-                                }
-                            });
-                            
-                            // 更新剩余文本
-                            remainingText = remainingText.substring(endMarkerIdx + '</tool_use>'.length);
-                        }
-                    }
-                    
-                    // 添加最后剩余的文本
-                    const finalText = remainingText.trim();
-                    if (finalText) {
-                        newParts.push({ text: finalText });
-                    }
-                } else {
-                    // 解析失败，保留原文本
-                    newParts.push(part);
-                }
-            }
-            // 检查文本中是否包含 JSON 边界标记工具调用
-            else if (part.text && part.text.includes(TOOL_CALL_START)) {
-                const jsonCalls = parseJSONToolCalls(part.text);
-                if (jsonCalls.length > 0) {
-                    // 提取所有工具调用，并分离前后文本
-                    let remainingText = part.text;
-                    
-                    for (const jsonCall of jsonCalls) {
-                        // 查找当前工具调用的位置
-                        const startMarkerIdx = remainingText.indexOf(TOOL_CALL_START);
-                        const endMarkerIdx = remainingText.indexOf('<<<END_TOOL_CALL>>>');
-                        
-                        if (startMarkerIdx !== -1 && endMarkerIdx !== -1) {
-                            // 添加工具调用前的文本
-                            const textBefore = remainingText.substring(0, startMarkerIdx).trim();
-                            if (textBefore) {
-                                newParts.push({ text: textBefore });
-                            }
-                            
-                            // 添加 functionCall
-                            newParts.push({
-                                functionCall: {
-                                    name: jsonCall.tool,
-                                    args: jsonCall.parameters,
-                                    id: generateToolCallId()
-                                }
-                            });
-                            
-                            // 更新剩余文本
-                            remainingText = remainingText.substring(endMarkerIdx + '<<<END_TOOL_CALL>>>'.length);
-                        }
-                    }
-                    
-                    // 添加最后剩余的文本
-                    const finalText = remainingText.trim();
-                    if (finalText) {
-                        newParts.push({ text: finalText });
-                    }
-                } else {
-                    // 解析失败，保留原文本
-                    newParts.push(part);
-                }
-            } else {
-                // 不包含工具调用，保留原 part
-                newParts.push(part);
-            }
+    convertPromptModeToolCallsToFunctionCalls(content: Content, toolMode: ToolMode = 'function_call'): void {
+        if (toolMode === 'function_call') {
+            return;
         }
-        
-        // 替换 parts
+
+        const promptMode = toolMode as PromptToolMode;
+        const newParts: ContentPart[] = [];
+
+        for (const part of content.parts) {
+            if (!part.text || part.thought) {
+                newParts.push(part);
+                continue;
+            }
+
+            const parsedParts = this.parsePromptText(part.text, promptMode);
+            if (parsedParts.length === 0) {
+                newParts.push(part);
+                continue;
+            }
+
+            newParts.push(...assignFunctionCallIds(parsedParts));
+        }
+
         content.parts = newParts;
     }
-    
+
+    /**
+     * 兼容旧名称
+     */
+    convertXMLToolCallsToFunctionCalls(content: Content, toolMode: ToolMode = 'function_call'): void {
+        this.convertPromptModeToolCallsToFunctionCalls(content, toolMode);
+    }
+
     /**
      * 确保 Content 中的所有 functionCall 都有唯一 id
      *
-     * Gemini 格式的响应不包含 functionCall.id，
-     * 我们在保存到历史之前为其添加唯一 id，
-     * 以便前端可以通过 id 匹配 functionCall 和 functionResponse
-     *
-     * 对于 OpenAI 格式，如果已经有 id 则保留原有 id
-     *
      * 注意：此方法会直接修改传入的 content 对象
-     *
-     * @param content 消息内容（会被修改）
      */
     ensureFunctionCallIds(content: Content): void {
         for (const part of content.parts) {
@@ -202,5 +125,23 @@ export class ToolCallParserService {
                 part.functionCall.id = generateToolCallId();
             }
         }
+    }
+
+    private parsePromptText(text: string, toolMode: ToolMode | PromptToolMode): ContentPart[] {
+        if (toolMode === 'function_call') {
+            return [];
+        }
+
+        const detectedMode = detectPromptToolMode(text);
+        const promptMode = (toolMode === 'json' || toolMode === 'xml') ? toolMode : detectedMode;
+        if (!promptMode) {
+            return [];
+        }
+
+        const { parts } = extractPromptToolParts(text, promptMode, {
+            flushIncompleteTailAsText: true
+        });
+
+        return parts;
     }
 }

--- a/backend/modules/api/chat/services/ToolIterationLoopService.ts
+++ b/backend/modules/api/chat/services/ToolIterationLoopService.ts
@@ -443,6 +443,7 @@ export class ToolIterationLoopService {
                 const processor = new StreamResponseProcessor({
                     requestStartTime,
                     providerType: config.type as 'gemini' | 'openai' | 'anthropic' | 'openai-responses' | 'custom',
+                    toolMode: config.toolMode || 'function_call',
                     abortSignal,
                     conversationId
                 });
@@ -469,6 +470,7 @@ export class ToolIterationLoopService {
                 const processor = new StreamResponseProcessor({
                     requestStartTime,
                     providerType: config.type as 'gemini' | 'openai' | 'anthropic' | 'openai-responses' | 'custom',
+                    toolMode: config.toolMode || 'function_call',
                     abortSignal,
                     conversationId
                 });
@@ -479,7 +481,7 @@ export class ToolIterationLoopService {
             }
 
             // 9. 转换工具调用格式
-            this.toolCallParserService.convertXMLToolCallsToFunctionCalls(finalContent);
+            this.toolCallParserService.convertPromptModeToolCallsToFunctionCalls(finalContent, config.toolMode || 'function_call');
             this.toolCallParserService.ensureFunctionCallIds(finalContent);
 
             // 10. 保存 AI 响应到历史
@@ -488,7 +490,7 @@ export class ToolIterationLoopService {
             }
 
             // 11. 检查是否有工具调用
-            const functionCalls = this.toolCallParserService.extractFunctionCalls(finalContent);
+            const functionCalls = this.toolCallParserService.extractFunctionCalls(finalContent, config.toolMode || 'function_call');
 
             if (functionCalls.length === 0) {
                 // 没有工具调用，创建模型消息后的检查点并返回完成数据
@@ -781,7 +783,7 @@ export class ToolIterationLoopService {
             const finalContent = generateResponse.content;
 
             // 转换 XML 工具调用为 functionCall 格式（如果有）
-            this.toolCallParserService.convertXMLToolCallsToFunctionCalls(finalContent);
+            this.toolCallParserService.convertPromptModeToolCallsToFunctionCalls(finalContent, config.toolMode || 'function_call');
             // 为没有 id 的 functionCall 添加唯一 id（Gemini 格式不返回 id）
             this.toolCallParserService.ensureFunctionCallIds(finalContent);
 
@@ -791,7 +793,7 @@ export class ToolIterationLoopService {
             }
 
             // 检查是否有工具调用
-            const functionCalls = this.toolCallParserService.extractFunctionCalls(finalContent);
+            const functionCalls = this.toolCallParserService.extractFunctionCalls(finalContent, config.toolMode || 'function_call');
 
             if (functionCalls.length === 0) {
                 // 没有工具调用，结束循环并返回

--- a/backend/modules/api/settings/types.ts
+++ b/backend/modules/api/settings/types.ts
@@ -57,7 +57,7 @@ export interface SetToolsEnabledRequest {
  */
 export interface SetDefaultToolModeRequest {
     /** 工具模式 */
-    mode: 'function_call' | 'xml';
+    mode: 'function_call' | 'xml' | 'json';
 }
 
 /**

--- a/backend/modules/channel/StreamAccumulator.ts
+++ b/backend/modules/channel/StreamAccumulator.ts
@@ -9,7 +9,7 @@ import type { Content, ContentPart, UsageMetadata, ThoughtSignatures } from '../
 import type { StreamChunk, StreamUsageMetadata } from './types';
 import type { ToolMode } from '../config/configs/base';
 import { parseXMLToolCalls } from '../../tools/xmlFormatter';
-import { getGlobalSettingsManager, getGlobalConfigManager } from '../../core/settingsContext';
+import { IncrementalPromptToolParser } from '../../tools/promptToolParser';
 
 // JSON 工具调用边界标记
 const TOOL_CALL_START = '<<<TOOL_CALL>>>';
@@ -76,32 +76,33 @@ export class StreamAccumulator {
     
     /** 请求开始时间戳（毫秒） - 由外部设置 */
     private requestStartTime?: number;
+
+    /** 当前请求的工具模式 */
+    private readonly toolMode: ToolMode;
+
+    /** 当前请求的工具调用 ID 工厂 */
+    private readonly createToolCallId: () => string;
+
+    /** Prompt 模式下的增量工具解析器 */
+    private promptToolParser?: IncrementalPromptToolParser;
     
+    constructor(
+        toolMode: ToolMode = 'function_call',
+        createToolCallId: () => string = () => `fc_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
+    ) {
+        this.toolMode = toolMode;
+        this.createToolCallId = createToolCallId;
+
+        if (toolMode === 'json' || toolMode === 'xml') {
+            this.promptToolParser = new IncrementalPromptToolParser(toolMode);
+        }
+    }
+
     /**
      * 获取工具模式
-     * 优先使用当前激活渠道的 toolMode，否则使用全局默认
      */
     private getToolMode(): ToolMode {
-        const settingsManager = getGlobalSettingsManager();
-        const configManager = getGlobalConfigManager();
-        
-        if (settingsManager && configManager) {
-            const activeChannelId = settingsManager.getActiveChannelId();
-            if (activeChannelId) {
-                // 同步获取配置（配置已在缓存中）
-                // 注意：getConfig 是异步的，但这里我们需要同步获取
-                // 使用内部缓存直接访问
-                const configCache = (configManager as any).configCache as Map<string, any>;
-                const config = configCache?.get(activeChannelId);
-                if (config?.toolMode) {
-                    return config.toolMode;
-                }
-            }
-            // 使用全局默认工具模式
-            return settingsManager.getDefaultToolMode();
-        }
-        
-        return 'function_call';
+        return this.toolMode;
     }
 
     /**
@@ -163,8 +164,9 @@ export class StreamAccumulator {
      *
      * @param chunk 流式响应块
      */
-    add(chunk: StreamChunk): void {
+    add(chunk: StreamChunk): ContentPart[] {
         const now = Date.now();
+        const visibleDelta: ContentPart[] = [];
         
         // 增加块计数
         this.chunkCount++;
@@ -181,7 +183,14 @@ export class StreamAccumulator {
         // 即使已经 done，也要处理 delta（虽然通常 done 后 delta 为空）
         if (chunk.delta && chunk.delta.length > 0) {
             for (const part of chunk.delta) {
-                this.addPart(part);
+                this.addPart(part, { visibleDelta });
+            }
+        }
+
+        if (chunk.done && this.promptToolParser) {
+            const trailingParts = this.promptToolParser.flushIncompleteAsText();
+            for (const part of trailingParts) {
+                this.addPart(part, { skipPromptParser: true, visibleDelta });
             }
         }
         
@@ -205,6 +214,8 @@ export class StreamAccumulator {
         if (chunk.done) {
             this.isDone = true;
         }
+
+        return visibleDelta;
     }
     
     /**
@@ -229,7 +240,34 @@ export class StreamAccumulator {
      * - 文本 part：尝试与相同类型的最后一个 part 合并
      * - 非文本 part（functionCall、thoughtSignature 等）：直接添加，保持原始结构
      */
-    private addPart(part: ContentPart): void {
+    private addPart(
+        part: ContentPart,
+        options?: {
+            skipPromptParser?: boolean;
+            visibleDelta?: ContentPart[];
+        }
+    ): void {
+        if (!options?.skipPromptParser && this.promptToolParser && part.text && !part.thought) {
+            const parsedParts = this.promptToolParser.appendText(part.text);
+            for (const parsedPart of parsedParts) {
+                this.addPart(parsedPart, {
+                    skipPromptParser: true,
+                    visibleDelta: options?.visibleDelta
+                });
+            }
+            return;
+        }
+
+        if (part.functionCall && !(part.functionCall as any).id) {
+            (part.functionCall as any).id = this.createToolCallId();
+        }
+
+        if (options?.visibleDelta && part.text !== undefined) {
+            options.visibleDelta.push(part.thought ? { text: part.text, thought: true } : { text: part.text });
+        } else if (options?.visibleDelta && part.functionCall) {
+            options.visibleDelta.push({ functionCall: { ...(part.functionCall as any) } });
+        }
+
         // 提取 thoughtSignature 用于内部追踪
         if ((part as any).thoughtSignature) {
             this.thoughtSignatures[this.providerType] = (part as any).thoughtSignature;
@@ -242,8 +280,17 @@ export class StreamAccumulator {
         
         // 处理非文本 part
         if (!('text' in part)) {
+            if (part.functionCall && this.thinkingStartTime !== undefined && !this.hasReceivedNormalText) {
+                this.hasReceivedNormalText = true;
+                this.thinkingDuration = Date.now() - this.thinkingStartTime;
+            }
+
             if (part.functionCall) {
                 const fc = part.functionCall as any;
+
+                if (!fc.id) {
+                    fc.id = this.createToolCallId();
+                }
                 
                 // 倒序搜索现有的 parts，寻找可以合并的工具调用块
                 // 解决并行调用或中间穿插其他消息导致的 lastPart 匹配失败问题
@@ -465,7 +512,7 @@ export class StreamAccumulator {
                                 functionCall: {
                                     name: toolCall.tool,
                                     args: toolCall.parameters,
-                                    id: `fc_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
+                                    id: this.createToolCallId()
                                 }
                             });
                         } else {
@@ -503,7 +550,7 @@ export class StreamAccumulator {
                                     functionCall: {
                                         name: xmlCall.name,
                                         args: xmlCall.args,
-                                        id: `fc_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
+                                        id: this.createToolCallId()
                                     }
                                 });
                             }
@@ -735,6 +782,10 @@ export class StreamAccumulator {
         this.firstChunkTime = undefined;
         this.lastChunkTime = undefined;
         this.requestStartTime = undefined;
+
+        if (this.promptToolParser) {
+            this.promptToolParser.reset();
+        }
     }
     
     /**

--- a/backend/modules/channel/formatters/anthropic.ts
+++ b/backend/modules/channel/formatters/anthropic.ts
@@ -39,6 +39,11 @@ import {
     TOOL_CALL_START,
     TOOL_CALL_END
 } from '../../../tools/jsonFormatter';
+import {
+    detectPromptToolMode,
+    extractPromptToolParts,
+    IncrementalPromptToolParser
+} from '../../../tools/promptToolParser';
 import { applyCustomBody } from '../../config/configs/base';
 import type {
     GenerateRequest,
@@ -616,17 +621,31 @@ export class AnthropicFormatter extends BaseFormatter {
         // 如果没有原生工具调用，尝试从文本中检测
         const hasToolUse = response.content.some((b: any) => b.type === 'tool_use');
         if (!hasToolUse) {
-            const textContent = parts
-                .filter(p => 'text' in p && !p.thought)
-                .map(p => p.text)
-                .join('\n');
-            
-            if (textContent) {
-                // 保留思考内容和签名，只对普通文本进行工具调用检测
-                        const thoughtParts = parts.filter(p => p.thought || p.thoughtSignatures);
-                const detectedParts = this.parseResponseAutoDetect(textContent);
-                parts = [...thoughtParts, ...detectedParts];
+            const normalizedParts: ContentPart[] = [];
+            let promptMode: 'json' | 'xml' | null = null;
+            let promptParser: IncrementalPromptToolParser | undefined;
+
+            for (const part of parts) {
+                if (!part.text || part.thought) {
+                    normalizedParts.push(part);
+                    continue;
+                }
+
+                if (!promptMode) {
+                    promptMode = detectPromptToolMode(part.text);
+                    if (promptMode) {
+                        promptParser = new IncrementalPromptToolParser(promptMode);
+                    }
+                }
+
+                if (promptParser) {
+                    normalizedParts.push(...promptParser.appendText(part.text));
+                } else {
+                    normalizedParts.push(part);
+                }
             }
+
+            parts = promptParser ? [...normalizedParts, ...promptParser.flushIncompleteAsText()] : normalizedParts;
         }
         
         // 构建完整的 Content
@@ -660,23 +679,19 @@ export class AnthropicFormatter extends BaseFormatter {
      * 自动检测模式解析响应
      */
     private parseResponseAutoDetect(contentText: string): ContentPart[] {
-        const parts: ContentPart[] = [];
-        
-        // 检测 JSON 边界标记
-        if (contentText.includes(TOOL_CALL_START)) {
-            return this.extractJSONToolCallsFromContent(contentText, parts);
+        const promptMode = detectPromptToolMode(contentText);
+        if (!promptMode) {
+            const parts: ContentPart[] = [];
+            if (contentText.trim()) {
+                parts.push({ text: contentText });
+            }
+            return parts;
         }
-        
-        // 检测 XML 工具调用
-        if (contentText.includes('<tool_use>')) {
-            return this.extractXMLToolCallsFromContent(contentText, parts);
-        }
-        
-        // 无工具调用，作为纯文本
-        if (contentText.trim()) {
-            parts.push({ text: contentText });
-        }
-        return parts;
+
+        const extracted = extractPromptToolParts(contentText, promptMode, {
+            flushIncompleteTailAsText: true
+        });
+        return extracted.parts;
     }
     
     /**

--- a/backend/modules/channel/formatters/openai.ts
+++ b/backend/modules/channel/formatters/openai.ts
@@ -37,6 +37,10 @@ import {
     TOOL_CALL_START,
     TOOL_CALL_END
 } from '../../../tools/jsonFormatter';
+import {
+    detectPromptToolMode,
+    extractPromptToolParts
+} from '../../../tools/promptToolParser';
 import { applyCustomBody } from '../../config/configs/base';
 import type {
     GenerateRequest,
@@ -659,22 +663,17 @@ export class OpenAIFormatter extends BaseFormatter {
         }
         
         const contentText = message.content as string;
-        
-        // 检测 JSON 边界标记
-        if (contentText.includes(TOOL_CALL_START)) {
-            return this.extractJSONToolCallsFromContent(contentText, parts);
+
+        const promptMode = detectPromptToolMode(contentText);
+        if (!promptMode) {
+            if (contentText.trim()) {
+                parts.push({ text: contentText });
+            }
+            return parts;
         }
-        
-        // 检测 XML 工具调用
-        if (contentText.includes('<tool_use>')) {
-            return this.extractXMLToolCallsFromContent(contentText, parts);
-        }
-        
-        // 无工具调用，作为纯文本
-        if (contentText.trim()) {
-            parts.push({ text: contentText });
-        }
-        return parts;
+
+        const extracted = extractPromptToolParts(contentText, promptMode, { flushIncompleteTailAsText: true });
+        return [...parts, ...extracted.parts];
     }
     
     /**

--- a/backend/modules/channel/types.ts
+++ b/backend/modules/channel/types.ts
@@ -176,6 +176,13 @@ export interface StreamChunk {
     
     /** 模型版本（仅最后一个块包含） */
     modelVersion?: string;
+
+    /**
+     * 当前已经归一化的内容快照
+     *
+     * 当流式内容发生结构改写时（如工具调用参数补全），后端会附带该快照。
+     */
+    contentSnapshot?: Content;
     
     /**
      * 思考开始时间戳（毫秒）

--- a/backend/modules/settings/SettingsManager.ts
+++ b/backend/modules/settings/SettingsManager.ts
@@ -884,14 +884,14 @@ export class SettingsManager {
     /**
      * 获取默认工具模式
      */
-    getDefaultToolMode(): 'function_call' | 'xml' {
+    getDefaultToolMode(): 'function_call' | 'xml' | 'json' {
         return this.settings.defaultToolMode || 'function_call';
     }
     
     /**
      * 设置默认工具模式
      */
-    async setDefaultToolMode(mode: 'function_call' | 'xml'): Promise<void> {
+    async setDefaultToolMode(mode: 'function_call' | 'xml' | 'json'): Promise<void> {
         const oldValue = this.settings.defaultToolMode;
         this.settings.defaultToolMode = mode;
         this.settings.lastUpdated = Date.now();

--- a/backend/modules/settings/VSCodeSettingsStorage.ts
+++ b/backend/modules/settings/VSCodeSettingsStorage.ts
@@ -134,7 +134,7 @@ export class VSCodeSettingsStorage implements SettingsStorage {
             settings.maxToolIterations = config.get('maxToolIterations');
             
             const defaultToolMode = config.get('defaultToolMode');
-            if (defaultToolMode === 'function_call' || defaultToolMode === 'xml') {
+            if (defaultToolMode === 'function_call' || defaultToolMode === 'xml' || defaultToolMode === 'json') {
                 settings.defaultToolMode = defaultToolMode;
             }
 

--- a/backend/modules/settings/types.ts
+++ b/backend/modules/settings/types.ts
@@ -1339,7 +1339,7 @@ export interface GlobalSettings {
      *
      * 当渠道配置未指定时使用
      */
-    defaultToolMode?: 'function_call' | 'xml';
+    defaultToolMode?: 'function_call' | 'xml' | 'json';
     
     /**
      * 代理配置

--- a/backend/tools/promptToolParser.ts
+++ b/backend/tools/promptToolParser.ts
@@ -1,0 +1,184 @@
+import type { ContentPart } from '../modules/conversation/types';
+import { parseJSONToolCalls, TOOL_CALL_END, TOOL_CALL_START } from './jsonFormatter';
+import { parseXMLToolCalls } from './xmlFormatter';
+
+export type PromptToolMode = 'json' | 'xml';
+
+const XML_TOOL_START = '<tool_use>';
+const XML_TOOL_END = '</tool_use>';
+
+interface MarkerDef {
+    start: string;
+    end: string;
+}
+
+export interface ExtractPromptToolPartsOptions {
+    flushIncompleteTailAsText?: boolean;
+}
+
+export interface ExtractPromptToolPartsResult {
+    parts: ContentPart[];
+    trailingIncomplete?: string;
+}
+
+function getMarkers(mode: PromptToolMode): MarkerDef {
+    return mode === 'json'
+        ? { start: TOOL_CALL_START, end: TOOL_CALL_END }
+        : { start: XML_TOOL_START, end: XML_TOOL_END };
+}
+
+function longestSuffixPrefixLength(text: string, marker: string): number {
+    const max = Math.min(text.length, marker.length - 1);
+    for (let len = max; len > 0; len--) {
+        if (text.endsWith(marker.slice(0, len))) {
+            return len;
+        }
+    }
+    return 0;
+}
+
+function toFunctionCallParts(blockText: string, mode: PromptToolMode): ContentPart[] | null {
+    if (mode === 'json') {
+        const calls = parseJSONToolCalls(blockText);
+        if (calls.length === 0) {
+            return null;
+        }
+        return calls.map(call => ({
+            functionCall: {
+                name: call.tool,
+                args: call.parameters || {}
+            }
+        }));
+    }
+
+    const calls = parseXMLToolCalls(blockText);
+    if (calls.length === 0) {
+        return null;
+    }
+    return calls.map(call => ({
+        functionCall: {
+            name: call.name,
+            args: call.args || {}
+        }
+    }));
+}
+
+function pushTextPart(parts: ContentPart[], text: string): void {
+    if (text.length > 0) {
+        parts.push({ text });
+    }
+}
+
+export function detectPromptToolMode(text: string): PromptToolMode | null {
+    const jsonIndex = text.indexOf(TOOL_CALL_START);
+    const xmlIndex = text.indexOf(XML_TOOL_START);
+
+    if (jsonIndex === -1 && xmlIndex === -1) {
+        return null;
+    }
+    if (jsonIndex !== -1 && (xmlIndex === -1 || jsonIndex <= xmlIndex)) {
+        return 'json';
+    }
+    return 'xml';
+}
+
+export class IncrementalPromptToolParser {
+    private readonly startMarker: string;
+    private readonly endMarker: string;
+    private buffer = '';
+
+    constructor(private readonly mode: PromptToolMode) {
+        const markers = getMarkers(mode);
+        this.startMarker = markers.start;
+        this.endMarker = markers.end;
+    }
+
+    appendText(fragment: string): ContentPart[] {
+        if (!fragment) {
+            return [];
+        }
+        this.buffer += fragment;
+        return this.consume(false);
+    }
+
+    flushIncompleteAsText(): ContentPart[] {
+        return this.consume(true);
+    }
+
+    getPendingText(): string {
+        return this.buffer;
+    }
+
+    reset(): void {
+        this.buffer = '';
+    }
+
+    private consume(flushIncompleteTailAsText: boolean): ContentPart[] {
+        const parts: ContentPart[] = [];
+
+        while (this.buffer.length > 0) {
+            const startIndex = this.buffer.indexOf(this.startMarker);
+
+            if (startIndex === -1) {
+                if (flushIncompleteTailAsText) {
+                    pushTextPart(parts, this.buffer);
+                    this.buffer = '';
+                } else {
+                    const keepLength = longestSuffixPrefixLength(this.buffer, this.startMarker);
+                    const visibleLength = this.buffer.length - keepLength;
+                    if (visibleLength > 0) {
+                        pushTextPart(parts, this.buffer.slice(0, visibleLength));
+                    }
+                    this.buffer = this.buffer.slice(visibleLength);
+                }
+                break;
+            }
+
+            if (startIndex > 0) {
+                pushTextPart(parts, this.buffer.slice(0, startIndex));
+                this.buffer = this.buffer.slice(startIndex);
+            }
+
+            const endIndex = this.buffer.indexOf(this.endMarker, this.startMarker.length);
+            if (endIndex === -1) {
+                if (flushIncompleteTailAsText) {
+                    pushTextPart(parts, this.buffer);
+                    this.buffer = '';
+                }
+                break;
+            }
+
+            const blockText = this.buffer.slice(0, endIndex + this.endMarker.length);
+            const functionCallParts = toFunctionCallParts(blockText, this.mode);
+            if (functionCallParts && functionCallParts.length > 0) {
+                parts.push(...functionCallParts);
+            } else {
+                pushTextPart(parts, blockText);
+            }
+
+            this.buffer = this.buffer.slice(endIndex + this.endMarker.length);
+        }
+
+        return parts;
+    }
+}
+
+export function extractPromptToolParts(
+    text: string,
+    mode: PromptToolMode,
+    options: ExtractPromptToolPartsOptions = {}
+): ExtractPromptToolPartsResult {
+    const flushIncompleteTailAsText = options.flushIncompleteTailAsText ?? true;
+    const parser = new IncrementalPromptToolParser(mode);
+    const parts = parser.appendText(text);
+
+    if (flushIncompleteTailAsText) {
+        parts.push(...parser.flushIncompleteAsText());
+        return { parts };
+    }
+
+    return {
+        parts,
+        trailingIncomplete: parser.getPendingText() || undefined
+    };
+}

--- a/frontend/src/components/message/MessageItem.vue
+++ b/frontend/src/components/message/MessageItem.vue
@@ -133,62 +133,6 @@ onUnmounted(() => {
   stopThinkingTimer()
 })
 
-// JSON 工具调用边界标记
-const TOOL_CALL_START = '<<<TOOL_CALL>>>'
-const TOOL_CALL_END = '<<<END_TOOL_CALL>>>'
-
-// XML 工具调用标记
-const XML_TOOL_START = '<tool_use>'
-const XML_TOOL_END = '</tool_use>'
-
-/**
- * 过滤掉文本中的工具调用标记
- * 支持 JSON 格式（<<<TOOL_CALL>>>...<<<END_TOOL_CALL>>>）
- * 和 XML 格式（<tool_use>...</tool_use>）
- * 流式响应时，这些标记可能先显示，等完成后才转换为 functionCall
- */
-function filterToolCallMarkers(text: string): string {
-  let result = text
-  
-  // 1. 处理 JSON 格式
-  if (result.includes(TOOL_CALL_START)) {
-    // 移除完整的工具调用块
-    const jsonRegex = new RegExp(
-      TOOL_CALL_START.replace(/[<>]/g, '\\$&') +
-      '[\\s\\S]*?' +
-      TOOL_CALL_END.replace(/[<>]/g, '\\$&'),
-      'g'
-    )
-    result = result.replace(jsonRegex, '')
-    
-    // 移除不完整的开始标记（流式时可能只有开头）
-    const jsonStartIdx = result.indexOf(TOOL_CALL_START)
-    if (jsonStartIdx !== -1) {
-      result = result.substring(0, jsonStartIdx)
-    }
-  }
-  
-  // 2. 处理 XML 格式
-  if (result.includes(XML_TOOL_START)) {
-    // 移除完整的工具调用块
-    const xmlRegex = new RegExp(
-      XML_TOOL_START.replace(/[<>]/g, '\\$&') +
-      '[\\s\\S]*?' +
-      XML_TOOL_END.replace(/[<>]/g, '\\$&'),
-      'g'
-    )
-    result = result.replace(xmlRegex, '')
-    
-    // 移除不完整的开始标记（流式时可能只有开头）
-    const xmlStartIdx = result.indexOf(XML_TOOL_START)
-    if (xmlStartIdx !== -1) {
-      result = result.substring(0, xmlStartIdx)
-    }
-  }
-  
-  return result.trim()
-}
-
 /**
  * 将 parts 转换为渲染块，保持原始顺序
  *
@@ -219,8 +163,8 @@ const renderBlocks = computed<RenderBlock[]>(() => {
   // 辅助函数：刷新文本块
   const flushText = () => {
     if (currentTextBlock.length > 0) {
-      const text = filterToolCallMarkers(currentTextBlock.join(''))
-      if (text) {
+      const text = currentTextBlock.join('')
+      if (text.trim()) {
         blocks.push({ type: 'text', text })
       }
       currentTextBlock = []

--- a/frontend/src/components/message/responseViewer/buildResponseViewerData.ts
+++ b/frontend/src/components/message/responseViewer/buildResponseViewerData.ts
@@ -133,10 +133,6 @@ interface FunctionResponseMatch {
   sourceBackendIndex?: number
 }
 
-const TOOL_CALL_START = '<<<TOOL_CALL>>>'
-const TOOL_CALL_END = '<<<END_TOOL_CALL>>>'
-const XML_TOOL_START = '<tool_use>'
-const XML_TOOL_END = '</tool_use>'
 const MAX_PREVIEW_LENGTH = 220
 const MAX_SAFE_STRING = 12_000
 const MAX_SAFE_DEPTH = 6
@@ -235,7 +231,7 @@ export function buildResponseViewerData(
 }
 
 function extractAnswerText(message: Message): string {
-  const fromContent = filterToolCallMarkers(message.content || '').trim()
+  const fromContent = (message.content || '').trim()
   if (fromContent) {
     return fromContent
   }
@@ -245,7 +241,7 @@ function extractAnswerText(message: Message): string {
     .map(part => part.text || '')
     .join('')
 
-  return filterToolCallMarkers(fromParts).trim()
+  return fromParts.trim()
 }
 
 function extractThoughtText(parts?: ContentPart[]): string {
@@ -371,7 +367,7 @@ function buildPartPreviews(
       return {
         index,
         type: 'text',
-        preview: summarizeText(filterToolCallMarkers(part.text), MAX_PREVIEW_LENGTH),
+        preview: summarizeText(part.text, MAX_PREVIEW_LENGTH),
         text: part.text,
         raw: sanitizeForViewer(part)
       }
@@ -705,42 +701,6 @@ function extractErrorMessage(result: unknown): string | undefined {
   }
 
   return undefined
-}
-
-function filterToolCallMarkers(text: string): string {
-  let result = text
-
-  if (result.includes(TOOL_CALL_START)) {
-    const jsonRegex = new RegExp(
-      TOOL_CALL_START.replace(/[<>]/g, '\\$&') +
-      '[\\s\\S]*?' +
-      TOOL_CALL_END.replace(/[<>]/g, '\\$&'),
-      'g'
-    )
-    result = result.replace(jsonRegex, '')
-
-    const jsonStartIdx = result.indexOf(TOOL_CALL_START)
-    if (jsonStartIdx !== -1) {
-      result = result.substring(0, jsonStartIdx)
-    }
-  }
-
-  if (result.includes(XML_TOOL_START)) {
-    const xmlRegex = new RegExp(
-      XML_TOOL_START.replace(/[<>]/g, '\\$&') +
-      '[\\s\\S]*?' +
-      XML_TOOL_END.replace(/[<>]/g, '\\$&'),
-      'g'
-    )
-    result = result.replace(xmlRegex, '')
-
-    const xmlStartIdx = result.indexOf(XML_TOOL_START)
-    if (xmlStartIdx !== -1) {
-      result = result.substring(0, xmlStartIdx)
-    }
-  }
-
-  return result.trim()
 }
 
 function isLargeValue(value: unknown): boolean {

--- a/frontend/src/stores/chat/checkpointActions.ts
+++ b/frontend/src/stores/chat/checkpointActions.ts
@@ -162,10 +162,6 @@ export async function restoreAndRetry(
       console.error('Failed to delete messages from backend:', err)
     }
     
-    // 4. 重置工具调用缓冲区
-    state.toolCallBuffer.value = ''
-    state.inToolCall.value = null
-    
     // 5. 开始流式重试
     state.isStreaming.value = true
     state.isWaitingForResponse.value = true
@@ -349,11 +345,7 @@ export async function restoreAndEdit(
     state.allMessages.value = state.allMessages.value.slice(0, messageIndex + 1)
     clearCheckpointsFromIndex(state, backendMessageIndex)
     setTotalMessagesFromWindow(state)
-    
-    // 4. 重置工具调用缓冲区
-    state.toolCallBuffer.value = ''
-    state.inToolCall.value = null
-    
+
     // 5. 开始流式编辑重试
     state.isStreaming.value = true
     state.isWaitingForResponse.value = true

--- a/frontend/src/stores/chat/messageActions.ts
+++ b/frontend/src/stores/chat/messageActions.ts
@@ -289,9 +289,7 @@ export async function sendMessage(
         conv.preview = messageText.slice(0, 50)
       }
     }
-    
-    state.toolCallBuffer.value = ''
-    state.inToolCall.value = null
+
     if (state.currentConversationId.value) {
       await syncConversationWorkspaceUri(state, state.currentConversationId.value)
     }
@@ -395,9 +393,6 @@ export async function retryFromMessage(
     clearCheckpointsFromIndex(state, backendFrom)
     setTotalMessagesFromWindow(state)
 
-    state.toolCallBuffer.value = ''
-    state.inToolCall.value = null
-
     const assistantMessageId = generateId()
     const assistantMessage: Message = {
       id: assistantMessageId,
@@ -495,9 +490,7 @@ export async function retryFromMessage(
   } catch (err) {
     console.error('Failed to delete messages from backend:', err)
   }
-  
-  state.toolCallBuffer.value = ''
-  state.inToolCall.value = null
+
   
   const assistantMessageId = generateId()
   const assistantMessage: Message = {
@@ -562,9 +555,7 @@ export async function retryAfterError(
   state.isLoading.value = true
   state.isStreaming.value = true
   state.isWaitingForResponse.value = true
-  
-  state.toolCallBuffer.value = ''
-  state.inToolCall.value = null
+
   
   const assistantMessageId = generateId()
   const assistantMessage: Message = {
@@ -650,9 +641,7 @@ export async function editAndRetry(
   state.allMessages.value = state.allMessages.value.slice(0, messageIndex + 1)
   clearCheckpointsFromIndex(state, backendMessageIndex)
   setTotalMessagesFromWindow(state)
-  
-  state.toolCallBuffer.value = ''
-  state.inToolCall.value = null
+
   
   const assistantMessageId = generateId()
   const assistantMessage: Message = {

--- a/frontend/src/stores/chat/parsers.ts
+++ b/frontend/src/stores/chat/parsers.ts
@@ -93,19 +93,19 @@ export function isOnlyFunctionResponse(content: Content): boolean {
  */
 export function contentToMessage(content: Content, id?: string): Message {
   const textParts = content.parts.filter(p => p.text && !p.thought)
-  const text = textParts.map(p => p.text).join('\n')
+  const text = textParts.map(p => p.text).join('')
   
   // 提取工具调用信息
   const toolUsages: import('../../types').ToolUsage[] = []
   for (const part of content.parts) {
     if (part.functionCall) {
+      const partialArgs = part.functionCall.partialArgs
       toolUsages.push({
         id: part.functionCall.id || generateId(),
         name: part.functionCall.name,
         args: part.functionCall.args,
-        // functionCall 表示“工具调用已完整出现”，但尚未开始执行。
-        // 后续状态由 toolsExecuting / awaitingConfirmation / toolIteration / diff 状态等更新。
-        status: 'queued'
+        partialArgs,
+        status: typeof partialArgs === 'string' ? 'streaming' : 'queued'
       })
     }
   }
@@ -153,7 +153,7 @@ export function contentToMessage(content: Content, id?: string): Message {
  */
 export function contentToMessageEnhanced(content: Content, id?: string): Message {
   const textParts = content.parts.filter(p => p.text && !p.thought)
-  const text = textParts.map(p => p.text).join('\n')
+  const text = textParts.map(p => p.text).join('')
   
   // 提取工具调用信息（不预先匹配响应）
   const toolUsages: import('../../types').ToolUsage[] = []
@@ -163,12 +163,14 @@ export function contentToMessageEnhanced(content: Content, id?: string): Message
   for (const part of content.parts) {
     if (part.functionCall) {
       // 检查是否被拒绝（用户在等待确认时点击了终止按钮）
+      const partialArgs = part.functionCall.partialArgs
       const isRejected = part.functionCall.rejected === true
       toolUsages.push({
         id: part.functionCall.id || generateId(),
         name: part.functionCall.name,
         args: part.functionCall.args,
-        status: isRejected ? 'error' : 'queued'  // 默认视为已排队
+        partialArgs,
+        status: isRejected ? 'error' : (typeof partialArgs === 'string' ? 'streaming' : 'queued')
       })
     }
     

--- a/frontend/src/stores/chat/state.ts
+++ b/frontend/src/stores/chat/state.ts
@@ -103,12 +103,6 @@ export function createChatState(): ChatStoreState {
   /** 自动总结状态（用于显示“自动总结中”提示） */
   const autoSummaryStatus = ref<AutoSummaryStatus | null>(null)
   
-  /** 工具调用缓冲区（用于检测流式中的 XML/JSON 工具调用） */
-  const toolCallBuffer = ref('')
-  
-  /** 当前是否在工具调用标记内 */
-  const inToolCall = ref<'xml' | 'json' | null>(null)
-  
   /** 当前对话的检查点列表 */
   const checkpoints = ref<CheckpointRecord[]>([])
   
@@ -189,8 +183,6 @@ export function createChatState(): ChatStoreState {
     isWaitingForResponse,
     retryStatus,
     autoSummaryStatus,
-    toolCallBuffer,
-    inToolCall,
     checkpoints,
     mergeUnchangedCheckpoints,
     deletingConversationIds,

--- a/frontend/src/stores/chat/streamChunkHandlers.ts
+++ b/frontend/src/stores/chat/streamChunkHandlers.ts
@@ -58,16 +58,27 @@ function mergeToolsPreferExisting(
       merged.push(t)
       continue
     }
+
+    const incomingHasArgs = !!(t.args && Object.keys(t.args).length > 0)
+    const partialArgs = typeof t.partialArgs === 'string'
+      ? (typeof e.partialArgs === 'string' && e.partialArgs.length > t.partialArgs.length ? e.partialArgs : t.partialArgs)
+      : (incomingHasArgs ? undefined : e.partialArgs)
+
+    let status = e.status ?? t.status
+    if (!partialArgs && incomingHasArgs && status === 'streaming') {
+      status = 'queued'
+    }
+
     // incoming 提供更完整的 name/args；existing 提供更可信的 status/result/error/duration
     merged.push({
       ...e,
       ...t,
-      status: e.status ?? t.status,
+      status,
       result: e.result ?? t.result,
       error: e.error ?? t.error,
       duration: e.duration ?? t.duration,
       awaitingConfirmation: e.awaitingConfirmation ?? t.awaitingConfirmation,
-      partialArgs: e.partialArgs ?? t.partialArgs
+      partialArgs
     })
     byId.delete(t.id)
   }
@@ -82,6 +93,33 @@ function mergeToolsPreferExisting(
 
 function normalizeStreamingToQueued(status?: ToolUsage['status']): ToolUsage['status'] | undefined {
   return status === 'streaming' ? 'queued' : status
+}
+
+function buildMessageFromContentSnapshot(currentMessage: Message, snapshotContent: NonNullable<StreamChunk['chunk']>['contentSnapshot']): Message {
+  const existingModelVersion = currentMessage.metadata?.modelVersion
+  const snapshotMessage = contentToMessageEnhanced(snapshotContent!, currentMessage.id)
+  const mergedTools = mergeToolsPreferExisting(currentMessage.tools, snapshotMessage.tools)
+
+  const updatedMessage: Message = {
+    ...currentMessage,
+    ...snapshotMessage,
+    id: currentMessage.id,
+    timestamp: currentMessage.timestamp,
+    backendIndex: currentMessage.backendIndex,
+    localOnly: currentMessage.localOnly,
+    streaming: currentMessage.streaming,
+    tools: mergedTools && mergedTools.length > 0 ? mergedTools : snapshotMessage.tools
+  }
+
+  if (!updatedMessage.metadata) {
+    updatedMessage.metadata = {}
+  }
+
+  if (existingModelVersion) {
+    updatedMessage.metadata.modelVersion = existingModelVersion
+  }
+
+  return updatedMessage
 }
 
 /**
@@ -114,29 +152,39 @@ function deriveToolStatusFromResult(result: Record<string, unknown>): ToolUsage[
  * 处理 chunk 类型
  */
 export function handleChunkType(chunk: StreamChunk, state: ChatStoreState): void {
-  const message = state.allMessages.value.find(m => m.id === state.streamingMessageId.value)
-  if (message && chunk.chunk?.delta) {
+  const messageIndex = state.allMessages.value.findIndex(m => m.id === state.streamingMessageId.value)
+  if (messageIndex === -1 || !chunk.chunk) {
+    return
+  }
+
+  const snapshotContent = chunk.chunk.contentSnapshot
+  if (snapshotContent) {
+    const updatedMessage = buildMessageFromContentSnapshot(state.allMessages.value[messageIndex], snapshotContent)
+    replaceMessageAt(state, messageIndex, updatedMessage)
+  }
+
+  const message = state.allMessages.value[messageIndex]
+  if (chunk.chunk.delta) {
     // 初始化 parts（如果不存在）
     if (!message.parts) {
       message.parts = []
     }
     
-    // chunk.chunk 是 BackendStreamChunk，包含 delta 数组
-    // delta 是 ContentPart 数组，每个元素可能包含 text 或 functionCall
-    for (const part of chunk.chunk.delta) {
-      if (part.text) {
-        if (part.thought) {
-          // 思考内容：直接添加，不检测工具调用
-          addTextToMessage(message, part.text, true)
-        } else {
-          // 普通文本：处理文本，检测 XML/JSON 工具调用标记
-          processStreamingText(message, part.text, state)
+    // 没有快照时，按增量追加；有快照时，以快照为准，跳过旧的本地文本猜测逻辑
+    if (!snapshotContent) {
+      for (const part of chunk.chunk.delta) {
+        if (part.text) {
+          if (part.thought) {
+            addTextToMessage(message, part.text, true)
+          } else {
+            processStreamingText(message, part.text, state)
+          }
         }
-      }
-      
-      // 处理工具调用（原生 function call format）
-      if (part.functionCall) {
-        handleFunctionCallPart(part, message)
+
+        // 处理工具调用（原生 function call format）
+        if (part.functionCall) {
+          handleFunctionCallPart(part, message)
+        }
       }
     }
     

--- a/frontend/src/stores/chat/streamHelpers.ts
+++ b/frontend/src/stores/chat/streamHelpers.ts
@@ -8,13 +8,6 @@
 import type { Message } from '../../types'
 import type { ChatStoreState } from './types'
 import { generateId } from '../../utils/format'
-import {
-  XML_TOOL_START,
-  XML_TOOL_END,
-  JSON_TOOL_START,
-  JSON_TOOL_END
-} from './types'
-import { parseXMLToolCall, parseJSONToolCall } from './parsers'
 import { isPerfEnabled } from '../../utils/perf'
 
 
@@ -97,120 +90,24 @@ export function addTextToMessage(message: Message, text: string, isThought: bool
 }
 
 /**
- * 处理流式文本，检测 XML/JSON 工具调用标记
+ * 处理流式文本
+ *
+ * Prompt 模式工具调用现在以后端解析结果为准。
+ * 前端这里只负责把可见文本追加到消息中。
  */
 export function processStreamingText(
   message: Message,
   text: string,
-  state: ChatStoreState
+  _state: ChatStoreState
 ): void {
-  let remainingText = text
-  
-  while (remainingText.length > 0) {
-    if (state.inToolCall.value === null) {
-      // 不在工具调用中，检测开始标记
-      const xmlStartIdx = remainingText.indexOf(XML_TOOL_START)
-      const jsonStartIdx = remainingText.indexOf(JSON_TOOL_START)
-      
-      let startIdx = -1
-      let startType: 'xml' | 'json' | null = null
-      let startMarker = ''
-      
-      if (xmlStartIdx !== -1 && (jsonStartIdx === -1 || xmlStartIdx < jsonStartIdx)) {
-        startIdx = xmlStartIdx
-        startType = 'xml'
-        startMarker = XML_TOOL_START
-      } else if (jsonStartIdx !== -1) {
-        startIdx = jsonStartIdx
-        startType = 'json'
-        startMarker = JSON_TOOL_START
-      }
-      
-      if (startIdx !== -1 && startType) {
-        // 找到开始标记，输出标记前的文本
-        const textBefore = remainingText.substring(0, startIdx)
-        if (textBefore) {
-          addTextToMessage(message, textBefore)
-        }
-        
-        // 进入工具调用状态
-        state.inToolCall.value = startType
-        state.toolCallBuffer.value = startMarker
-        remainingText = remainingText.substring(startIdx + startMarker.length)
-      } else {
-        // 没有找到开始标记，检查是否有部分匹配
-        // 为了简化，如果文本末尾可能是开始标记的前缀，暂存
-        const possiblePrefixes = [
-          XML_TOOL_START.substring(0, Math.min(remainingText.length, XML_TOOL_START.length - 1)),
-          JSON_TOOL_START.substring(0, Math.min(remainingText.length, JSON_TOOL_START.length - 1))
-        ]
-        
-        let foundPartial = false
-        for (const prefix of possiblePrefixes) {
-          if (prefix && remainingText.endsWith(prefix.substring(0, remainingText.length))) {
-            // 可能是部分匹配，但为简化处理，直接输出全部文本
-            // 完整的部分匹配检测会很复杂
-          }
-        }
-        
-        if (!foundPartial) {
-          // 输出全部文本
-          addTextToMessage(message, remainingText)
-          remainingText = ''
-        }
-      }
-    } else {
-      // 在工具调用中，查找结束标记
-      const endMarker = state.inToolCall.value === 'xml' ? XML_TOOL_END : JSON_TOOL_END
-      state.toolCallBuffer.value += remainingText
-      
-      const endIdx = state.toolCallBuffer.value.indexOf(endMarker)
-      if (endIdx !== -1) {
-        // 找到结束标记，解析工具调用
-        const toolContent = state.toolCallBuffer.value.substring(
-          state.inToolCall.value === 'xml' ? XML_TOOL_START.length : JSON_TOOL_START.length,
-          endIdx
-        )
-        
-        const parsed = state.inToolCall.value === 'xml'
-          ? parseXMLToolCall(toolContent)
-          : parseJSONToolCall(toolContent)
-        
-        if (parsed) {
-          // 成功解析，添加 functionCall
-          addFunctionCallToMessage(message, {
-            id: generateId(),
-            name: parsed.name,
-            args: parsed.args
-          })
-        } else {
-          // 解析失败，作为普通文本输出
-          addTextToMessage(message, state.toolCallBuffer.value.substring(0, endIdx + endMarker.length))
-        }
-        
-        // 重置状态，处理剩余文本
-        const afterEnd = state.toolCallBuffer.value.substring(endIdx + endMarker.length)
-        state.inToolCall.value = null
-        state.toolCallBuffer.value = ''
-        remainingText = afterEnd
-      } else {
-        // 未找到结束标记，继续累积
-        remainingText = ''
-      }
-    }
-  }
+  addTextToMessage(message, text)
 }
 
 /**
- * 完成流式时清理工具调用缓冲区
+ * 兼容旧调用链。
+ * Prompt 模式工具缓冲现在位于后端，此处不再需要额外处理。
  */
-export function flushToolCallBuffer(message: Message, state: ChatStoreState): void {
-  if (state.toolCallBuffer.value) {
-    // 如果有未完成的工具调用内容，作为普通文本输出
-    addTextToMessage(message, state.toolCallBuffer.value)
-    state.toolCallBuffer.value = ''
-    state.inToolCall.value = null
-  }
+export function flushToolCallBuffer(_message: Message, _state: ChatStoreState): void {
 }
 
 /**

--- a/frontend/src/stores/chat/tabActions.ts
+++ b/frontend/src/stores/chat/tabActions.ts
@@ -41,8 +41,6 @@ export function snapshotCurrentSession(state: ChatStoreState): ConversationSessi
     autoSummaryStatus: state.autoSummaryStatus.value ? { ...state.autoSummaryStatus.value } : null,
     historyFolded: state.historyFolded.value,
     foldedMessageCount: state.foldedMessageCount.value,
-    toolCallBuffer: state.toolCallBuffer.value,
-    inToolCall: state.inToolCall.value,
     inputValue: state.inputValue.value,
     pendingModelOverride: state.pendingModelOverride.value,
     editorNodes: [...state.editorNodes.value],
@@ -78,8 +76,6 @@ export function restoreSessionFromSnapshot(
   state.autoSummaryStatus.value = snapshot.autoSummaryStatus ? { ...snapshot.autoSummaryStatus } : null
   state.historyFolded.value = snapshot.historyFolded
   state.foldedMessageCount.value = snapshot.foldedMessageCount
-  state.toolCallBuffer.value = snapshot.toolCallBuffer
-  state.inToolCall.value = snapshot.inToolCall
   state.inputValue.value = snapshot.inputValue
   state.pendingModelOverride.value = snapshot.pendingModelOverride
   state.editorNodes.value = [...snapshot.editorNodes]
@@ -111,8 +107,6 @@ export function resetConversationState(state: ChatStoreState): void {
   state.autoSummaryStatus.value = null
   state.historyFolded.value = false
   state.foldedMessageCount.value = 0
-  state.toolCallBuffer.value = ''
-  state.inToolCall.value = null
   state.inputValue.value = ''
   state.pendingModelOverride.value = null
   state.selectedModelId.value = state.currentConfig.value?.model || ''

--- a/frontend/src/stores/chat/types.ts
+++ b/frontend/src/stores/chat/types.ts
@@ -171,10 +171,6 @@ export interface ChatStoreState {
   retryStatus: Ref<RetryStatus | null>
   /** 自动总结状态（用于显示“自动总结中”提示） */
   autoSummaryStatus: Ref<AutoSummaryStatus | null>
-  /** 工具调用缓冲区 */
-  toolCallBuffer: Ref<string>
-  /** 当前是否在工具调用标记内 */
-  inToolCall: Ref<'xml' | 'json' | null>
   /** 当前对话的检查点列表 */
   checkpoints: Ref<CheckpointRecord[]>
   /** 存档点配置：是否合并无变更的存档点 */
@@ -304,10 +300,6 @@ export interface ConversationSessionSnapshot {
   historyFolded: boolean
   /** 折叠消息数 */
   foldedMessageCount: number
-  /** 工具调用缓冲区 */
-  toolCallBuffer: string
-  /** 工具调用标记 */
-  inToolCall: 'xml' | 'json' | null
   /** 输入框内容 */
   inputValue: string
   /** 模型覆盖 */
@@ -335,14 +327,3 @@ export interface TabInfo {
   /** 是否正在流式响应中 */
   isStreaming: boolean
 }
-
-// ============ 常量 ============
-
-/** XML 工具调用开始标记 */
-export const XML_TOOL_START = '<tool_use>'
-/** XML 工具调用结束标记 */
-export const XML_TOOL_END = '</tool_use>'
-/** JSON 工具调用开始标记 */
-export const JSON_TOOL_START = '<<<TOOL_CALL>>>'
-/** JSON 工具调用结束标记 */
-export const JSON_TOOL_END = '<<<END_TOOL_CALL>>>'

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -454,6 +454,7 @@ export interface BackendStreamChunk {
   done: boolean
   usage?: UsageMetadata
   finishReason?: string
+  contentSnapshot?: Content
   /** 模型版本（仅最后一个块包含） */
   modelVersion?: string
 }

--- a/package.json
+++ b/package.json
@@ -220,7 +220,8 @@
           "default": "function_call",
           "enum": [
             "function_call",
-            "xml"
+            "xml",
+            "json"
           ],
           "description": "默认工具模式（可同步）"
         },


### PR DESCRIPTION
## 变更背景

当前工具调用链路在 `json` / `xml` prompt 模式下存在几类问题：

1. 同一段工具调用在流式阶段、流结束补偿阶段、不同渠道格式转换阶段分别使用了不同解析逻辑，行为不一致。
2. `StreamAccumulator` 没有直接使用当前请求的 `toolMode`，而是依赖全局激活渠道配置，存在与实际请求不一致的风险。
3. 当流式文本在后端被转换为 `functionCall` 结构后，前端仍可能停留在原始文本状态，出现展示不一致。
4. 前端仍在自行猜测 XML / JSON prompt 工具调用，同时稳定消息展示会误处理正文中的工具标记字面量。
5. `defaultToolMode` 的后端持久化链路缺少 `json` 支持。
本次 PR 的目标是统一 prompt 工具解析实现，修复流式展示不一致问题，并补齐 `json` 工具模式的后端支持。

---

## 主要修改

### 1. 新增共享的 prompt 工具解析器

新增文件：

- `backend/tools/promptToolParser.ts`
主要作用：
- 统一 `json` / `xml` prompt 模式的完整文本解析
- 统一流式增量解析逻辑
- 支持开始标记跨 chunk 拆分
- 支持未闭合尾部缓冲
- 支持流结束时将未闭合残留按普通文本回吐
这样可以避免同一类工具调用在不同阶段使用不同规则。

---

### 2. 调整 `StreamAccumulator` 的工具模式来源与流式处理方式

修改文件：

- `backend/modules/channel/StreamAccumulator.ts`
主要变化：
- 改为直接接收当前请求的 `toolMode`
- 不再依赖全局激活渠道配置来判断工具模式
- prompt 模式下改用共享增量解析器处理文本
- 未闭合工具标记不会提前暴露到前端
- 流式阶段会为缺失的 `functionCall.id` 分配稳定 ID
这部分修复了请求级配置与全局配置不一致的问题，也提升了流式阶段的稳定性。

---

### 3. 为流式协议增加结构化内容快照

修改文件：

- `backend/modules/channel/types.ts`
- `frontend/src/types/index.ts`
- `backend/modules/api/chat/handlers/StreamResponseProcessor.ts`
- `frontend/src/stores/chat/streamChunkHandlers.ts`
主要变化：
- 新增 `contentSnapshot?: Content`
- 当内容发生结构性变化时，后端发送完整快照，而不是只发送尾部追加增量
- 前端收到快照后，直接以快照为准更新当前流式消息
这部分解决了“后端已经识别为 `functionCall`，但前端仍停留在原始文本”的问题。

---

### 4. 移除前端对 prompt 工具调用的重复猜测

修改文件：

- `frontend/src/stores/chat/streamHelpers.ts`
- `frontend/src/stores/chat/state.ts`
- `frontend/src/stores/chat/types.ts`
- `frontend/src/stores/chat/tabActions.ts`
- `frontend/src/stores/chat/messageActions.ts`
- `frontend/src/stores/chat/checkpointActions.ts`
主要变化：
- `processStreamingText()` 只负责普通文本追加
- 前端不再自行解析 XML / JSON prompt 工具调用
- 清理旧的前端缓冲状态，如 `toolCallBuffer`、`inToolCall`
这样可以避免前后端各自解析，导致结果不一致。

---

### 5. 修复稳定消息展示与文本拼接问题

修改文件：

- `frontend/src/components/message/MessageItem.vue`
- `frontend/src/components/message/responseViewer/buildResponseViewerData.ts`
- `frontend/src/stores/chat/parsers.ts`
主要变化：
- 稳定消息展示不再误删正文中的 `<<<TOOL_CALL>>>`、`<tool_use>` 等字面量
- 文本 part 改为直接拼接，不再额外插入换行
- 保留 `partialArgs` 到展示层
这部分修复了“正文被误删”与“文本被多插入换行”的问题。

---

### 6. 让 `ToolCallParserService` 与补偿解析逻辑具备模式感知

修改文件：

- `backend/modules/api/chat/services/ToolCallParserService.ts`
- `backend/modules/api/chat/services/ToolIterationLoopService.ts`
主要变化：
- 仅在 `toolMode = 'json' | 'xml'` 时解析 prompt 模式文本工具调用
- `function_call` 模式下不再误把正文中的字面量当成真实工具调用
- 最终补偿解析改为复用共享解析器
这样可以减少误判，并保持流式与最终补偿逻辑一致。

---

### 7. 统一 Anthropic / OpenAI 的非流式 prompt 解析行为

修改文件：

- `backend/modules/channel/formatters/anthropic.ts`
- `backend/modules/channel/formatters/openai.ts`
主要变化：
- 复用共享 prompt 解析器
- 避免不同渠道对同一段 prompt 工具调用使用不同解析方式
- Anthropic 不再通过额外拼接换行来影响解析结果

---

### 8. 补齐 `defaultToolMode = 'json'` 的后端支持

修改文件：

- `backend/modules/settings/types.ts`
- `backend/modules/settings/SettingsManager.ts`
- `backend/modules/settings/VSCodeSettingsStorage.ts`
- `backend/modules/api/settings/types.ts`
- `package.json`
主要变化：
- 默认工具模式的类型定义加入 `json`
- 设置管理器与持久化链路支持 `json`
- 配置枚举与后端读写保持一致
这样可以确保 `function_call`、`xml`、`json` 三种模式在前后端配置上保持一致。

---

## 影响范围

本次修改涉及以下部分：

### 后端

- prompt 工具解析
- 流式累计
- 流式响应处理
- 工具调用补偿提取
- OpenAI / Anthropic 渠道格式转换
- 设置读写与持久化

### 前端

- 流式消息合并
- 稳定消息展示
- 消息解析与工具展示
- 流式缓冲状态管理

---

## 兼容性说明

- `function_call` 模式下，正文中的工具标记字面量不应再被误识别为真实工具调用
- `json` / `xml` prompt 模式下，流式与非流式解析行为更加一致
- 流式协议新增了 `contentSnapshot` 字段，前后端建议配套使用

---

## 测试情况

已执行：

- `pnpm build`
- `pnpm test -- --runInBand`
新增测试：
- `test/unit/tools/promptToolParser.test.ts`
- `test/unit/api/chat/handlers/StreamResponseProcessor.test.ts`
- `test/unit/settings/defaultToolMode.test.ts`
更新测试：
- `test/unit/channel/StreamAccumulator.test.ts`
- `test/unit/api/chat/services/ToolCallParserService.test.ts`
- `test/unit/api/chat/services/MessageBuilderService.test.ts`
测试结果：
- 构建通过
- 单元测试通过

---

## 本次 PR 的结果

本次 PR 主要完成了三件事：

1. 将 prompt 工具调用解析收敛到共享实现，减少多处重复解析带来的不一致。
2. 修复流式阶段“后端已识别，前端仍显示原始文本”的问题。
3. 补齐 `json` 默认工具模式在后端设置链路中的支持。
