### PR TITLE
Fix: execute command race condition

### DIFF
--- a/backend/modules/api/chat/services/ToolIterationLoopService.ts
+++ b/backend/modules/api/chat/services/ToolIterationLoopService.ts
@@ -163,6 +163,73 @@ export class ToolIterationLoopService {
             skills
         };
     }
+
+    private orderToolResultsByCallSequence(
+        calls: FunctionCallInfo[],
+        groups: Array<ToolExecutionResult[] | undefined>
+    ): ToolExecutionResult[] {
+        const byId = new Map<string, ToolExecutionResult>();
+        const extras: ToolExecutionResult[] = [];
+
+        for (const group of groups) {
+            if (!group) continue;
+            for (const result of group) {
+                if (!result?.id) {
+                    extras.push(result);
+                    continue;
+                }
+                if (!byId.has(result.id)) {
+                    byId.set(result.id, result);
+                }
+            }
+        }
+
+        const ordered: ToolExecutionResult[] = [];
+        for (const call of calls) {
+            const match = byId.get(call.id);
+            if (match) {
+                ordered.push(match);
+                byId.delete(call.id);
+            }
+        }
+
+        ordered.push(...byId.values(), ...extras);
+        return ordered;
+    }
+
+    private orderFunctionResponsePartsByCallSequence(
+        calls: FunctionCallInfo[],
+        groups: Array<ContentPart[] | undefined>
+    ): ContentPart[] {
+        const byId = new Map<string, ContentPart>();
+        const extras: ContentPart[] = [];
+
+        for (const group of groups) {
+            if (!group) continue;
+            for (const part of group) {
+                const id = part.functionResponse?.id;
+                if (!id) {
+                    extras.push(part);
+                    continue;
+                }
+                if (!byId.has(id)) {
+                    byId.set(id, part);
+                }
+            }
+        }
+
+        const ordered: ContentPart[] = [];
+        for (const call of calls) {
+            const match = byId.get(call.id);
+            if (match) {
+                ordered.push(match);
+                byId.delete(call.id);
+            }
+        }
+
+        ordered.push(...byId.values(), ...extras);
+        return ordered;
+    }
     
     /**
      * 找到当前回合的起始用户消息索引（最后一个 isUserInput=true 的 user 消息）
@@ -605,6 +672,16 @@ export class ToolIterationLoopService {
                 autoPrefix.push(...remainingAutoPrefix);
             }
 
+            const earlyToolResults = this.orderToolResultsByCallSequence(
+                functionCalls,
+                [Array.from(streamingToolResults.values()).flatMap(result => result.toolResults)]
+            );
+            const orderedEarlyResponseParts = this.orderFunctionResponsePartsByCallSequence(
+                functionCalls,
+                [Array.from(streamingToolResults.values()).flatMap(result => result.responseParts)]
+            );
+            earlyResponseParts = orderedEarlyResponseParts;
+
             // 如果所有工具都已在流式期间执行完，autoPrefix 为空，
             // 但 earlyResponseParts 中有结果需要写入历史。
             // 必须写入，否则下一轮 LLM 调用时 assistant 的 tool_use 没有对应的 tool_result，
@@ -621,13 +698,6 @@ export class ToolIterationLoopService {
                 // start/end 进度事件，需要在这里补发 toolIteration 让前端更新 UI。
                 // 直接从 ToolExecutionFullResult.toolResults 中提取，
                 // 其 result 字段就是工具本身的业务返回值，与传统路径格式一致。
-                const earlyToolResults: ToolExecutionResult[] = [];
-                for (const call of functionCalls) {
-                    if (streamingToolResults.has(call.id)) {
-                        earlyToolResults.push(...streamingToolResults.get(call.id)!.toolResults);
-                    }
-                }
-
                 // 发送每个工具的完成状态（让前端逐个显示工具结果）
                 for (const tr of earlyToolResults) {
                     const r = tr.result as any;
@@ -744,11 +814,37 @@ export class ToolIterationLoopService {
                 }
 
                 // 将函数响应添加到历史（合并流式期间提前执行的 + 后续执行的结果）
-                const laterResponseParts = executionResult.multimodalAttachments
-                    ? [...executionResult.multimodalAttachments, ...executionResult.responseParts]
-                    : executionResult.responseParts;
-                // earlyResponseParts 排在前面，保持与模型输出顺序一致
-                const functionResponseParts = [...earlyResponseParts, ...laterResponseParts];
+
+                const combinedToolResults = this.orderToolResultsByCallSequence(
+                    functionCalls,
+                    [earlyToolResults, executionResult.toolResults]
+                );
+                const orderedFunctionResponseParts = this.orderFunctionResponsePartsByCallSequence(
+                    functionCalls,
+                    [earlyResponseParts, executionResult.responseParts]
+                );
+                const functionResponseParts = executionResult.multimodalAttachments
+                    ? [...executionResult.multimodalAttachments, ...orderedFunctionResponseParts]
+                    : orderedFunctionResponseParts;
+
+                if (earlyToolResults.length > 0 && autoPrefix.length > 0) {
+                    try {
+                        this.log.warn('stream.early_tool_mixed_with_sequential', {
+                            conversationId,
+                            iteration,
+                            earlyToolIds: earlyToolResults.map(result => result.id),
+                            sequentialToolIds: executionResult.toolResults.map(result => result.id),
+                            callOrder: functionCalls.map(call => call.id)
+                        });
+                    } catch {}
+                }
+
+                executionResult = {
+                    ...executionResult,
+                    responseParts: orderedFunctionResponseParts,
+                    toolResults: combinedToolResults,
+                    multimodalAttachments: executionResult.multimodalAttachments
+                };
 
                 await this.conversationManager.addContent(conversationId, {
                     role: 'user',

--- a/backend/modules/api/chat/services/ToolIterationLoopService.ts
+++ b/backend/modules/api/chat/services/ToolIterationLoopService.ts
@@ -693,6 +693,25 @@ export class ToolIterationLoopService {
                     isFunctionResponse: true
                 });
 
+                if (firstConfirmTool) {
+                    yield {
+                        conversationId,
+                        pendingToolCalls: [{
+                            id: firstConfirmTool.id,
+                            name: firstConfirmTool.name,
+                            args: firstConfirmTool.args
+                        }],
+                        content: finalContent,
+                        awaitingConfirmation: true as const,
+                        // 已在流式期间自动完成的前缀工具结果仍需同步给前端，
+                        // 但不能 continue 到下一轮，否则后续待确认工具会变成“无响应的 functionCall”。
+                        toolResults: earlyToolResults,
+                        checkpoints: []
+                    } satisfies ChatStreamToolConfirmationData;
+
+                    return;
+                }
+
                 // 通知前端所有工具已执行完毕（构造与传统路径一致的 toolResults 格式）。
                 // 流式提前执行的工具绕过了 executeFunctionCallsWithProgress 的
                 // start/end 进度事件，需要在这里补发 toolIteration 让前端更新 UI。
@@ -826,18 +845,6 @@ export class ToolIterationLoopService {
                 const functionResponseParts = executionResult.multimodalAttachments
                     ? [...executionResult.multimodalAttachments, ...orderedFunctionResponseParts]
                     : orderedFunctionResponseParts;
-
-                if (earlyToolResults.length > 0 && autoPrefix.length > 0) {
-                    try {
-                        this.log.warn('stream.early_tool_mixed_with_sequential', {
-                            conversationId,
-                            iteration,
-                            earlyToolIds: earlyToolResults.map(result => result.id),
-                            sequentialToolIds: executionResult.toolResults.map(result => result.id),
-                            callOrder: functionCalls.map(call => call.id)
-                        });
-                    } catch {}
-                }
 
                 executionResult = {
                     ...executionResult,

--- a/package.json
+++ b/package.json
@@ -258,7 +258,8 @@
     "build": "pnpm run compile && pnpm run build:frontend",
     "test": "jest --config jest.backend.config.js",
     "test:watch": "jest --config jest.backend.config.js --watch",
-    "test:coverage": "jest --config jest.backend.config.js --coverage"
+    "test:coverage": "jest --config jest.backend.config.js --coverage",
+    "test:diagnose-execute-command-order": "jest --config jest.backend.config.js test/unit/chat/tool_iteration_loop.execute_command_diagnostic.test.ts --runInBand"
   },
   "dependencies": {
     "@vscode/codicons": "^0.0.43",


### PR DESCRIPTION
## 背景

在同一个 assistant turn 内存在多个工具调用时，`execute_command` 在某些场景下虽然已经执行完成、前端终端也能看到输出，但下一轮模型请求却拿不到对应的 `functionResponse`，最终触发 provider 报错：

- `No response provided for this function call.`

该问题主要出现在：
- 同一轮存在多个工具调用；
- `execute_command` 不是第一个工具；
- 前面的工具可能在 streaming 阶段被 early-run；
- 后面的工具仍可能处于需要确认的流程中。

---

## 根因分析

本次问题实际涉及两个层面的逻辑缺陷：

### 1. early-run 与顺序执行结果合并时，可能没有严格按原始 tool call 顺序回写
在 mixed path 场景下，旧逻辑可能按“完成顺序”拼接 `toolResults` / `functionResponseParts`，而不是按 assistant 原始 `functionCall` 顺序组装，导致 provider 侧把前一个 tool call 识别为“未响应”。

### 2. early-only 分支在后面仍有待确认工具时，错误继续进入下一轮模型调用
当：
- 前缀 auto 工具已经在 streaming 阶段完成；
- 后续仍有需要确认的工具（例如 `execute_command`）；

旧逻辑在 `autoPrefix.length === 0 && earlyResponseParts.length > 0` 的情况下，会先写入前缀工具结果，然后直接继续下一轮模型调用，而不是进入 `awaitingConfirmation`。  
这会造成历史里已经存在 `functionCall`，但还没有对应的 `functionResponse`，从而触发报错。

---

## 变更内容

### `backend/modules/api/chat/services/ToolIterationLoopService.ts`
- 新增按 assistant 原始 `functionCalls` 顺序重排结果的逻辑，确保：
  - `toolResults` 顺序稳定；
  - `functionResponseParts` 写回历史时顺序稳定；
  - 不再受工具“谁先完成”影响。

- 修复 early-only 分支控制流：
  - 先持久化已完成的前缀 auto 工具结果；
  - 如果后续仍有 `firstConfirmTool`，则返回等待确认；
  - 不再错误继续到下一轮模型调用。

- 清理本次排障中加入的临时运行时诊断日志，避免污染正常日志输出。

### `package.json`
- 新增诊断脚本：
  - `test:diagnose-execute-command-order`
- 方便单独回归验证本次问题相关场景。

---

## 修复效果

本次修复后：
- 多工具同轮场景下，`functionResponse` 与原始 `functionCall` 顺序保持一致；
- 当前缀工具已完成、后续工具仍需确认时，会正确进入等待确认流程；
- 不再出现 `execute_command` 已执行但模型侧缺少对应 `functionResponse` 的情况；
- 避免 provider 报错：
  - `No response provided for this function call.`

---

## 验证方式

### 自动化验证
- `pnpm run test:diagnose-execute-command-order`
- `pnpm run test`

### 手动验证
在 VS Code Extension Development Host 中验证以下场景：
- `execute_command` 需要手动确认；
- `execute_command` 自动执行；

两种路径下均应能正确拿到工具输出，不再出现 functionResponse 缺失问题。

---

## 影响范围

本次改动主要影响工具迭代循环中：
- streaming early-run 工具执行结果回写；
- 多工具同轮时的结果合并顺序；
- 遇到需确认工具时的暂停/继续控制流。

对单工具调用场景影响较小，但会提升整体工具调用链路的一致性与稳定性。
