### PR TITLE
feat: 补齐 design 文档产出与 design 到 plan 联动链路

### DIFF
--- a/backend/modules/settings/SettingsManager.ts
+++ b/backend/modules/settings/SettingsManager.ts
@@ -1609,9 +1609,16 @@ export class SettingsManager {
         const modes = { ...config.modes };
         let needsUpdate = false;
         
-        // 补齐 design 模式
+        // 补齐或更新 design 模式（强制同步 toolPolicy）
         if (!modes[DESIGN_MODE_ID]) {
             modes[DESIGN_MODE_ID] = DESIGN_PROMPT_MODE;
+            needsUpdate = true;
+        } else if (!this.arraysEqual(modes[DESIGN_MODE_ID].toolPolicy, DESIGN_PROMPT_MODE.toolPolicy)) {
+            // 已存在但 toolPolicy 不一致，强制更新
+            modes[DESIGN_MODE_ID] = {
+                ...modes[DESIGN_MODE_ID],
+                toolPolicy: DESIGN_PROMPT_MODE.toolPolicy
+            };
             needsUpdate = true;
         }
         

--- a/backend/modules/settings/modeToolsPolicy.ts
+++ b/backend/modules/settings/modeToolsPolicy.ts
@@ -4,23 +4,16 @@
  */
 
 /**
- * 检查路径是否允许在 Plan 模式下写入
- * 
- * 允许的路径：
- * - .limcode/plans/xxx.plan.md
- * - .limcode/plans/sub/xxx.md
- * 
- * 拒绝的路径：
- * - 不在 .limcode/plans/ 下的路径
+ * 检查路径是否允许在指定 LimCode 文档目录下写入
+ *
+ * 通用拒绝规则：
+ * - 不在指定目录下的路径
  * - 绝对路径
  * - 包含路径穿越（..）的路径
- * - 非 .md 或 .plan.md 扩展名的文件
+ * - 非 .md 扩展名的文件
  * - 空字符串或目录路径
- * 
- * @param path 要检查的路径
- * @returns 如果路径允许则返回 true，否则返回 false
  */
-export function isPlanPathAllowed(path: string): boolean {
+function isScopedMarkdownPathAllowed(path: string, scopeRoot: string): boolean {
     // 空字符串不允许
     if (!path || path.length === 0) {
         return false;
@@ -39,8 +32,8 @@ export function isPlanPathAllowed(path: string): boolean {
         return false;
     }
 
-    // 必须以 .limcode/plans/ 开头
-    if (!normalizedPath.startsWith('.limcode/plans/')) {
+    // 必须以指定目录开头
+    if (!normalizedPath.startsWith(scopeRoot)) {
         return false;
     }
 
@@ -49,23 +42,56 @@ export function isPlanPathAllowed(path: string): boolean {
         return false;
     }
 
-    // 必须是一个文件路径（不能只是 .limcode/plans/）
-    const relativePath = normalizedPath.substring('.limcode/plans/'.length);
+    // 必须是一个文件路径（不能只是目录本身）
+    const relativePath = normalizedPath.substring(scopeRoot.length);
     if (!relativePath || relativePath.length === 0) {
         return false;
     }
 
-    // 检查文件扩展名：必须是 .md 或 .plan.md
-    if (relativePath.endsWith('.plan.md')) {
-        return true;
-    }
-    
-    if (relativePath.endsWith('.md')) {
-        return true;
-    }
+    // 仅允许 Markdown 文件
+    return relativePath.endsWith('.md');
+}
 
-    // 其他扩展名或没有扩展名都不允许
-    return false;
+/**
+ * 检查路径是否允许在 Plan 模式下写入
+ * 
+ * 允许的路径：
+ * - .limcode/plans/xxx.plan.md
+ * - .limcode/plans/sub/xxx.md
+ * 
+ * 拒绝的路径：
+ * - 不在 .limcode/plans/ 下的路径
+ * - 绝对路径
+ * - 包含路径穿越（..）的路径
+ * - 非 .md 或 .plan.md 扩展名的文件
+ * - 空字符串或目录路径
+ * 
+ * @param path 要检查的路径
+ * @returns 如果路径允许则返回 true，否则返回 false
+ */
+export function isPlanPathAllowed(path: string): boolean {
+    return isScopedMarkdownPathAllowed(path, '.limcode/plans/');
+}
+
+/**
+ * 检查路径是否允许在 Design 模式下写入
+ *
+ * 允许的路径：
+ * - .limcode/design/xxx.md
+ * - .limcode/design/sub/xxx.md
+ *
+ * 拒绝的路径：
+ * - 不在 .limcode/design/ 下的路径
+ * - 绝对路径
+ * - 包含路径穿越（..）的路径
+ * - 非 .md 扩展名的文件
+ * - 空字符串或目录路径
+ *
+ * @param path 要检查的路径
+ * @returns 如果路径允许则返回 true，否则返回 false
+ */
+export function isDesignPathAllowed(path: string): boolean {
+    return isScopedMarkdownPathAllowed(path, '.limcode/design/');
 }
 
 /**

--- a/backend/modules/settings/types.ts
+++ b/backend/modules/settings/types.ts
@@ -2065,7 +2065,13 @@ DESIGN MODE BEHAVIOR
    - Data models and schemas
    - Implementation roadmaps and task breakdowns
 
-6. **Iterative Refinement**: Work with the user to refine the design through multiple rounds of discussion before implementation.`;
+6. **Iterative Refinement**: Work with the user to refine the design through multiple rounds of discussion before implementation.
+
+7. **Create Design Docs via Tool**: When you finish a design artifact, use create_design to write it under .limcode/design/**.md.
+
+8. **Stop After Creating Design Doc**: After calling create_design, STOP and wait for the user to review the design and decide whether to generate a plan.
+
+9. **Do Not Skip to Plan or Code**: Do not create plan documents or perform implementation work directly in Design mode unless the user explicitly changes the workflow.`;
 
 /**
  * 计划模式系统提示词模板
@@ -2089,6 +2095,8 @@ PLAN MODE
 - Use the provided tools to analyze the codebase and create implementation plans.
 - **IMPORTANT: Avoid duplicate tool calls.** Each tool should only be called once with the same parameters. Never repeat the same tool call multiple times.
 - When you need to understand the codebase, use read_file to examine specific files or search_in_files to find relevant code patterns.
+- If the conversation contains a user-confirmed design response (for example planGenerationPrompt, designPath, or designContent), use that design as the source document for the plan.
+- When generating a plan from a confirmed design, include a clear section near the top of the plan that references the source design document path.
 - Use create_plan to write the plan document in .limcode/plans/**.md.
 - **MANDATORY: When calling create_plan, you MUST provide the "todos" argument.** This will automatically create a TaskCard for the user to track your progress.
 - After creating the plan, STOP and wait for the user to review and confirm the plan before doing any implementation work. The user will click the "Execute Plan" button on the plan card to confirm.
@@ -2144,7 +2152,18 @@ export const DESIGN_PROMPT_MODE: PromptMode = {
     icon: 'lightbulb',
     template: DESIGN_MODE_TEMPLATE,
     dynamicTemplateEnabled: true,
-    dynamicTemplate: DEFAULT_DYNAMIC_CONTEXT_TEMPLATE
+    dynamicTemplate: DEFAULT_DYNAMIC_CONTEXT_TEMPLATE,
+    toolPolicy: [
+        'read_file',
+        'list_files',
+        'find_files',
+        'search_in_files',
+        'goto_definition',
+        'find_references',
+        'get_symbols',
+        'subagents',
+        'create_design'
+    ]
 };
 
 /**

--- a/backend/tools/design/create_design.ts
+++ b/backend/tools/design/create_design.ts
@@ -1,0 +1,127 @@
+/**
+ * create_design 工具
+ *
+ * 目标：把设计文档写入 .limcode/design/**.md（或 multi-root: workspace/.limcode/design/**.md）。
+ * 注意：这是“生成设计”工具，不负责创建 plan 或执行代码。
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import type { Tool, ToolDeclaration, ToolResult } from '../types';
+import { getAllWorkspaces, normalizeLineEndingsToLF, resolveUriWithInfo } from '../utils';
+import { isDesignPathAllowed } from '../../modules/settings/modeToolsPolicy';
+
+export interface CreateDesignArgs {
+  title?: string;
+  overview?: string;
+  design: string;
+  path?: string;
+}
+
+function slugify(input: string): string {
+  const s = (input || '').trim().toLowerCase();
+  const slug = s
+    .replace(/[\s_]+/g, '-')
+    .replace(/[^a-z0-9\u4e00-\u9fa5-]+/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return slug || `design-${Date.now()}`;
+}
+
+function isDesignModePathAllowedWithMultiRoot(pathStr: string): boolean {
+  // 单工作区格式：.limcode/design/...
+  if (isDesignPathAllowed(pathStr)) return true;
+
+  // 多工作区：允许 workspaceName/.limcode/design/...
+  const workspaces = getAllWorkspaces();
+  if (workspaces.length <= 1) return false;
+
+  const normalized = (pathStr || '').replace(/\\/g, '/');
+  const slashIndex = normalized.indexOf('/');
+  if (slashIndex <= 0) return false;
+
+  const workspacePrefix = normalized.slice(0, slashIndex);
+  // 基本拒绝：伪前缀/盘符
+  if (workspacePrefix === '.' || workspacePrefix === '..') return false;
+  if (workspacePrefix.includes(':')) return false;
+
+  const rest = normalized.slice(slashIndex + 1);
+  return isDesignPathAllowed(rest);
+}
+
+export function createCreateDesignToolDeclaration(): ToolDeclaration {
+  return {
+    name: 'create_design',
+    description:
+      'Create a design document (markdown) and write it under .limcode/design/**.md. This tool only creates the design; it does NOT create a plan or implement code.',
+    category: 'design',
+    parameters: {
+      type: 'object',
+      properties: {
+        title: { type: 'string', description: 'Optional design title (used for default filename)' },
+        overview: { type: 'string', description: 'Optional one-line overview' },
+        design: { type: 'string', description: 'Design content in markdown' },
+        path: {
+          type: 'string',
+          description:
+            'Optional output path. Must be under .limcode/design/**.md (or multi-root: workspace/.limcode/design/**.md).'
+        }
+      },
+      required: ['design']
+    }
+  };
+}
+
+async function ensureParentDir(uriFsPath: string): Promise<void> {
+  const dir = path.dirname(uriFsPath);
+  await vscode.workspace.fs.createDirectory(vscode.Uri.file(dir));
+}
+
+export function createCreateDesignTool(): Tool {
+  return {
+    declaration: createCreateDesignToolDeclaration(),
+    handler: async (rawArgs: Record<string, unknown>): Promise<ToolResult> => {
+      const args = rawArgs as unknown as CreateDesignArgs;
+      const design = typeof args.design === 'string' ? args.design : '';
+      if (!design.trim()) {
+        return { success: false, error: 'design is required and must be a non-empty string' };
+      }
+
+      const title = typeof args.title === 'string' ? args.title : '';
+      const defaultPath = `.limcode/design/${slugify(title || 'design')}.md`;
+      const outPath = (typeof args.path === 'string' && args.path.trim()) ? args.path.trim() : defaultPath;
+
+      if (!isDesignModePathAllowedWithMultiRoot(outPath)) {
+        return { success: false, error: `Invalid design path. Only ".limcode/design/**.md" is allowed. Rejected path: ${outPath}` };
+      }
+
+      const { uri, error } = resolveUriWithInfo(outPath);
+      if (!uri) {
+        return { success: false, error: error || 'No workspace folder open' };
+      }
+
+      try {
+        await ensureParentDir(uri.fsPath);
+
+        const content = normalizeLineEndingsToLF(design);
+        const bytes = new TextEncoder().encode(content);
+        await vscode.workspace.fs.writeFile(uri, bytes);
+
+        return {
+          success: true,
+          requiresUserConfirmation: true,
+          data: {
+            path: outPath,
+            content
+          }
+        };
+      } catch (e: any) {
+        return { success: false, error: e?.message || String(e) };
+      }
+    }
+  };
+}
+
+export function registerCreateDesign(): Tool {
+  return createCreateDesignTool();
+}

--- a/backend/tools/design/index.ts
+++ b/backend/tools/design/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Design 工具模块
+ */
+
+import type { Tool, ToolRegistration } from '../types';
+
+// 导出各个工具的注册函数
+export { registerCreateDesign } from './create_design';
+
+/**
+ * 获取所有 Design 工具的注册函数
+ */
+export function getDesignToolRegistrations(): ToolRegistration[] {
+  const { registerCreateDesign } = require('./create_design');
+  return [registerCreateDesign];
+}
+
+/**
+ * 获取所有 Design 工具
+ */
+export function getAllDesignTools(): Tool[] {
+  const { registerCreateDesign } = require('./create_design');
+  return [registerCreateDesign()];
+}

--- a/backend/tools/index.ts
+++ b/backend/tools/index.ts
@@ -33,6 +33,7 @@ export * from './media';
 export * from './lsp';
 export * from './subagents';
 export * from './todo';
+export * from './design';
 export * from './plan';
 export * from './history';
 
@@ -67,6 +68,7 @@ export function getAllTools(): Tool[] {
     const { getLspToolRegistrations } = require('./lsp');
     const { getSubAgentsToolRegistrations } = require('./subagents');
     const { getTodoToolRegistrations } = require('./todo');
+    const { getDesignToolRegistrations } = require('./design');
     const { getPlanToolRegistrations } = require('./plan');
     const { getHistoryToolRegistrations } = require('./history');
     
@@ -77,6 +79,7 @@ export function getAllTools(): Tool[] {
         ...getMediaToolRegistrations(),
         ...getLspToolRegistrations(),
         ...getTodoToolRegistrations(),
+        ...getDesignToolRegistrations(),
         ...getPlanToolRegistrations(),
         ...getHistoryToolRegistrations()
     ];

--- a/frontend/src/components/message/MessageTaskCards.vue
+++ b/frontend/src/components/message/MessageTaskCards.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 /**
- * MessageTaskCards - 在消息正文里显示 Plan 卡片
- * 
- * 风格和 write_file 工具面板保持一致
+ * MessageTaskCards - 在消息正文里显示 Design / Plan 文档卡片
+ *
+ * 第一版复用现有 Plan 卡片结构，同时承载 design 与 plan 的文档交互。
  */
 import { computed, ref, onMounted, watch } from 'vue'
 import { sendToExtension, loadState, saveState } from '@/utils/vscode'
@@ -12,7 +12,8 @@ import ModeSelector from '../input/ModeSelector.vue'
 import ChannelSelector from '../input/ChannelSelector.vue'
 import ModelSelector from '../input/ModelSelector.vue'
 import type { PromptMode, ChannelOption, ModelInfo } from '../input/types'
-import { isPlanDocPath } from '../../utils/taskCards'
+import { isDesignDocPath, isPlanDocPath } from '../../utils/taskCards'
+import { getPlanExecutionPrompt, getPlanGenerationPrompt } from '../../utils/toolContinuations'
 import { generateId } from '../../utils/format'
 import { useChatStore, useSettingsStore } from '@/stores'
 import * as configService from '@/services/config'
@@ -29,32 +30,36 @@ const settingsStore = useSettingsStore()
 const { t } = useI18n()
 
 type CardStatus = 'pending' | 'running' | 'success' | 'error'
+type TaskCardKind = 'design' | 'plan'
 
-type PlanEntry = {
+type TaskEntry = {
+  kind: TaskCardKind
   path: string
   content: string
   success?: boolean
-  executionPrompt?: string
+  continuationPrompt?: string
 }
 
-type PlanCardItem = {
+type TaskCardItem = {
   key: string
+  kind: TaskCardKind
   status: CardStatus
   title: string
   path: string
   content: string
-  badge?: string
   toolId: string
   toolName: string
-  isExecuted: boolean
+  isActionCompleted: boolean
 }
 
 const PLAN_EXECUTION_MODE_STATE_KEY = 'planExecution.preferredModeId'
+const PLAN_GENERATION_MODE_STATE_KEY = 'planGeneration.preferredModeId'
 
 // ============ 渠道选择相关 ============
 const channelConfigs = ref<any[]>([])
 const selectedChannelId = ref('')
-const selectedModeId = ref('code')
+const selectedPlanExecutionModeId = ref('code')
+const selectedPlanGenerationModeId = ref('plan')
 const selectedModelId = ref('')
 const modelOptions = ref<ModelInfo[]>([])
 const isLoadingChannels = ref(false)
@@ -62,8 +67,9 @@ const isLoadingModes = ref(false)
 const promptModeOptions = ref<PromptMode[]>([])
 const isLoadingModels = ref(false)
 const isExecutingPlan = ref(false)
-const expandedPlans = ref<Set<string>>(new Set())
-const autoOpenedPlanCardKeys = ref<Set<string>>(new Set())
+const isGeneratingPlan = ref(false)
+const expandedCards = ref<Set<string>>(new Set())
+const autoOpenedCardKeys = ref<Set<string>>(new Set())
 
 const channelOptions = computed<ChannelOption[]>(() =>
   channelConfigs.value
@@ -76,28 +82,47 @@ const channelOptions = computed<ChannelOption[]>(() =>
     }))
 )
 
+const isAnyTaskActionRunning = computed(() => isExecutingPlan.value || isGeneratingPlan.value)
 
 function openModeSettings() {
   settingsStore.showSettings('prompt')
 }
 
-function resolvePreferredModeId(modes: PromptMode[], currentModeId?: string): string {
-  const persisted = String(loadState<string>(PLAN_EXECUTION_MODE_STATE_KEY, '') || '').trim()
+function resolvePreferredModeId(
+  modes: PromptMode[],
+  storageKey: string,
+  fallbackModeId: string,
+  currentModeId?: string
+): string {
+  const persisted = String(loadState<string>(storageKey, '') || '').trim()
   if (persisted && modes.some(mode => mode.id === persisted)) return persisted
 
-  if (modes.some(mode => mode.id === 'code')) return 'code'
+  if (fallbackModeId && modes.some(mode => mode.id === fallbackModeId)) return fallbackModeId
 
   const current = String(currentModeId || '').trim()
   if (current && modes.some(mode => mode.id === current)) return current
 
-  return modes[0]?.id || 'code'
+  return modes[0]?.id || fallbackModeId || 'code'
 }
 
-function handleModeChange(modeId: string) {
+function getModeIdForKind(kind: TaskCardKind): string {
+  return kind === 'plan'
+    ? selectedPlanExecutionModeId.value
+    : selectedPlanGenerationModeId.value
+}
+
+function handleModeChange(kind: TaskCardKind, modeId: string) {
   const normalized = String(modeId || '').trim()
   if (!normalized) return
-  selectedModeId.value = normalized
-  saveState(PLAN_EXECUTION_MODE_STATE_KEY, normalized)
+
+  if (kind === 'plan') {
+    selectedPlanExecutionModeId.value = normalized
+    saveState(PLAN_EXECUTION_MODE_STATE_KEY, normalized)
+    return
+  }
+
+  selectedPlanGenerationModeId.value = normalized
+  saveState(PLAN_GENERATION_MODE_STATE_KEY, normalized)
 }
 
 async function loadPromptModes() {
@@ -107,12 +132,27 @@ async function loadPromptModes() {
     const modes = Array.isArray(result?.modes) ? result.modes : []
     promptModeOptions.value = modes
 
-    const preferredModeId = resolvePreferredModeId(modes, result?.currentModeId)
-    selectedModeId.value = preferredModeId
-    saveState(PLAN_EXECUTION_MODE_STATE_KEY, preferredModeId)
+    const preferredExecutionModeId = resolvePreferredModeId(
+      modes,
+      PLAN_EXECUTION_MODE_STATE_KEY,
+      'code',
+      result?.currentModeId
+    )
+    const preferredGenerationModeId = resolvePreferredModeId(
+      modes,
+      PLAN_GENERATION_MODE_STATE_KEY,
+      'plan',
+      result?.currentModeId
+    )
+
+    selectedPlanExecutionModeId.value = preferredExecutionModeId
+    selectedPlanGenerationModeId.value = preferredGenerationModeId
+    saveState(PLAN_EXECUTION_MODE_STATE_KEY, preferredExecutionModeId)
+    saveState(PLAN_GENERATION_MODE_STATE_KEY, preferredGenerationModeId)
   } catch (error) {
-    console.error('[plan] Failed to load prompt modes for plan execution:', error)
-    selectedModeId.value = 'code'
+    console.error('[task-cards] Failed to load prompt modes:', error)
+    selectedPlanExecutionModeId.value = 'code'
+    selectedPlanGenerationModeId.value = 'plan'
   } finally {
     isLoadingModes.value = false
   }
@@ -181,19 +221,50 @@ async function loadModelsForChannel(configId: string) {
   }
 }
 
-function togglePlanExpand(key: string) {
-  if (expandedPlans.value.has(key)) {
-    expandedPlans.value.delete(key)
+function toggleCardExpand(key: string) {
+  if (expandedCards.value.has(key)) {
+    expandedCards.value.delete(key)
   } else {
-    expandedPlans.value.add(key)
+    expandedCards.value.add(key)
   }
 }
 
-function isPlanExpanded(key: string): boolean {
-  return expandedPlans.value.has(key)
+function isCardExpanded(key: string): boolean {
+  return expandedCards.value.has(key)
 }
 
-async function openPlanFile(card: PlanCardItem) {
+function getCreateFallbackTitle(kind: TaskCardKind): string {
+  return kind === 'plan'
+    ? t('components.message.tool.createPlan.fallbackTitle')
+    : t('components.message.tool.createDesign.fallbackTitle')
+}
+
+function getDocumentTitle(docContent: string, docPath: string, kind: TaskCardKind): string {
+  const m = (docContent || '').match(/^\s*#\s+(.+)\s*$/m)
+  if (m && m[1] && m[1].trim()) return m[1].trim()
+
+  if (docPath) {
+    const parts = docPath.replace(/\\/g, '/').split('/')
+    const file = parts[parts.length - 1] || docPath
+    return file.replace(/\.md$/i, '') || getCreateFallbackTitle(kind)
+  }
+
+  return getCreateFallbackTitle(kind)
+}
+
+function getOpenFileLabel(kind: TaskCardKind): string {
+  return kind === 'plan'
+    ? t('components.message.tool.planCard.openFile')
+    : t('components.message.tool.designCard.openFile')
+}
+
+function getOpenFileFailedMessage(kind: TaskCardKind): string {
+  return kind === 'plan'
+    ? t('components.message.tool.planCard.openFileFailed')
+    : t('components.message.tool.designCard.openFileFailed')
+}
+
+async function openDocFile(card: TaskCardItem) {
   if (!card?.path) return
   try {
     await sendToExtension('openWorkspaceFileAt', {
@@ -202,121 +273,218 @@ async function openPlanFile(card: PlanCardItem) {
       preview: false
     })
   } catch (error) {
-    console.error(t('components.message.tool.planCard.openFileFailed'), error)
+    console.error(getOpenFileFailedMessage(card.kind), error)
   }
 }
 
-function getPlanTitle(planContent: string, planPath?: string): string {
-  const m = (planContent || '').match(/^\s*#\s+(.+)\s*$/m)
-  if (m && m[1] && m[1].trim()) return m[1].trim()
-
-  if (planPath) {
-    const parts = planPath.replace(/\\/g, '/').split('/')
-    const file = parts[parts.length - 1] || planPath
-    return file.replace(/\.md$/i, '') || t('components.message.tool.planCard.title')
-  }
-
-  return t('components.message.tool.planCard.title')
-}
-
-async function executePlan(card: PlanCardItem) {
-  if (isExecutingPlan.value || card.isExecuted || !card.content.trim()) return
-  isExecutingPlan.value = true
-  let latestPlanContent = card.content
-  
+async function withSelectedChannel<T>(runner: () => Promise<T>): Promise<T> {
   const originalConfigId = chatStore.configId
-  const switchedConfig = !!selectedChannelId.value && selectedChannelId.value !== originalConfigId
+  const nextConfigId = selectedChannelId.value
+  const switchedConfig = !!nextConfigId && nextConfigId !== originalConfigId
 
   try {
-    // one-off：仅本次执行使用所选渠道，不永久切换当前渠道
+    // one-off：仅本次操作使用所选渠道，不永久切换当前渠道
     if (switchedConfig) {
-      chatStore.setConfigId(selectedChannelId.value)
-    }
-    
-    // 后端对比计划文件内容，返回确认/修改 prompt
-    const confirmResult = await sendToExtension<{
-      success: boolean
-      prompt: string
-      planContent: string
-      todos?: Array<{
-        id: string
-        content: string
-        status: 'pending' | 'in_progress' | 'completed' | 'cancelled'
-      }>
-    }>('plan.confirmExecution', {
-      path: card.path,
-      originalContent: card.content,
-      conversationId: chatStore.currentConversationId
-    })
-
-    const prompt = confirmResult.prompt
-    latestPlanContent = confirmResult.planContent || card.content
-    const todosFromPlan = Array.isArray(confirmResult.todos) ? confirmResult.todos : []
-
-
-    // 确认执行后，切换到用户选择的模式，确保后续请求按目标模式运行
-    try {
-      const targetModeId = String(selectedModeId.value || 'code').trim() || 'code'
-      await chatStore.setCurrentPromptModeId(targetModeId)
-      saveState(PLAN_EXECUTION_MODE_STATE_KEY, targetModeId)
-      // InputArea 现在直接读取 chatStore.currentPromptModeId，不需要手动触发刷新
-    } catch (modeError) {
-      // 模式切换失败不阻塞执行
-      console.error('[plan] Failed to switch prompt mode before execution:', modeError)
+      chatStore.setConfigId(nextConfigId)
     }
 
-    // 启动 Build 顶部卡片（Cursor-like）
-    await chatStore.setActiveBuild({
-      id: generateId(),
-      conversationId: chatStore.currentConversationId || '',
-      title: getPlanTitle(latestPlanContent, card.path),
-      planContent: latestPlanContent,
-      planPath: card.path,
-      channelId: selectedChannelId.value || undefined,
-      modelId: selectedModelId.value || undefined,
-      startedAt: Date.now(),
-      status: 'running'
-    })
-
-    // 不创建新的可见 user 消息：把确认信息追加到 create_plan 的 functionResponse 字段里再继续对话
-    await chatStore.sendMessage('', undefined, {
-      modelOverride: selectedModelId.value || undefined,
-      hidden: {
-        functionResponse: {
-          id: card.toolId,
-          name: card.toolName,
-          response: {
-            planExecutionPrompt: prompt,
-            todos: todosFromPlan
-          }
-        }
-      }
-    })
-  } catch (error) {
-    console.error(t('components.message.tool.planCard.executePlanFailed'), error)
+    return await runner()
   } finally {
     if (switchedConfig) {
       chatStore.setConfigId(originalConfigId)
     }
+  }
+}
+
+function isCardActionRunning(kind: TaskCardKind): boolean {
+  return kind === 'plan' ? isExecutingPlan.value : isGeneratingPlan.value
+}
+
+function getActionLabel(kind: TaskCardKind): string {
+  return kind === 'plan'
+    ? t('components.message.tool.planCard.executeLabel')
+    : t('components.message.tool.designCard.generateLabel')
+}
+
+function getActionText(card: TaskCardItem): string {
+  if (card.kind === 'plan') {
+    if (card.isActionCompleted) return t('components.message.tool.planCard.executed')
+    if (isExecutingPlan.value) return t('components.message.tool.planCard.executing')
+    return t('components.message.tool.planCard.executePlan')
+  }
+
+  if (card.isActionCompleted) return t('components.message.tool.designCard.generated')
+  if (isGeneratingPlan.value) return t('components.message.tool.designCard.generating')
+  return t('components.message.tool.designCard.generatePlan')
+}
+
+function getActionIconClass(card: TaskCardItem): string {
+  if (card.isActionCompleted) return 'codicon-check'
+  if (isCardActionRunning(card.kind)) return 'codicon-loading codicon-modifier-spin'
+  return card.kind === 'plan' ? 'codicon-play' : 'codicon-arrow-right'
+}
+
+function isActionDisabled(card: TaskCardItem): boolean {
+  const modeId = getModeIdForKind(card.kind)
+  return (
+    isAnyTaskActionRunning.value ||
+    card.isActionCompleted ||
+    !modeId ||
+    !selectedChannelId.value ||
+    !selectedModelId.value
+  )
+}
+
+async function executePlan(card: TaskCardItem) {
+  if (card.kind !== 'plan') return
+  if (isExecutingPlan.value || card.isActionCompleted || !card.content.trim()) return
+
+  isExecutingPlan.value = true
+  try {
+    await withSelectedChannel(async () => {
+      const confirmResult = await sendToExtension<{
+        success: boolean
+        prompt: string
+        planContent: string
+        todos?: Array<{
+          id: string
+          content: string
+          status: 'pending' | 'in_progress' | 'completed' | 'cancelled'
+        }>
+      }>('plan.confirmExecution', {
+        path: card.path,
+        originalContent: card.content,
+        conversationId: chatStore.currentConversationId
+      })
+
+      const prompt = String(confirmResult?.prompt || '')
+      const latestPlanContent = confirmResult?.planContent || card.content
+      const todosFromPlan = Array.isArray(confirmResult?.todos) ? confirmResult.todos : []
+
+      // 确认执行后，切换到用户选择的模式，确保后续请求按目标模式运行
+      try {
+        const targetModeId = String(selectedPlanExecutionModeId.value || 'code').trim() || 'code'
+        await chatStore.setCurrentPromptModeId(targetModeId)
+        saveState(PLAN_EXECUTION_MODE_STATE_KEY, targetModeId)
+      } catch (modeError) {
+        // 模式切换失败不阻塞执行
+        console.error('[plan] Failed to switch prompt mode before execution:', modeError)
+      }
+
+      // 启动 Build 顶部卡片（Cursor-like）
+      await chatStore.setActiveBuild({
+        id: generateId(),
+        conversationId: chatStore.currentConversationId || '',
+        title: getDocumentTitle(latestPlanContent, card.path, 'plan'),
+        planContent: latestPlanContent,
+        planPath: card.path,
+        channelId: selectedChannelId.value || undefined,
+        modelId: selectedModelId.value || undefined,
+        startedAt: Date.now(),
+        status: 'running'
+      })
+
+      // 不创建新的可见 user 消息：把确认信息追加到对应工具的 functionResponse 字段里再继续对话
+      await chatStore.sendMessage('', undefined, {
+        modelOverride: selectedModelId.value || undefined,
+        hidden: {
+          functionResponse: {
+            id: card.toolId,
+            name: card.toolName,
+            response: {
+              planExecutionPrompt: prompt,
+              todos: todosFromPlan
+            }
+          }
+        }
+      })
+    })
+  } catch (error) {
+    console.error(t('components.message.tool.planCard.executePlanFailed'), error)
+  } finally {
     isExecutingPlan.value = false
   }
 }
 
-async function autoOpenPendingPlanTabs(cards: PlanCardItem[]) {
+async function generatePlan(card: TaskCardItem) {
+  if (card.kind !== 'design') return
+  if (isGeneratingPlan.value || card.isActionCompleted || !card.content.trim()) return
+
+  isGeneratingPlan.value = true
+  try {
+    await withSelectedChannel(async () => {
+      const confirmResult = await sendToExtension<{
+        success: boolean
+        prompt: string
+        designContent: string
+        designPath: string
+      }>('design.confirmPlanGeneration', {
+        path: card.path,
+        originalContent: card.content,
+        conversationId: chatStore.currentConversationId
+      })
+
+      const prompt = String(confirmResult?.prompt || '')
+      const latestDesignContent = confirmResult?.designContent || card.content
+      const latestDesignPath = String(confirmResult?.designPath || card.path || '')
+
+      // 生成计划前，切换到用户选择的目标模式，默认优先 plan
+      try {
+        const targetModeId = String(selectedPlanGenerationModeId.value || 'plan').trim() || 'plan'
+        await chatStore.setCurrentPromptModeId(targetModeId)
+        saveState(PLAN_GENERATION_MODE_STATE_KEY, targetModeId)
+      } catch (modeError) {
+        // 模式切换失败不阻塞继续对话
+        console.error('[design] Failed to switch prompt mode before plan generation:', modeError)
+      }
+
+      // 不创建新的可见 user 消息：把确认信息追加到对应工具的 functionResponse 字段里再继续对话
+      await chatStore.sendMessage('', undefined, {
+        modelOverride: selectedModelId.value || undefined,
+        hidden: {
+          functionResponse: {
+            id: card.toolId,
+            name: card.toolName,
+            response: {
+              planGenerationPrompt: prompt,
+              designPath: latestDesignPath,
+              designContent: latestDesignContent
+            }
+          }
+        }
+      })
+    })
+  } catch (error) {
+    console.error(t('components.message.tool.designCard.generatePlanFailed'), error)
+  } finally {
+    isGeneratingPlan.value = false
+  }
+}
+
+function handleCardAction(card: TaskCardItem) {
+  if (card.kind === 'plan') {
+    void executePlan(card)
+    return
+  }
+
+  void generatePlan(card)
+}
+
+async function autoOpenPendingCardTabs(cards: TaskCardItem[]) {
   for (const card of cards) {
     if (!card?.path) continue
-    if (card.isExecuted) continue
+    if (card.isActionCompleted) continue
     if (card.status === 'error') continue
-    if (autoOpenedPlanCardKeys.value.has(card.key)) continue
+    if (autoOpenedCardKeys.value.has(card.key)) continue
 
-    autoOpenedPlanCardKeys.value.add(card.key)
+    autoOpenedCardKeys.value.add(card.key)
     try {
       await sendToExtension('openWorkspaceFileAt', {
         path: card.path,
         highlight: false
       })
     } catch (error) {
-      console.error(t('components.message.tool.planCard.executePlanFailed'), error)
+      console.error(getOpenFileFailedMessage(card.kind), error)
     }
   }
 }
@@ -324,7 +492,7 @@ async function autoOpenPendingPlanTabs(cards: PlanCardItem[]) {
 onMounted(() => {
   loadChannels()
   void loadPromptModes()
-  void autoOpenPendingPlanTabs(planCards.value)
+  void autoOpenPendingCardTabs(taskCards.value)
 })
 
 watch(
@@ -336,7 +504,6 @@ watch(
   }
 )
 
-
 // ============ 工具状态映射 ============
 function getToolResult(tool: ToolUsage): any {
   const fromTool = tool.result && typeof tool.result === 'object'
@@ -347,7 +514,7 @@ function getToolResult(tool: ToolUsage): any {
     ? chatStore.getToolResponseById(tool.id) as any
     : undefined
 
-  // 优先融合 functionResponse（包含 reload 后的真实结果、以及执行计划确认字段）
+  // 优先融合 functionResponse（包含 reload 后的真实结果、以及后续确认字段）
   if (fromTool && fromResponse && typeof fromResponse === 'object') {
     return { ...fromTool, ...fromResponse }
   }
@@ -369,8 +536,8 @@ function mapToolStatus(tool: ToolUsage): CardStatus {
   return 'pending'
 }
 
-// ============ Plan 数据提取 ============
-function getWriteFilePlanEntries(tool: ToolUsage): PlanEntry[] {
+// ============ 文档数据提取 ============
+function getWriteFileTaskEntries(tool: ToolUsage): TaskEntry[] {
   const args = tool.args as any
   const files = Array.isArray(args?.files) ? args.files : []
 
@@ -383,18 +550,41 @@ function getWriteFilePlanEntries(tool: ToolUsage): PlanEntry[] {
     }
   }
 
-  const entries: PlanEntry[] = []
+  const planExecutionPrompt = getPlanExecutionPrompt(result)
+  const planGenerationPrompt = getPlanGenerationPrompt(result)
+
+  const entries: TaskEntry[] = []
   for (const f of files) {
     const path = f?.path
     const content = f?.content
     if (typeof path !== 'string' || typeof content !== 'string') continue
-    if (!isPlanDocPath(path)) continue
-    entries.push({ path, content, success: successByPath.get(path) })
+
+    if (isDesignDocPath(path)) {
+      entries.push({
+        kind: 'design',
+        path,
+        content,
+        success: successByPath.get(path),
+        continuationPrompt: planGenerationPrompt || undefined
+      })
+      continue
+    }
+
+    if (isPlanDocPath(path)) {
+      entries.push({
+        kind: 'plan',
+        path,
+        content,
+        success: successByPath.get(path),
+        continuationPrompt: planExecutionPrompt || undefined
+      })
+    }
   }
+
   return entries
 }
 
-function getCreatePlanEntries(tool: ToolUsage): PlanEntry[] {
+function getCreatePlanEntries(tool: ToolUsage): TaskEntry[] {
   const args = tool.args as any
   const result = getToolResult(tool)
 
@@ -405,139 +595,173 @@ function getCreatePlanEntries(tool: ToolUsage): PlanEntry[] {
   if (!isPlanDocPath(path)) return []
 
   const success = typeof result?.success === 'boolean' ? result.success : undefined
-  const executionPrompt = typeof result?.planExecutionPrompt === 'string' && result.planExecutionPrompt.trim()
-    ? result.planExecutionPrompt
-    : undefined
-  return [{ path, content, success, executionPrompt }]
+  const continuationPrompt = getPlanExecutionPrompt(result) || undefined
+
+  return [{
+    kind: 'plan',
+    path,
+    content,
+    success,
+    continuationPrompt
+  }]
 }
 
-const planCards = computed<PlanCardItem[]>(() => {
-  const cards: PlanCardItem[] = []
+function getCreateDesignEntries(tool: ToolUsage): TaskEntry[] {
+  const args = tool.args as any
+  const result = getToolResult(tool)
+
+  const path = (result?.data?.path || args?.path) as string | undefined
+  const content = (result?.data?.content || args?.design) as string | undefined
+
+  if (typeof path !== 'string' || typeof content !== 'string') return []
+  if (!isDesignDocPath(path)) return []
+
+  const success = typeof result?.success === 'boolean' ? result.success : undefined
+  const continuationPrompt = getPlanGenerationPrompt(result) || undefined
+
+  return [{
+    kind: 'design',
+    path,
+    content,
+    success,
+    continuationPrompt
+  }]
+}
+
+function getTaskEntries(tool: ToolUsage): TaskEntry[] {
+  if (tool.name === 'write_file') return getWriteFileTaskEntries(tool)
+  if (tool.name === 'create_plan') return getCreatePlanEntries(tool)
+  if (tool.name === 'create_design') return getCreateDesignEntries(tool)
+  return []
+}
+
+const taskCards = computed<TaskCardItem[]>(() => {
+  const cards: TaskCardItem[] = []
 
   for (const tool of props.tools) {
-    const entries = tool.name === 'write_file'
-      ? getWriteFilePlanEntries(tool)
-      : tool.name === 'create_plan'
-        ? getCreatePlanEntries(tool)
-        : []
+    const entries = getTaskEntries(tool)
     if (entries.length === 0) continue
 
     for (const entry of entries) {
-      const status: CardStatus = entry.executionPrompt
+      const status: CardStatus = entry.continuationPrompt
         ? 'success'
         : typeof entry.success === 'boolean'
-        ? (entry.success ? 'success' : 'error')
-        : mapToolStatus(tool)
+          ? (entry.success ? 'success' : 'error')
+          : mapToolStatus(tool)
 
       cards.push({
-        key: `plan:${tool.id}:${entry.path}`,
+        key: `${entry.kind}:${tool.id}:${entry.path}`,
+        kind: entry.kind,
         status,
-        title: t('components.message.tool.planCard.title'),
+        title: getDocumentTitle(entry.content, entry.path, entry.kind),
         path: entry.path,
         content: entry.content,
-        badge: props.messageModelVersion || '',
         toolId: tool.id,
         toolName: tool.name,
-        isExecuted: !!entry.executionPrompt
+        isActionCompleted: !!entry.continuationPrompt
       })
     }
   }
+
   return cards
 })
 
-
 watch(
-  () => planCards.value,
+  () => taskCards.value,
   (cards) => {
-    void autoOpenPendingPlanTabs(cards)
+    void autoOpenPendingCardTabs(cards)
   }
 )
 
-const hasAny = computed(() => planCards.value.length > 0)
+const hasAny = computed(() => taskCards.value.length > 0)
 </script>
 
 <template>
   <div v-if="hasAny" class="message-taskcards">
-    <!-- Plan 卡片（面板风格） -->
-    <div v-for="c in planCards" :key="c.key" class="plan-panel">
-      <div class="plan-header">
-        <div class="plan-info">
-          <span class="codicon codicon-list-unordered plan-icon"></span>
-          <span class="plan-title">{{ c.title }}</span>
-          <span v-if="c.status === 'success'" class="plan-status success">
+    <div v-for="c in taskCards" :key="c.key" class="task-panel">
+      <div class="task-header">
+        <div class="task-info">
+          <span
+            :class="[
+              'codicon',
+              c.kind === 'plan' ? 'codicon-list-unordered' : 'codicon-lightbulb',
+              'task-icon',
+              c.kind
+            ]"
+          ></span>
+          <span class="task-title">{{ c.title }}</span>
+          <span v-if="c.status === 'success'" class="task-status success">
             <span class="codicon codicon-check"></span>
           </span>
-          <span v-else-if="c.status === 'running'" class="plan-status running">
+          <span v-else-if="c.status === 'running'" class="task-status running">
             <span class="codicon codicon-loading codicon-modifier-spin"></span>
           </span>
-          <span v-else-if="c.status === 'error'" class="plan-status error">
+          <span v-else-if="c.status === 'error'" class="task-status error">
             <span class="codicon codicon-error"></span>
           </span>
         </div>
-        <div class="plan-actions">
+        <div class="task-actions">
           <button
             class="action-btn"
-            :title="t('components.message.tool.planCard.openFile')"
+            :title="getOpenFileLabel(c.kind)"
             :disabled="!c.path"
-            @click="openPlanFile(c)"
+            @click="openDocFile(c)"
           >
             <span class="codicon codicon-go-to-file"></span>
           </button>
           <button
             class="action-btn"
-            :title="isPlanExpanded(c.key) ? t('common.collapse') : t('common.expand')"
-            @click="togglePlanExpand(c.key)"
+            :title="isCardExpanded(c.key) ? t('common.collapse') : t('common.expand')"
+            @click="toggleCardExpand(c.key)"
           >
-            <span :class="['codicon', isPlanExpanded(c.key) ? 'codicon-chevron-up' : 'codicon-chevron-down']"></span>
+            <span :class="['codicon', isCardExpanded(c.key) ? 'codicon-chevron-up' : 'codicon-chevron-down']"></span>
           </button>
         </div>
       </div>
-      
-      <div class="plan-path">{{ c.path }}</div>
-      
-      <div class="plan-content">
-        <CustomScrollbar :max-height="isPlanExpanded(c.key) ? 500 : 200">
-          <div class="plan-preview">
+
+      <div class="task-path">{{ c.path }}</div>
+
+      <div class="task-content">
+        <CustomScrollbar :max-height="isCardExpanded(c.key) ? 500 : 200">
+          <div class="task-preview">
             <MarkdownRenderer :content="c.content" />
           </div>
         </CustomScrollbar>
       </div>
-      
-      <div class="plan-execute">
-        <div class="execute-selector">
-          <span class="execute-label">{{ t('components.message.tool.planCard.executeLabel') }}</span>
+
+      <div class="task-footer">
+        <div class="task-selector">
+          <span class="task-label">{{ getActionLabel(c.kind) }}</span>
           <ModeSelector
-            v-model="selectedModeId"
+            :model-value="getModeIdForKind(c.kind)"
             :options="promptModeOptions"
             :drop-up="true"
-            :disabled="isLoadingModes || isExecutingPlan"
+            :disabled="isLoadingModes || isAnyTaskActionRunning"
             class="mode-select"
-            @update:model-value="handleModeChange"
+            @update:model-value="(value) => handleModeChange(c.kind, value)"
             @open-settings="openModeSettings"
           />
           <ChannelSelector
             v-model="selectedChannelId"
             :options="channelOptions"
-            :disabled="isLoadingChannels || isExecutingPlan"
+            :disabled="isLoadingChannels || isAnyTaskActionRunning"
             class="channel-select"
           />
           <ModelSelector
             v-model="selectedModelId"
             :models="modelOptions"
-            :disabled="isLoadingChannels || isLoadingModels || isExecutingPlan || !selectedChannelId"
+            :disabled="isLoadingChannels || isLoadingModels || isAnyTaskActionRunning || !selectedChannelId"
             class="model-select"
           />
         </div>
         <button
-          class="execute-btn"
-          :class="{ done: c.isExecuted }"
-          :disabled="isExecutingPlan || c.isExecuted || !selectedModeId || !selectedChannelId || !selectedModelId"
-          @click="executePlan(c)"
+          class="task-btn"
+          :class="{ done: c.isActionCompleted }"
+          :disabled="isActionDisabled(c)"
+          @click="handleCardAction(c)"
         >
-          <span v-if="c.isExecuted" class="codicon codicon-check"></span>
-          <span v-else-if="isExecutingPlan" class="codicon codicon-loading codicon-modifier-spin"></span>
-          <span v-else class="codicon codicon-play"></span>
-          <span class="btn-text">{{ c.isExecuted ? t('components.message.tool.planCard.executed') : (isExecutingPlan ? t('components.message.tool.planCard.executing') : t('components.message.tool.planCard.executePlan')) }}</span>
+          <span :class="['codicon', getActionIconClass(c)]"></span>
+          <span class="btn-text">{{ getActionText(c) }}</span>
         </button>
       </div>
     </div>
@@ -552,15 +776,14 @@ const hasAny = computed(() => planCards.value.length > 0)
   margin: 8px 0 10px;
 }
 
-/* ============ Plan 面板（继承 write_file 风格） ============ */
-.plan-panel {
+.task-panel {
   border: 1px solid var(--vscode-editorWidget-border, var(--vscode-panel-border));
   border-radius: var(--radius-sm, 2px);
   overflow: hidden;
   background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
 }
 
-.plan-header {
+.task-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -569,7 +792,7 @@ const hasAny = computed(() => planCards.value.length > 0)
   border-bottom: 1px solid var(--vscode-panel-border);
 }
 
-.plan-info {
+.task-info {
   display: flex;
   align-items: center;
   gap: var(--spacing-xs, 4px);
@@ -577,28 +800,39 @@ const hasAny = computed(() => planCards.value.length > 0)
   min-width: 0;
 }
 
-.plan-icon {
+.task-icon {
   font-size: 12px;
-  color: var(--vscode-charts-blue, #3794ff);
   flex-shrink: 0;
 }
 
-.plan-title {
+.task-icon.plan {
+  color: var(--vscode-charts-blue, #3794ff);
+}
+
+.task-icon.design {
+  color: var(--vscode-charts-yellow, #d7ba7d);
+}
+
+.task-title {
   font-size: 11px;
   font-weight: 600;
   color: var(--vscode-foreground);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.plan-status {
+.task-status {
   font-size: 12px;
   margin-left: var(--spacing-xs, 4px);
 }
 
-.plan-status.success { color: var(--vscode-testing-iconPassed); }
-.plan-status.running { color: var(--vscode-charts-blue); }
-.plan-status.error { color: var(--vscode-testing-iconFailed); }
+.task-status.success { color: var(--vscode-testing-iconPassed); }
+.task-status.running { color: var(--vscode-charts-blue); }
+.task-status.error { color: var(--vscode-testing-iconFailed); }
 
-.plan-actions {
+.task-actions {
   display: flex;
   align-items: center;
   gap: var(--spacing-xs, 4px);
@@ -633,7 +867,7 @@ const hasAny = computed(() => planCards.value.length > 0)
   color: var(--vscode-descriptionForeground);
 }
 
-.plan-path {
+.task-path {
   padding: 2px var(--spacing-sm, 8px);
   font-size: 10px;
   color: var(--vscode-descriptionForeground);
@@ -645,15 +879,15 @@ const hasAny = computed(() => planCards.value.length > 0)
   white-space: nowrap;
 }
 
-.plan-content {
+.task-content {
   background: var(--vscode-editor-background);
 }
 
-.plan-preview {
+.task-preview {
   padding: var(--spacing-sm, 8px);
 }
 
-.plan-execute {
+.task-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -663,7 +897,7 @@ const hasAny = computed(() => planCards.value.length > 0)
   border-top: 1px solid var(--vscode-panel-border);
 }
 
-.execute-selector {
+.task-selector {
   display: flex;
   align-items: center;
   gap: var(--spacing-xs, 4px);
@@ -671,7 +905,7 @@ const hasAny = computed(() => planCards.value.length > 0)
   min-width: 0;
 }
 
-.execute-label {
+.task-label {
   font-size: 10px;
   color: var(--vscode-descriptionForeground);
   white-space: nowrap;
@@ -694,7 +928,7 @@ const hasAny = computed(() => planCards.value.length > 0)
   max-width: 220px;
 }
 
-.execute-btn {
+.task-btn {
   display: flex;
   align-items: center;
   gap: var(--spacing-xs, 4px);
@@ -709,26 +943,26 @@ const hasAny = computed(() => planCards.value.length > 0)
   white-space: nowrap;
 }
 
-.execute-btn:hover:not(:disabled) {
+.task-btn:hover:not(:disabled) {
   background: var(--vscode-button-hoverBackground);
 }
 
-.execute-btn.done {
+.task-btn.done {
   background: var(--vscode-button-secondaryBackground);
   color: var(--vscode-button-secondaryForeground);
   opacity: 0.85;
 }
 
-.execute-btn.done:hover:not(:disabled) {
+.task-btn.done:hover:not(:disabled) {
   background: var(--vscode-button-secondaryBackground);
 }
 
-.execute-btn:disabled {
+.task-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.execute-btn.done:disabled {
+.task-btn.done:disabled {
   background: var(--vscode-button-secondaryBackground);
   color: var(--vscode-button-secondaryForeground);
   opacity: 0.7;
@@ -738,8 +972,7 @@ const hasAny = computed(() => planCards.value.length > 0)
   font-size: 11px;
 }
 
-/* 让 ModelSelector 在 Plan 面板里看起来像输入框（与 ChannelSelector 对齐） */
-.plan-execute :deep(.model-trigger) {
+.task-footer :deep(.model-trigger) {
   background: var(--vscode-input-background);
   color: var(--vscode-input-foreground);
   border: 1px solid var(--vscode-input-border);
@@ -747,16 +980,15 @@ const hasAny = computed(() => planCards.value.length > 0)
   padding: 4px 8px;
 }
 
-.plan-execute :deep(.model-trigger:hover:not(:disabled)) {
+.task-footer :deep(.model-trigger:hover:not(:disabled)) {
   border-color: var(--vscode-focusBorder);
   background: var(--vscode-input-background);
   color: var(--vscode-input-foreground);
 }
 
-.plan-execute :deep(.model-selector.open .model-trigger) {
+.task-footer :deep(.model-selector.open .model-trigger) {
   border-color: var(--vscode-focusBorder);
   background: var(--vscode-input-background);
   color: var(--vscode-input-foreground);
 }
-
 </style>

--- a/frontend/src/components/message/responseViewer/buildResponseViewerData.ts
+++ b/frontend/src/components/message/responseViewer/buildResponseViewerData.ts
@@ -6,6 +6,7 @@ import type {
   ToolUsage,
   UsageMetadata
 } from '../../../types'
+import { isAwaitingToolUserConfirmation } from '../../../utils/toolContinuations'
 
 export type ResponseViewerMode = 'common' | 'advanced'
 export type ResponseViewerPartType =
@@ -583,7 +584,7 @@ function deriveToolStatusFromResult(
   if (result && typeof result === 'object') {
     const record = result as Record<string, unknown>
 
-    if (record.requiresUserConfirmation === true) {
+    if (isAwaitingToolUserConfirmation(record)) {
       return 'awaiting_apply'
     }
 

--- a/frontend/src/i18n/langs/en.ts
+++ b/frontend/src/i18n/langs/en.ts
@@ -526,6 +526,10 @@ const en: LanguageMessages = {
                     label: 'Create Plan',
                     fallbackTitle: 'Plan'
                 },
+                createDesign: {
+                    label: 'Create Design',
+                    fallbackTitle: 'Design'
+                },
                 todoPanel: {
                     title: 'TODO List',
                     modePlan: 'plan',
@@ -558,6 +562,18 @@ const en: LanguageMessages = {
                     executePlanFailed: 'Failed to execute plan',
                     openFileFailed: 'Failed to open file',
                     promptPrefix: 'Please execute the following plan:\n\n{plan}'
+                },
+                designCard: {
+                    title: 'Design',
+                    generateLabel: 'Plan:',
+                    generated: 'Plan Generated',
+                    generating: 'Generating Plan...',
+                    generatePlan: 'Generate Plan',
+                    openFile: 'Open File',
+                    loadChannelsFailed: 'Failed to load channels',
+                    loadModelsFailed: 'Failed to load models',
+                    generatePlanFailed: 'Failed to generate plan',
+                    openFileFailed: 'Failed to open file'
                 }
             },
             attachment: {

--- a/frontend/src/i18n/langs/ja.ts
+++ b/frontend/src/i18n/langs/ja.ts
@@ -526,6 +526,10 @@ const ja: LanguageMessages = {
                     label: 'プランを作成',
                     fallbackTitle: 'プラン'
                 },
+                createDesign: {
+                    label: '設計を作成',
+                    fallbackTitle: '設計'
+                },
                 todoPanel: {
                     title: 'TODO リスト',
                     modePlan: 'プラン',
@@ -558,6 +562,18 @@ const ja: LanguageMessages = {
                     executePlanFailed: 'プランの実行に失敗しました',
                     openFileFailed: 'ファイルを開くのに失敗しました',
                     promptPrefix: '以下のプランに従って実行してください:\n\n{plan}'
+                },
+                designCard: {
+                    title: '設計',
+                    generateLabel: 'プラン生成:',
+                    generated: 'プラン生成済み',
+                    generating: 'プランを生成中...',
+                    generatePlan: 'プランを生成',
+                    openFile: 'ファイルを開く',
+                    loadChannelsFailed: 'チャンネルの読み込みに失敗しました',
+                    loadModelsFailed: 'モデルの読み込みに失敗しました',
+                    generatePlanFailed: 'プランの生成に失敗しました',
+                    openFileFailed: 'ファイルを開くのに失敗しました'
                 }
             },
             attachment: {

--- a/frontend/src/i18n/langs/zh-CN.ts
+++ b/frontend/src/i18n/langs/zh-CN.ts
@@ -526,6 +526,10 @@ const zhCN: LanguageMessages = {
                     label: '创建计划',
                     fallbackTitle: '计划'
                 },
+                createDesign: {
+                    label: '创建设计',
+                    fallbackTitle: '设计'
+                },
                 todoPanel: {
                     title: 'TODO 列表',
                     modePlan: '计划',
@@ -558,6 +562,18 @@ const zhCN: LanguageMessages = {
                     executePlanFailed: '执行计划失败',
                     openFileFailed: '打开文件失败',
                     promptPrefix: '请按照以下计划执行：\n\n{plan}'
+                },
+                designCard: {
+                    title: '设计',
+                    generateLabel: '生成计划：',
+                    generated: '已生成计划',
+                    generating: '生成计划中...',
+                    generatePlan: '生成计划',
+                    openFile: '打开文件',
+                    loadChannelsFailed: '加载渠道失败',
+                    loadModelsFailed: '加载模型失败',
+                    generatePlanFailed: '生成计划失败',
+                    openFileFailed: '打开文件失败'
                 }
             },
             attachment: {

--- a/frontend/src/i18n/types.ts
+++ b/frontend/src/i18n/types.ts
@@ -447,6 +447,10 @@ export interface LanguageMessages {
                     label: string;
                     fallbackTitle: string;
                 };
+                createDesign: {
+                    label: string;
+                    fallbackTitle: string;
+                };
                 todoPanel: {
                     title: string;
                     modePlan: string;
@@ -479,6 +483,18 @@ export interface LanguageMessages {
                     executePlanFailed: string;
                     openFileFailed: string;
                     promptPrefix: string;
+                };
+                designCard: {
+                    title: string;
+                    generateLabel: string;
+                    generated: string;
+                    generating: string;
+                    generatePlan: string;
+                    openFile: string;
+                    loadChannelsFailed: string;
+                    loadModelsFailed: string;
+                    generatePlanFailed: string;
+                    openFileFailed: string;
                 };
             };
             attachment: {

--- a/frontend/src/stores/chat/computed.ts
+++ b/frontend/src/stores/chat/computed.ts
@@ -4,6 +4,7 @@
 
 import { computed } from 'vue'
 import type { ChatStoreState, ChatStoreComputed } from './types'
+import { isAwaitingToolUserConfirmation } from '../../utils/toolContinuations'
 
 /**
  * 创建 Chat Store 计算属性
@@ -69,10 +70,10 @@ export function createChatComputed(state: ChatStoreState): ChatStoreComputed {
    * 且不在流式响应状态、没有错误、没有正在重试时，
    * 说明对话被中断，需要显示继续按钮
    *
-   * 例外：如果工具返回了 requiresUserConfirmation（如 create_plan），
-   * 说明工具主动要求暂停循环等待用户操作（如点击"执行计划"），
+   * 例外：如果工具返回了 requiresUserConfirmation（如 create_plan / create_design），
+   * 说明工具主动要求暂停循环等待用户操作（如点击"执行计划"或"生成计划"），
    * 此时不应显示此提示。
-   * 但若该工具已被确认执行（response 中已有 planExecutionPrompt），则恢复显示"继续"提示。
+   * 但若该工具已写入 continuation prompt（如 planExecutionPrompt / planGenerationPrompt），则恢复显示"继续"提示。
    */
   const needsContinueButton = computed(() => {
     if (state.allMessages.value.length === 0) return false
@@ -83,20 +84,11 @@ export function createChatComputed(state: ChatStoreState): ChatStoreComputed {
     const lastMessage = state.allMessages.value[state.allMessages.value.length - 1]
     if (!lastMessage.isFunctionResponse) return false
 
-    // 检查是否有工具要求暂停等待用户确认（如 create_plan 的 requiresUserConfirmation）
-    // 此时计划卡片会显示"执行计划"按钮，不需要额外的"继续"提示
+    // 检查是否有工具要求暂停等待用户确认（如 create_plan / create_design）
+    // 此时卡片会显示对应操作按钮，不需要额外的"继续"提示
     const hasPendingUserConfirmation = lastMessage.parts?.some(p => {
       const response = (p.functionResponse?.response as any)
-      if (!response?.requiresUserConfirmation) return false
-
-      // 如果已经写入执行确认提示（执行计划完成态），说明“确认阶段”已结束；
-      // 这时若对话被中断，应显示底部“继续对话”提示用于恢复。
-      const executedPrompt =
-        typeof response?.planExecutionPrompt === 'string'
-          ? response.planExecutionPrompt.trim()
-          : ''
-
-      return executedPrompt.length === 0
+      return isAwaitingToolUserConfirmation(response)
     })
 
     if (hasPendingUserConfirmation) {

--- a/frontend/src/utils/taskCards.ts
+++ b/frontend/src/utils/taskCards.ts
@@ -45,25 +45,22 @@ export function formatSubAgentRuntimeBadge(meta: SubAgentRuntimeMeta): string {
   return channel || model
 }
 
-/**
- * Whether a path looks like a plan doc under .limcode/plans and ends with .md
- * (supports multi-root prefix like "workspace/.limcode/plans/x.plan.md").
- */
-export function isPlanDocPath(path: string): boolean {
+function isScopedMarkdownDocPath(path: string, scopeRoot: string): boolean {
   const normalized = (path || '').replace(/\\/g, '/')
   const lower = normalized.toLowerCase()
+  const scopeLower = scopeRoot.toLowerCase()
 
   // Must be a markdown file
   if (!lower.endsWith('.md')) return false
 
-  // Keep consistent with backend plan path safety rules
-  // (avoid path traversal patterns showing up as “plan docs” in UI)
+  // Keep consistent with backend path safety rules
+  // (avoid path traversal patterns showing up as document cards in UI)
   if (lower.includes('..')) return false
 
-  // Single-root: .limcode/plans/...
-  if (lower.startsWith('.limcode/plans/')) return true
+  // Single-root: .limcode/.../...md
+  if (lower.startsWith(scopeLower)) return true
 
-  // Multi-root: workspaceName/.limcode/plans/...
+  // Multi-root: workspaceName/.limcode/.../...md
   // Only allow a single path segment as workspace prefix.
   const slashIndex = normalized.indexOf('/')
   if (slashIndex <= 0) return false
@@ -74,7 +71,23 @@ export function isPlanDocPath(path: string): boolean {
   if (workspacePrefix.includes(':')) return false
 
   const rest = normalized.slice(slashIndex + 1)
-  return rest.toLowerCase().startsWith('.limcode/plans/')
+  return rest.toLowerCase().startsWith(scopeLower)
+}
+
+/**
+ * Whether a path looks like a plan doc under .limcode/plans and ends with .md
+ * (supports multi-root prefix like "workspace/.limcode/plans/x.plan.md").
+ */
+export function isPlanDocPath(path: string): boolean {
+  return isScopedMarkdownDocPath(path, '.limcode/plans/')
+}
+
+/**
+ * Whether a path looks like a design doc under .limcode/design and ends with .md
+ * (supports multi-root prefix like "workspace/.limcode/design/x.md").
+ */
+export function isDesignDocPath(path: string): boolean {
+  return isScopedMarkdownDocPath(path, '.limcode/design/')
 }
 
 export interface PlanTodoItem {
@@ -141,4 +154,3 @@ export function extractTodosFromPlan(content: string): PlanTodoItem[] {
 
   return todos
 }
-

--- a/frontend/src/utils/toolContinuations.ts
+++ b/frontend/src/utils/toolContinuations.ts
@@ -1,0 +1,26 @@
+function normalizePrompt(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export function getPlanExecutionPrompt(response: unknown): string {
+  if (!response || typeof response !== 'object') return ''
+  return normalizePrompt((response as Record<string, unknown>).planExecutionPrompt)
+}
+
+export function getPlanGenerationPrompt(response: unknown): string {
+  if (!response || typeof response !== 'object') return ''
+  return normalizePrompt((response as Record<string, unknown>).planGenerationPrompt)
+}
+
+export function getToolContinuationPrompt(response: unknown): string {
+  return getPlanExecutionPrompt(response) || getPlanGenerationPrompt(response)
+}
+
+export function isAwaitingToolUserConfirmation(response: unknown): boolean {
+  if (!response || typeof response !== 'object') return false
+
+  const record = response as Record<string, unknown>
+  if (record.requiresUserConfirmation !== true) return false
+
+  return getToolContinuationPrompt(record).length === 0
+}

--- a/frontend/src/utils/tools/design/create_design.ts
+++ b/frontend/src/utils/tools/design/create_design.ts
@@ -1,0 +1,23 @@
+/**
+ * create_design 工具注册（前端展示）
+ */
+
+import { registerTool } from '../../toolRegistry'
+import { t } from '../../../i18n'
+
+registerTool('create_design', {
+  name: 'create_design',
+  label: t('components.message.tool.createDesign.label'),
+  icon: 'codicon-lightbulb',
+  descriptionFormatter: (args) => {
+    const path = (args as any)?.path as string | undefined
+    const title = (args as any)?.title as string | undefined
+    if (path && path.trim()) return path
+    if (title && title.trim()) return title.trim()
+    return t('components.message.tool.createDesign.fallbackTitle')
+  },
+  contentFormatter: (args, result) => {
+    const content = ((result as any)?.data?.content || (args as any)?.design || '') as string
+    return content || ''
+  }
+})

--- a/frontend/src/utils/tools/index.ts
+++ b/frontend/src/utils/tools/index.ts
@@ -43,6 +43,9 @@ import './subagents/subagents'
 import './todo/todo_write'
 import './todo/todo_update'
 
+// Design 工具
+import './design/create_design'
+
 // Plan 工具
 import './plan/create_plan'
 

--- a/webview/handlers/FileHandlers.ts
+++ b/webview/handlers/FileHandlers.ts
@@ -1163,6 +1163,60 @@ export const showNotification: MessageHandler = async (data, requestId, ctx) => 
   }
 };
 
+// ========== Design 生成计划确认 ==========
+
+export const designConfirmPlanGeneration: MessageHandler = async (data, requestId, ctx) => {
+  try {
+    const { path: designPathRaw, originalContent } = data || {};
+    const designPath = typeof designPathRaw === 'string' ? designPathRaw.trim() : '';
+    const originalText = typeof originalContent === 'string' ? originalContent : '';
+    const confirmedPrompt = 'User confirmed this design. Please create an implementation plan document based on it.';
+    const modifiedPrompt = 'User modified this design and confirmed the latest version. Please create an implementation plan document based on the latest design content.';
+
+    const replyWithDesign = async (prompt: string, designContent: string) => {
+      ctx.sendResponse(requestId, {
+        success: true,
+        prompt,
+        designContent,
+        designPath
+      });
+    };
+
+    if (!designPath) {
+      await replyWithDesign(confirmedPrompt, originalText);
+      return;
+    }
+
+    const { uri } = resolveUriWithInfo(designPath);
+    if (!uri) {
+      await replyWithDesign(confirmedPrompt, originalText);
+      return;
+    }
+
+    try {
+      const bytes = await vscode.workspace.fs.readFile(uri);
+      const currentContent = Buffer.from(bytes).toString('utf-8');
+
+      const currentTrimmed = (currentContent || '').trim();
+      const originalTrimmed = originalText.trim();
+
+      if (currentTrimmed !== originalTrimmed) {
+        await replyWithDesign(modifiedPrompt, currentContent);
+      } else {
+        await replyWithDesign(
+          confirmedPrompt,
+          originalText || currentContent || ''
+        );
+      }
+    } catch {
+      // File read failed, fallback to original content
+      await replyWithDesign(confirmedPrompt, originalText);
+    }
+  } catch (error: any) {
+    ctx.sendError(requestId, 'DESIGN_CONFIRM_PLAN_GENERATION_ERROR', error.message || 'Failed to confirm design plan generation');
+  }
+};
+
 // ========== Plan 执行确认 ==========
 
 export const planConfirmExecution: MessageHandler = async (data, requestId, ctx) => {
@@ -1274,6 +1328,9 @@ export function registerFileHandlers(registry: Map<string, MessageHandler>): voi
   // 通知
   registry.set('showNotification', showNotification);
   
+  // Design 生成计划确认
+  registry.set('design.confirmPlanGeneration', designConfirmPlanGeneration);
+
   // Plan 执行确认
   registry.set('plan.confirmExecution', planConfirmExecution);
 }


### PR DESCRIPTION
## 背景

当前 `plan` 模式已经具备较完整的确认式链路：

`create_plan` 创建文档 -> 用户确认 -> 执行计划 -> 进入实施

相比之下，`design` 模式此前还缺少两部分能力：

1. 缺少正式的 design 文档产出工具和统一落点；
2. 缺少从 design 阶段进入 plan 阶段的标准继续链路。

本 PR 的目标是补齐这一段流程，使整体工作流变为：

`design 文档 -> 生成 plan 文档 -> 执行 plan -> 实施代码`

---

## 本次改动

### 1. 新增 `create_design` 工具
- 新增 `create_design` 工具；
- 设计文档固定写入 `.limcode/design/**.md`；
- 增加 design 路径校验；
- 支持单工作区和 multi-root 场景；
- 工具返回 `requiresUserConfirmation: true`，写完 design 文档后暂停，等待用户确认下一步。

### 2. 增加 design 文档识别与前端展示
- 前端注册 `create_design`；
- 增加 `.limcode/design/**.md` 路径识别；
- 在消息区域展示 design 文档卡片；
- 补充 design 卡片相关文案与多语言资源。

### 3. 增加 design -> plan 的用户入口
- 在 design 文档卡片上增加“生成计划”按钮；
- 支持选择目标模式、渠道和模型；
- 新增 `design.confirmPlanGeneration` 处理器；
- 点击“生成计划”时，会优先读取 design 文档的最新内容；
- 如果用户在文件里修改过 design 文档，则后续生成 plan 时使用最新内容。

### 4. 补齐 design -> plan 的继续链路
- 生成计划前，先切换当前对话的 Prompt 模式到 `plan`；
- 沿用现有对话级模式持久化逻辑；
- 通过隐藏 `functionResponse` 继续对话；
- 新增 `planGenerationPrompt` 及通用 continuation 读取逻辑；
- 补齐暂停/恢复状态识别；
- 补齐 response viewer 对隐藏 `functionResponse` 的识别支持。

### 5. 让 plan 文档记录来源 design 文档
- 在 `plan` 模式提示词中补充约束；
- 当计划来自用户确认后的 design 文档时，要求在 plan 文档前部明确记录来源 design 文档路径；
- 这样 design 和 plan 之间形成可追踪关联。

### 6. 补充测试
- 新增 `designConfirmPlanGeneration` 单元测试；
- 覆盖以下场景：
  - design 文档内容已被用户修改时，使用最新内容继续；
  - path 缺失时，回退到原始内容继续。

---

## 影响范围

### Backend
- `backend/tools/design/**`
- `backend/tools/index.ts`
- `backend/modules/settings/**`

### Webview
- `webview/handlers/FileHandlers.ts`

### Frontend
- `frontend/src/components/message/MessageTaskCards.vue`
- `frontend/src/components/message/responseViewer/buildResponseViewerData.ts`
- `frontend/src/utils/toolContinuations.ts`
- `frontend/src/utils/taskCards.ts`
- `frontend/src/utils/tools/**`
- `frontend/src/stores/chat/computed.ts`
- i18n 相关文件

---

## 验证

### 自动验证
- `pnpm run build`
- `pnpm test -- --runInBand test/unit/webview/handlers/FileHandlers.designConfirmPlanGeneration.test.ts`

### 手动验收
在接近空白的调试环境中，已经完整走通以下链路：

1. Design 模式调用 `create_design` 生成 design 文档；
2. 前端正常展示 design 文档卡片；
3. 点击“生成计划”后，切换到 `plan` 模式继续对话；
4. Plan 模式调用 `create_plan` 生成 plan 文档；
5. plan 文档中正确记录来源 design 文档路径；
6. 点击“执行计划”后，继续进入实施链路。

手动验收结果：主流程通过。

---

## 兼容性说明

- 现有 `plan -> 执行计划` 链路继续保留；
- 本次新增能力主要围绕 design 文档产出和 design -> plan 继续流程；
- 非 design / plan 场景的既有行为不受影响。

---

## 结果

本 PR 补齐了 design 模式的正式文档产出能力，并把 design 与 plan 两个阶段通过统一的确认式链路连接起来。  
用户现在可以按“设计 -> 计划 -> 实施”的顺序完成流程，并在 design 和 plan 两个阶段都保留清晰的确认点。
