### PR TITLE
feat(progress): add project progress workflow and validation

### DIFF
--- a/backend/modules/settings/modeToolsPolicy.ts
+++ b/backend/modules/settings/modeToolsPolicy.ts
@@ -113,6 +113,25 @@ export function isReviewPathAllowed(path: string): boolean {
 }
 
 /**
+ * 检查路径是否允许在 Progress 能力下写入
+ *
+ * 首版仅允许固定文件：
+ * - .limcode/progress.md
+ *
+ * 拒绝：
+ * - 绝对路径
+ * - 包含路径穿越（..）的路径
+ * - 空字符串、目录路径或其他 Markdown 文件
+ */
+export function isProgressPathAllowed(path: string): boolean {
+    const normalizedPath = (path || '').replace(/\\/g, '/');
+    if (!normalizedPath || normalizedPath.startsWith('/') || normalizedPath.includes('..') || normalizedPath.endsWith('/')) {
+        return false;
+    }
+    return normalizedPath === '.limcode/progress.md';
+}
+
+/**
  * 获取只读模式下被认为是危险的工具集合
  * 
  * @returns 危险工具名称的 Set

--- a/backend/modules/settings/types.ts
+++ b/backend/modules/settings/types.ts
@@ -2237,6 +2237,10 @@ export const DESIGN_PROMPT_MODE: PromptMode = {
         'history_search',
         'todo_write',
         'todo_update',
+        'create_progress',
+        'update_progress',
+        'record_progress_milestone',
+        'validate_progress_document',
         'subagents',
         'create_design',
         'update_design'
@@ -2264,6 +2268,10 @@ export const PLAN_PROMPT_MODE: PromptMode = {
         'history_search',
         'todo_write',
         'todo_update',
+        'create_progress',
+        'update_progress',
+        'record_progress_milestone',
+        'validate_progress_document',
         'subagents',
         'create_plan',
         'update_plan'
@@ -2310,6 +2318,10 @@ export const REVIEW_MODE_TOOL_POLICY: string[] = [
     'subagents',
     'create_review',
     'validate_review_document',
+    'create_progress',
+    'update_progress',
+    'record_progress_milestone',
+    'validate_progress_document',
     'record_review_milestone',
     'finalize_review',
     'reopen_review'

--- a/backend/tools/design/create_design.ts
+++ b/backend/tools/design/create_design.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import type { Tool, ToolDeclaration, ToolResult } from '../types';
 import { normalizeLineEndingsToLF, resolveUriWithInfo } from '../utils';
 import { ensureParentDir, isDesignModePathAllowedWithMultiRoot } from './pathUtils';
+import { syncProgressFromDesignArtifact } from '../progress/autoSync';
 
 export interface CreateDesignArgs {
   title?: string;
@@ -79,13 +80,18 @@ export function createCreateDesignTool(): Tool {
         const content = normalizeLineEndingsToLF(design);
         const bytes = new TextEncoder().encode(content);
         await vscode.workspace.fs.writeFile(uri, bytes);
+        const progressWarnings = await syncProgressFromDesignArtifact({
+          designPath: outPath,
+          title: title || undefined
+        });
 
         return {
           success: true,
           requiresUserConfirmation: true,
           data: {
             path: outPath,
-            content
+            content,
+            ...(progressWarnings.length > 0 ? { warnings: progressWarnings } : {})
           }
         };
       } catch (e: any) {

--- a/backend/tools/design/update_design.ts
+++ b/backend/tools/design/update_design.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import type { Tool, ToolDeclaration, ToolResult } from '../types';
 import { normalizeLineEndingsToLF, resolveUriWithInfo } from '../utils';
 import { ensureParentDir, isDesignModePathAllowedWithMultiRoot } from './pathUtils';
+import { syncProgressFromDesignArtifact } from '../progress/autoSync';
 
 export interface UpdateDesignArgs {
   path: string;
@@ -81,6 +82,10 @@ export function createUpdateDesignTool(): Tool {
         const content = normalizeLineEndingsToLF(design);
         const bytes = new TextEncoder().encode(content);
         await vscode.workspace.fs.writeFile(uri, bytes);
+        const progressWarnings = await syncProgressFromDesignArtifact({
+          designPath: targetPath,
+          title: typeof args.title === 'string' ? args.title : undefined
+        });
 
         return {
           success: true,
@@ -88,7 +93,8 @@ export function createUpdateDesignTool(): Tool {
           data: {
             path: targetPath,
             content,
-            changeSummary: changeSummary || undefined
+            changeSummary: changeSummary || undefined,
+            ...(progressWarnings.length > 0 ? { warnings: progressWarnings } : {})
           }
         };
       } catch (e: any) {

--- a/backend/tools/index.ts
+++ b/backend/tools/index.ts
@@ -35,6 +35,7 @@ export * from './subagents';
 export * from './todo';
 export * from './design';
 export * from './plan';
+export * from './progress';
 export * from './review';
 export * from './history';
 
@@ -71,6 +72,7 @@ export function getAllTools(): Tool[] {
     const { getTodoToolRegistrations } = require('./todo');
     const { getDesignToolRegistrations } = require('./design');
     const { getPlanToolRegistrations } = require('./plan');
+    const { getProgressToolRegistrations } = require('./progress');
     const { getReviewToolRegistrations } = require('./review');
     const { getHistoryToolRegistrations } = require('./history');
     
@@ -83,6 +85,7 @@ export function getAllTools(): Tool[] {
         ...getTodoToolRegistrations(),
         ...getDesignToolRegistrations(),
         ...getPlanToolRegistrations(),
+        ...getProgressToolRegistrations(),
         ...getReviewToolRegistrations(),
         ...getHistoryToolRegistrations()
     ];

--- a/backend/tools/plan/create_plan.ts
+++ b/backend/tools/plan/create_plan.ts
@@ -11,6 +11,7 @@ import { normalizeLineEndingsToLF, resolveUriWithInfo } from '../utils';
 import { buildPlanDocument } from './documentLayout';
 import { ensureParentDir, isPlanModePathAllowedWithMultiRoot } from './pathUtils';
 import { buildTrackedPlanSourceArtifact, renderPlanSourceArtifactSection, type PlanSourceArtifactInput } from './sourceArtifactSection';
+import { syncProgressFromPlanArtifact } from '../progress/autoSync';
 
 export interface CreatePlanArgs {
   title?: string;
@@ -112,6 +113,12 @@ export function createCreatePlanTool(): Tool {
         const { content, todos } = buildPlanDocument(normalizedPlan, args.todos, sourceSection);
         const bytes = new TextEncoder().encode(content);
         await vscode.workspace.fs.writeFile(uri, bytes);
+        const progressWarnings = await syncProgressFromPlanArtifact({
+          planPath: outPath,
+          title: title || undefined,
+          todos,
+          updateMode: 'revision'
+        });
 
         return {
           success: true,
@@ -120,7 +127,8 @@ export function createCreatePlanTool(): Tool {
             path: outPath,
             content,
             todos,
-            sourceArtifact: trackedSourceArtifact
+            sourceArtifact: trackedSourceArtifact,
+            ...(progressWarnings.length > 0 ? { warnings: progressWarnings } : {})
           }
         };
       } catch (e: any) {

--- a/backend/tools/plan/update_plan.ts
+++ b/backend/tools/plan/update_plan.ts
@@ -15,6 +15,7 @@ import {
   renderPlanSourceArtifactSection,
   type PlanSourceArtifactInput
 } from './sourceArtifactSection';
+import { syncProgressFromPlanArtifact } from '../progress/autoSync';
 
 export type PlanUpdateMode = 'revision' | 'progress_sync';
 
@@ -144,6 +145,13 @@ export function createUpdatePlanTool(): Tool {
         const { content, todos } = buildPlanDocument(bodyContent, args.todos, sourceSection);
         const bytes = new TextEncoder().encode(content);
         await vscode.workspace.fs.writeFile(uri, bytes);
+        const progressWarnings = await syncProgressFromPlanArtifact({
+          planPath: targetPath,
+          title: typeof args.title === 'string' ? args.title : undefined,
+          todos,
+          updateMode,
+        });
+        const mergedWarnings = [...warnings, ...progressWarnings];
 
         return {
           success: true,
@@ -154,7 +162,7 @@ export function createUpdatePlanTool(): Tool {
             todos,
             updateMode,
             changeSummary: changeSummary || undefined,
-            warnings: warnings.length > 0 ? warnings : undefined
+            warnings: mergedWarnings.length > 0 ? mergedWarnings : undefined
           }
         };
       } catch (e: any) {

--- a/backend/tools/progress/autoSync.ts
+++ b/backend/tools/progress/autoSync.ts
@@ -1,0 +1,301 @@
+/**
+ * Progress 自动联动辅助函数
+ *
+ * 用于在 design / plan 文档成功写入后，自动同步 `.limcode/progress.md`。
+ * 该同步是 best-effort：失败时只返回 warning，不阻断主工具成功。
+ */
+
+import * as vscode from 'vscode';
+import { getAllWorkspaces, resolveUriWithInfo } from '../utils';
+import { buildProgressDocument, validateProgressDocument } from './documentLayout';
+import { ensureParentDir, isProgressModePathAllowedWithMultiRoot } from './pathUtils';
+import type { ProgressDocumentMetadataV1, ProgressTodoItem } from './schema';
+
+interface SyncProgressFromDesignArtifactArgs {
+  designPath: string;
+  title?: string;
+}
+
+interface SyncProgressFromPlanArtifactArgs {
+  planPath: string;
+  title?: string;
+  todos?: ProgressTodoItem[];
+  updateMode?: 'revision' | 'progress_sync';
+}
+
+interface SyncProgressFromReviewArtifactArgs {
+  reviewPath: string;
+  title?: string;
+  latestConclusion?: string;
+  nextAction?: string;
+  eventMessage?: string;
+}
+
+function normalizeSingleLineText(value: unknown): string {
+  return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
+}
+
+function slugify(input: string): string {
+  const source = (input || '').trim().toLowerCase();
+  const slug = source
+    .replace(/[\s_]+/g, '-')
+    .replace(/[^a-z0-9\u4e00-\u9fa5-]+/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return slug || 'project';
+}
+
+function getWorkspaceDisplayName(): string | undefined {
+  const workspace = getAllWorkspaces()[0];
+  return typeof workspace?.name === 'string' && workspace.name.trim()
+    ? workspace.name.trim()
+    : undefined;
+}
+
+function resolveProgressPathForArtifact(artifactPath: string): string {
+  const normalized = (artifactPath || '').replace(/\\/g, '/');
+  const slashIndex = normalized.indexOf('/');
+  if (slashIndex > 0) {
+    const workspacePrefix = normalized.slice(0, slashIndex);
+    const rest = normalized.slice(slashIndex + 1);
+    if (
+      workspacePrefix !== '.' &&
+      workspacePrefix !== '..' &&
+      !workspacePrefix.includes(':') &&
+      rest.startsWith('.limcode/')
+    ) {
+      return `${workspacePrefix}/.limcode/progress.md`;
+    }
+  }
+  return '.limcode/progress.md';
+}
+
+async function loadExistingProgress(progressPath: string): Promise<{
+  metadata?: ProgressDocumentMetadataV1;
+  missing: boolean;
+  error?: string;
+}> {
+  const { uri, error } = resolveUriWithInfo(progressPath);
+  if (!uri) {
+    return { missing: false, error: error || 'No workspace folder open' };
+  }
+
+  try {
+    const bytes = await vscode.workspace.fs.readFile(uri);
+    const content = Buffer.from(bytes).toString('utf-8');
+    const validation = validateProgressDocument(content);
+    if (!validation.success) {
+      return { missing: false, error: 'error' in validation ? validation.error : 'Failed to validate progress document' };
+    }
+    return { metadata: validation.metadata, missing: false };
+  } catch (e: any) {
+    const message = String(e?.message || '');
+    if (/enoent|not exist|file not found/i.test(message)) {
+      return { missing: true };
+    }
+    return { missing: false, error: message || `Failed to read progress document: ${progressPath}` };
+  }
+}
+
+async function writeProgress(progressPath: string, metadata: Partial<ProgressDocumentMetadataV1>, now: string): Promise<void> {
+  if (!isProgressModePathAllowedWithMultiRoot(progressPath)) {
+    throw new Error(`Invalid progress path. Only ".limcode/progress.md" is allowed. Rejected path: ${progressPath}`);
+  }
+
+  const { uri, error } = resolveUriWithInfo(progressPath);
+  if (!uri) {
+    throw new Error(error || 'No workspace folder open');
+  }
+
+  await ensureParentDir(uri.fsPath);
+  const { content } = buildProgressDocument(metadata, { generatedAt: now });
+  await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(content));
+}
+
+function buildInitialProgressMetadata(now: string, progressPath: string): Partial<ProgressDocumentMetadataV1> {
+  const projectName = getWorkspaceDisplayName();
+  return {
+    projectId: slugify(projectName || progressPath),
+    projectName,
+    createdAt: now,
+    updatedAt: now,
+    status: 'active',
+    phase: 'design',
+    activeArtifacts: {},
+    todos: [],
+    milestones: [],
+    risks: [],
+    log: [{
+      at: now,
+      type: 'created',
+      message: '初始化项目进度'
+    }]
+  };
+}
+
+export async function syncProgressFromDesignArtifact(
+  args: SyncProgressFromDesignArtifactArgs
+): Promise<string[]> {
+  const designPath = normalizeSingleLineText(args.designPath);
+  if (!designPath) return [];
+
+  const progressPath = resolveProgressPathForArtifact(designPath);
+  const now = new Date().toISOString();
+
+  try {
+    const loaded = await loadExistingProgress(progressPath);
+    if (loaded.error) {
+      return [`Failed to auto-sync progress after design write: ${loaded.error}`];
+    }
+
+    const base = loaded.missing || !loaded.metadata
+      ? buildInitialProgressMetadata(now, progressPath)
+      : loaded.metadata;
+
+    const nextMetadata: Partial<ProgressDocumentMetadataV1> = {
+      ...base,
+      updatedAt: now,
+      phase: loaded.missing ? 'design' : base.phase,
+      currentFocus: loaded.missing && normalizeSingleLineText(args.title)
+        ? normalizeSingleLineText(args.title)
+        : base.currentFocus,
+      activeArtifacts: {
+        ...(base.activeArtifacts || {}),
+        design: designPath,
+      },
+      log: [
+        ...(base.log || []),
+        {
+          at: now,
+          type: 'artifact_changed',
+          refId: 'design',
+          message: `同步设计文档：${designPath}`,
+        }
+      ]
+    };
+
+    await writeProgress(progressPath, nextMetadata, now);
+    return [];
+  } catch (e: any) {
+    return [`Failed to auto-sync progress after design write: ${e?.message || String(e)}`];
+  }
+}
+
+export async function syncProgressFromPlanArtifact(
+  args: SyncProgressFromPlanArtifactArgs
+): Promise<string[]> {
+  const planPath = normalizeSingleLineText(args.planPath);
+  if (!planPath) return [];
+
+  const progressPath = resolveProgressPathForArtifact(planPath);
+  const now = new Date().toISOString();
+  const updateMode = args.updateMode === 'progress_sync' ? 'progress_sync' : 'revision';
+
+  try {
+    const loaded = await loadExistingProgress(progressPath);
+    if (loaded.error) {
+      return [`Failed to auto-sync progress after plan write: ${loaded.error}`];
+    }
+
+    const base = loaded.missing || !loaded.metadata
+      ? {
+        ...buildInitialProgressMetadata(now, progressPath),
+        phase: updateMode === 'progress_sync' ? 'implementation' : 'plan',
+      }
+      : loaded.metadata;
+
+    const currentPhase = base.phase as ProgressDocumentMetadataV1['phase'] | undefined;
+    const nextPhase: ProgressDocumentMetadataV1['phase'] | undefined = loaded.missing
+      ? (updateMode === 'progress_sync' ? 'implementation' : 'plan')
+      : updateMode === 'progress_sync'
+        ? currentPhase
+        : (currentPhase === 'design' || currentPhase === 'plan' ? 'plan' : currentPhase);
+
+    const nextMetadata: Partial<ProgressDocumentMetadataV1> = {
+      ...base,
+      updatedAt: now,
+      phase: nextPhase,
+      currentFocus: !base.currentFocus && normalizeSingleLineText(args.title)
+        ? normalizeSingleLineText(args.title)
+        : base.currentFocus,
+      activeArtifacts: {
+        ...(base.activeArtifacts || {}),
+        plan: planPath,
+      },
+      todos: Array.isArray(args.todos) ? args.todos : base.todos,
+      log: [
+        ...(base.log || []),
+        {
+          at: now,
+          type: 'artifact_changed',
+          refId: 'plan',
+          message: updateMode === 'progress_sync'
+            ? `同步计划 TODO 快照：${planPath}`
+            : `同步计划文档：${planPath}`,
+        }
+      ]
+    };
+
+    await writeProgress(progressPath, nextMetadata, now);
+    return [];
+  } catch (e: any) {
+    return [`Failed to auto-sync progress after plan write: ${e?.message || String(e)}`];
+  }
+}
+
+export async function syncProgressFromReviewArtifact(
+  args: SyncProgressFromReviewArtifactArgs
+): Promise<string[]> {
+  const reviewPath = normalizeSingleLineText(args.reviewPath);
+  if (!reviewPath) return [];
+
+  const progressPath = resolveProgressPathForArtifact(reviewPath);
+  const now = new Date().toISOString();
+
+  try {
+    const loaded = await loadExistingProgress(progressPath);
+    if (loaded.error) {
+      return [`Failed to auto-sync progress after review write: ${loaded.error}`];
+    }
+
+    const base = loaded.missing || !loaded.metadata
+      ? {
+        ...buildInitialProgressMetadata(now, progressPath),
+        phase: 'review' as const,
+      }
+      : loaded.metadata;
+
+    const nextMetadata: Partial<ProgressDocumentMetadataV1> = {
+      ...base,
+      updatedAt: now,
+      phase: loaded.missing ? 'review' : base.phase,
+      currentFocus: !base.currentFocus && normalizeSingleLineText(args.title)
+        ? normalizeSingleLineText(args.title)
+        : base.currentFocus,
+      latestConclusion: normalizeSingleLineText(args.latestConclusion)
+        ? args.latestConclusion
+        : base.latestConclusion,
+      nextAction: normalizeSingleLineText(args.nextAction)
+        ? args.nextAction
+        : base.nextAction,
+      activeArtifacts: {
+        ...(base.activeArtifacts || {}),
+        review: reviewPath,
+      },
+      log: [
+        ...(base.log || []),
+        {
+          at: now,
+          type: 'artifact_changed',
+          refId: 'review',
+          message: args.eventMessage || `同步审查文档：${reviewPath}`,
+        }
+      ]
+    };
+
+    await writeProgress(progressPath, nextMetadata, now);
+    return [];
+  } catch (e: any) {
+    return [`Failed to auto-sync progress after review write: ${e?.message || String(e)}`];
+  }
+}

--- a/backend/tools/progress/create_progress.ts
+++ b/backend/tools/progress/create_progress.ts
@@ -1,0 +1,227 @@
+/**
+ * create_progress 工具
+ */
+
+import * as vscode from 'vscode';
+import type { Tool, ToolDeclaration, ToolResult } from '../types';
+import { getAllWorkspaces, resolveUriWithInfo } from '../utils';
+import {
+  buildProgressDocument,
+  isProgressPhase,
+  isProgressStatus,
+  validateProgressRisksInput,
+  validateProgressTodosInput,
+  validateProgressDocument,
+} from './documentLayout';
+import { ensureParentDir, isProgressModePathAllowedWithMultiRoot, normalizeProgressArtifactRef, validateProgressArtifactRefInput } from './pathUtils';
+import { projectProgressToolResultData } from './resultProjection';
+import type { ProgressArtifactRef, ProgressPhase, ProgressRiskItem, ProgressStatus, ProgressTodoItem } from './schema';
+
+export interface CreateProgressArgs {
+  path?: string;
+  projectName?: string;
+  projectId?: string;
+  status?: ProgressStatus;
+  phase?: ProgressPhase;
+  currentFocus?: string;
+  latestConclusion?: string;
+  currentBlocker?: string;
+  nextAction?: string;
+  activeArtifacts?: ProgressArtifactRef;
+  todos?: ProgressTodoItem[];
+  risks?: ProgressRiskItem[];
+}
+
+function slugify(input: string): string {
+  const source = (input || '').trim().toLowerCase();
+  const slug = source
+    .replace(/[\s_]+/g, '-')
+    .replace(/[^a-z0-9\u4e00-\u9fa5-]+/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return slug || 'project';
+}
+
+function getDefaultProjectName(): string | undefined {
+  const workspace = getAllWorkspaces()[0];
+  return typeof workspace?.name === 'string' && workspace.name.trim()
+    ? workspace.name.trim()
+    : undefined;
+}
+
+export function createCreateProgressToolDeclaration(): ToolDeclaration {
+  return {
+    name: 'create_progress',
+    strict: true,
+    description:
+      'Create the project progress document at .limcode/progress.md. This initializes the project-level status ledger and returns a lightweight progress snapshot instead of the full markdown body.',
+    category: 'progress',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Optional output path. Must be .limcode/progress.md (or multi-root: workspace/.limcode/progress.md).'
+        },
+        projectName: { type: 'string', description: 'Optional human-readable project name.' },
+        projectId: { type: 'string', description: 'Optional stable project id. Defaults to a slug from the project name.' },
+        status: { type: 'string', enum: ['active', 'blocked', 'completed', 'archived'] },
+        phase: { type: 'string', enum: ['design', 'plan', 'implementation', 'review', 'maintenance'] },
+        currentFocus: { type: 'string' },
+        latestConclusion: { type: 'string' },
+        currentBlocker: { type: 'string' },
+        nextAction: { type: 'string' },
+        activeArtifacts: {
+          type: 'object',
+          properties: {
+            design: { type: 'string' },
+            plan: { type: 'string' },
+            review: { type: 'string' }
+          }
+        },
+        todos: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              content: { type: 'string' },
+              status: { type: 'string', enum: ['pending', 'in_progress', 'completed', 'cancelled'] }
+            },
+            required: ['id', 'content', 'status']
+          }
+        },
+        risks: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              title: { type: 'string' },
+              status: { type: 'string', enum: ['active', 'resolved', 'accepted'] },
+              description: { type: 'string' }
+            },
+            required: ['id', 'title', 'status', 'description']
+          }
+        }
+      }
+    }
+  };
+}
+
+export function createCreateProgressTool(): Tool {
+  return {
+    declaration: createCreateProgressToolDeclaration(),
+    handler: async (rawArgs: Record<string, unknown>): Promise<ToolResult> => {
+      const args = rawArgs as unknown as CreateProgressArgs;
+      const outPath = typeof args.path === 'string' && args.path.trim()
+        ? args.path.trim()
+        : '.limcode/progress.md';
+
+      if (!isProgressModePathAllowedWithMultiRoot(outPath)) {
+        return { success: false, error: `Invalid progress path. Only ".limcode/progress.md" is allowed. Rejected path: ${outPath}` };
+      }
+
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'status') && !isProgressStatus(args.status)) {
+        return { success: false, error: 'status must be one of: active, blocked, completed, archived' };
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'phase') && !isProgressPhase(args.phase)) {
+        return { success: false, error: 'phase must be one of: design, plan, implementation, review, maintenance' };
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'todos')) {
+        const todosError = validateProgressTodosInput(args.todos);
+        if (todosError) return { success: false, error: todosError };
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'risks')) {
+        const risksError = validateProgressRisksInput(args.risks);
+        if (risksError) return { success: false, error: risksError };
+      }
+      const artifactsError = validateProgressArtifactRefInput(args.activeArtifacts, {
+        fieldName: 'activeArtifacts',
+        allowEmptyString: true,
+      });
+      if (artifactsError) {
+        return { success: false, error: artifactsError };
+      }
+
+      const { uri, error } = resolveUriWithInfo(outPath);
+      if (!uri) {
+        return { success: false, error: error || 'No workspace folder open' };
+      }
+
+      try {
+        const existingBytes = await vscode.workspace.fs.readFile(uri);
+        const existingContent = Buffer.from(existingBytes).toString('utf-8');
+        const validation = validateProgressDocument(existingContent);
+        if (!validation.success) {
+          return {
+            success: false,
+            error: `Progress document already exists but is invalid: ${'error' in validation ? validation.error : outPath}`
+          };
+        }
+
+        return {
+          success: true,
+          data: projectProgressToolResultData({
+            path: outPath,
+            metadata: validation.metadata,
+            delta: { type: 'updated', changedFields: [] },
+            warnings: [`Progress document already exists at ${outPath}. Returned the existing snapshot instead of creating a second file.`]
+          })
+        };
+      } catch (readError: any) {
+        // file does not exist, continue
+      }
+
+      const now = new Date().toISOString();
+      const projectName = typeof args.projectName === 'string' && args.projectName.trim()
+        ? args.projectName.trim()
+        : getDefaultProjectName();
+      const projectId = typeof args.projectId === 'string' && args.projectId.trim()
+        ? args.projectId.trim()
+        : slugify(projectName || getDefaultProjectName() || 'project');
+
+      try {
+        await ensureParentDir(uri.fsPath);
+
+        const { metadata, content } = buildProgressDocument({
+          projectId,
+          projectName,
+          createdAt: now,
+          updatedAt: now,
+          status: isProgressStatus(args.status) ? args.status : 'active',
+          phase: isProgressPhase(args.phase) ? args.phase : 'implementation',
+          currentFocus: args.currentFocus,
+          latestConclusion: args.latestConclusion,
+          currentBlocker: args.currentBlocker,
+          nextAction: args.nextAction,
+          activeArtifacts: normalizeProgressArtifactRef(args.activeArtifacts),
+          todos: args.todos,
+          milestones: [],
+          risks: args.risks,
+          log: [{ at: now, type: 'created', message: '初始化项目进度' }],
+        }, { generatedAt: now });
+
+        await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(content));
+
+        return {
+          success: true,
+          data: projectProgressToolResultData({
+            path: outPath,
+            metadata,
+            delta: {
+              type: 'created',
+              changedFields: ['header', 'summary', 'artifacts', 'todos', 'risks', 'log']
+            }
+          })
+        };
+      } catch (e: any) {
+        return { success: false, error: e?.message || String(e) };
+      }
+    }
+  };
+}
+
+export function registerCreateProgress(): Tool {
+  return createCreateProgressTool();
+}

--- a/backend/tools/progress/documentLayout.ts
+++ b/backend/tools/progress/documentLayout.ts
@@ -1,0 +1,793 @@
+/**
+ * Progress 文档布局与校验辅助函数
+ */
+
+import { createHash } from 'crypto';
+import { normalizeLineEndingsToLF } from '../utils';
+import {
+  MAX_PROGRESS_LOG_ENTRIES,
+  PROGRESS_ARTIFACTS_END,
+  PROGRESS_ARTIFACTS_SECTION_TITLE,
+  PROGRESS_ARTIFACTS_START,
+  PROGRESS_DOCUMENT_TITLE,
+  PROGRESS_LOG_END,
+  PROGRESS_LOG_SECTION_TITLE,
+  PROGRESS_LOG_START,
+  PROGRESS_METADATA_END,
+  PROGRESS_METADATA_START,
+  PROGRESS_MILESTONES_END,
+  PROGRESS_MILESTONES_SECTION_TITLE,
+  PROGRESS_MILESTONES_START,
+  PROGRESS_RENDERER_VERSION,
+  PROGRESS_RISKS_END,
+  PROGRESS_RISKS_SECTION_TITLE,
+  PROGRESS_RISKS_START,
+  PROGRESS_SUMMARY_END,
+  PROGRESS_SUMMARY_SECTION_TITLE,
+  PROGRESS_SUMMARY_START,
+  PROGRESS_TODOS_END,
+  PROGRESS_TODOS_SECTION_TITLE,
+  PROGRESS_TODOS_START,
+  type ProgressArtifactRef,
+  type ProgressDocumentMetadataV1,
+  type ProgressLogItem,
+  type ProgressLogType,
+  type ProgressMilestoneRecord,
+  type ProgressMilestoneStatus,
+  type ProgressPhase,
+  type ProgressRiskItem,
+  type ProgressRiskStatus,
+  type ProgressStats,
+  type ProgressStatus,
+  type ProgressTodoItem,
+  type ProgressTodoStatus,
+  type ProgressValidationIssue,
+  type ProgressValidationSummaryV1,
+} from './schema';
+
+function normalizeSingleLineText(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function normalizeMarkdownBlock(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = normalizeLineEndingsToLF(value).trim();
+  return normalized || null;
+}
+
+function normalizeTimestamp(value: unknown, fallback: string): string {
+  const normalized = normalizeSingleLineText(value);
+  return normalized || fallback;
+}
+
+function getDuplicateIds(value: unknown, fieldName: string): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+    const rawId = (item as Record<string, unknown>).id;
+    const id = normalizeSingleLineText(rawId);
+    if (!id) continue;
+    if (seen.has(id)) {
+      duplicates.add(id);
+      continue;
+    }
+    seen.add(id);
+  }
+
+  return Array.from(duplicates).map((id) => `${fieldName}:${id}`);
+}
+
+function computeHash(content: string): string {
+  const normalized = normalizeLineEndingsToLF(content || '').trim();
+  return `sha256:${createHash('sha256').update(normalized, 'utf8').digest('hex')}`;
+}
+
+function buildInlinePreview(value: string | null | undefined, maxChars = 180): string {
+  const normalized = normalizeLineEndingsToLF(value || '').replace(/\s+/g, ' ').trim();
+  if (!normalized) return '';
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, maxChars).trimEnd()}…`;
+}
+
+export function isProgressStatus(value: unknown): value is ProgressStatus {
+  return value === 'active' || value === 'blocked' || value === 'completed' || value === 'archived';
+}
+
+export function isProgressPhase(value: unknown): value is ProgressPhase {
+  return value === 'design' ||
+    value === 'plan' ||
+    value === 'implementation' ||
+    value === 'review' ||
+    value === 'maintenance';
+}
+
+export function isProgressTodoStatus(value: unknown): value is ProgressTodoStatus {
+  return value === 'pending' || value === 'in_progress' || value === 'completed' || value === 'cancelled';
+}
+
+export function isProgressMilestoneStatus(value: unknown): value is ProgressMilestoneStatus {
+  return value === 'in_progress' || value === 'completed';
+}
+
+export function isProgressRiskStatus(value: unknown): value is ProgressRiskStatus {
+  return value === 'active' || value === 'resolved' || value === 'accepted';
+}
+
+export function isProgressLogType(value: unknown): value is ProgressLogType {
+  return value === 'created' ||
+    value === 'updated' ||
+    value === 'milestone_recorded' ||
+    value === 'artifact_changed' ||
+    value === 'risk_changed';
+}
+
+export function normalizeOptionalProgressText(value: unknown): string | null {
+  return normalizeMarkdownBlock(value);
+}
+
+export function normalizeOptionalProgressSingleLineText(value: unknown): string | null {
+  const normalized = normalizeSingleLineText(value);
+  return normalized || null;
+}
+
+export function validateProgressTodosInput(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return 'todos must be an array';
+  }
+
+  for (const item of value) {
+    if (!item || typeof item !== 'object') {
+      return 'each todo must be an object';
+    }
+    const id = normalizeSingleLineText((item as Record<string, unknown>).id);
+    const content = normalizeSingleLineText((item as Record<string, unknown>).content);
+    const status = (item as Record<string, unknown>).status;
+    if (!id) return 'todo.id must be a non-empty string';
+    if (!content) return 'todo.content must be a non-empty string';
+    if (!isProgressTodoStatus(status)) {
+      return 'todo.status must be one of: pending, in_progress, completed, cancelled';
+    }
+  }
+
+  const duplicates = getDuplicateIds(value, 'todo');
+  if (duplicates.length > 0) {
+    return `duplicate todo ids are not allowed: ${duplicates.join(', ')}`;
+  }
+
+  return null;
+}
+
+export function validateProgressRisksInput(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return 'risks must be an array';
+  }
+
+  for (const item of value) {
+    if (!item || typeof item !== 'object') {
+      return 'each risk must be an object';
+    }
+    const id = normalizeSingleLineText((item as Record<string, unknown>).id);
+    const title = normalizeSingleLineText((item as Record<string, unknown>).title);
+    const description = normalizeSingleLineText((item as Record<string, unknown>).description);
+    const status = (item as Record<string, unknown>).status;
+    if (!id) return 'risk.id must be a non-empty string';
+    if (!title) return 'risk.title must be a non-empty string';
+    if (!description) return 'risk.description must be a non-empty string';
+    if (!isProgressRiskStatus(status)) {
+      return 'risk.status must be one of: active, resolved, accepted';
+    }
+  }
+
+  const duplicates = getDuplicateIds(value, 'risk');
+  if (duplicates.length > 0) {
+    return `duplicate risk ids are not allowed: ${duplicates.join(', ')}`;
+  }
+
+  return null;
+}
+
+export function validateProgressLogAppendInput(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return 'appendLog must be an array';
+  }
+
+  for (const item of value) {
+    if (!item || typeof item !== 'object') {
+      return 'each appendLog entry must be an object';
+    }
+
+    const type = (item as Record<string, unknown>).type;
+    const message = normalizeSingleLineText((item as Record<string, unknown>).message);
+    const refId = (item as Record<string, unknown>).refId;
+
+    if (!isProgressLogType(type)) {
+      return 'appendLog.type must be one of: created, updated, milestone_recorded, artifact_changed, risk_changed';
+    }
+    if (!message) {
+      return 'appendLog.message must be a non-empty string';
+    }
+    if (refId !== undefined && typeof refId !== 'string') {
+      return 'appendLog.refId must be a string when provided';
+    }
+  }
+
+  return null;
+}
+
+export function normalizeProgressTodos(value: unknown): ProgressTodoItem[] {
+  if (!Array.isArray(value)) return [];
+
+  const byId = new Map<string, ProgressTodoItem>();
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+
+    const id = normalizeSingleLineText((item as Record<string, unknown>).id);
+    const content = normalizeSingleLineText((item as Record<string, unknown>).content);
+    const status = (item as Record<string, unknown>).status;
+    if (!id || !content || !isProgressTodoStatus(status)) continue;
+
+    byId.set(id, { id, content, status });
+  }
+
+  return Array.from(byId.values());
+}
+
+export function normalizeProgressRisks(value: unknown): ProgressRiskItem[] {
+  if (!Array.isArray(value)) return [];
+
+  const byId = new Map<string, ProgressRiskItem>();
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+
+    const id = normalizeSingleLineText((item as Record<string, unknown>).id);
+    const title = normalizeSingleLineText((item as Record<string, unknown>).title);
+    const description = normalizeSingleLineText((item as Record<string, unknown>).description);
+    const status = (item as Record<string, unknown>).status;
+    if (!id || !title || !description || !isProgressRiskStatus(status)) continue;
+
+    byId.set(id, { id, title, description, status });
+  }
+
+  return Array.from(byId.values());
+}
+
+export function normalizeProgressLogEntries(value: unknown): ProgressLogItem[] {
+  if (!Array.isArray(value)) return [];
+
+  const entries: ProgressLogItem[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+
+    const at = normalizeSingleLineText((item as Record<string, unknown>).at);
+    const type = (item as Record<string, unknown>).type;
+    const refId = normalizeSingleLineText((item as Record<string, unknown>).refId) || undefined;
+    const message = normalizeSingleLineText((item as Record<string, unknown>).message);
+    if (!at || !message || !isProgressLogType(type)) continue;
+
+    entries.push({ at, type, refId, message });
+  }
+
+  return entries.slice(-MAX_PROGRESS_LOG_ENTRIES);
+}
+
+function normalizeProgressArtifactRef(value: unknown): ProgressArtifactRef {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const next: ProgressArtifactRef = {};
+  const design = normalizeSingleLineText((value as Record<string, unknown>).design);
+  const plan = normalizeSingleLineText((value as Record<string, unknown>).plan);
+  const review = normalizeSingleLineText((value as Record<string, unknown>).review);
+  if (design) next.design = design;
+  if (plan) next.plan = plan;
+  if (review) next.review = review;
+  return next;
+}
+
+function normalizeProgressMilestones(value: unknown): ProgressMilestoneRecord[] {
+  if (!Array.isArray(value)) return [];
+
+  const byId = new Map<string, ProgressMilestoneRecord>();
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+
+    const id = normalizeSingleLineText((item as Record<string, unknown>).id);
+    const title = normalizeSingleLineText((item as Record<string, unknown>).title);
+    const summary = normalizeMarkdownBlock((item as Record<string, unknown>).summary);
+    const status = (item as Record<string, unknown>).status;
+    const recordedAt = normalizeSingleLineText((item as Record<string, unknown>).recordedAt);
+    if (!id || !title || !summary || !recordedAt || !isProgressMilestoneStatus(status)) continue;
+
+    const rawRelatedTodoIds = (item as Record<string, unknown>).relatedTodoIds;
+    const relatedTodoIds = Array.isArray(rawRelatedTodoIds)
+      ? rawRelatedTodoIds
+        .map((entry: unknown) => normalizeSingleLineText(entry))
+        .filter(Boolean)
+      : [];
+
+    const rawRelatedReviewMilestoneIds = (item as Record<string, unknown>).relatedReviewMilestoneIds;
+    const relatedReviewMilestoneIds = Array.isArray(rawRelatedReviewMilestoneIds)
+      ? rawRelatedReviewMilestoneIds
+        .map((entry: unknown) => normalizeSingleLineText(entry))
+        .filter(Boolean)
+      : [];
+
+    byId.set(id, {
+      id,
+      title,
+      status,
+      summary,
+      relatedTodoIds,
+      relatedReviewMilestoneIds,
+      relatedArtifacts: normalizeProgressArtifactRef((item as Record<string, unknown>).relatedArtifacts),
+      startedAt: normalizeOptionalProgressSingleLineText((item as Record<string, unknown>).startedAt) || undefined,
+      completedAt: normalizeOptionalProgressSingleLineText((item as Record<string, unknown>).completedAt) || undefined,
+      recordedAt,
+      nextAction: normalizeOptionalProgressText((item as Record<string, unknown>).nextAction)
+    });
+  }
+
+  return Array.from(byId.values());
+}
+
+function computeProgressStats(
+  todos: ProgressTodoItem[],
+  milestones: ProgressMilestoneRecord[],
+  risks: ProgressRiskItem[]
+): ProgressStats {
+  let todosCompleted = 0;
+  let todosInProgress = 0;
+  let todosCancelled = 0;
+  for (const todo of todos) {
+    if (todo.status === 'completed') todosCompleted++;
+    if (todo.status === 'in_progress') todosInProgress++;
+    if (todo.status === 'cancelled') todosCancelled++;
+  }
+
+  return {
+    milestonesTotal: milestones.length,
+    milestonesCompleted: milestones.filter((item) => item.status === 'completed').length,
+    todosTotal: todos.length,
+    todosCompleted,
+    todosInProgress,
+    todosCancelled,
+    activeRisks: risks.filter((item) => item.status === 'active').length,
+  };
+}
+
+function normalizeProgressMetadataInput(
+  value: Partial<ProgressDocumentMetadataV1>,
+  now: string
+): ProgressDocumentMetadataV1 {
+  const todos = normalizeProgressTodos(value.todos);
+  const milestones = normalizeProgressMilestones(value.milestones);
+  const risks = normalizeProgressRisks(value.risks);
+  const log = normalizeProgressLogEntries(value.log);
+
+  return {
+    formatVersion: 1,
+    kind: 'limcode.progress',
+    projectId: normalizeSingleLineText(value.projectId) || 'project',
+    projectName: normalizeOptionalProgressSingleLineText(value.projectName) || undefined,
+    createdAt: normalizeTimestamp(value.createdAt, now),
+    updatedAt: normalizeTimestamp(value.updatedAt, now),
+    status: isProgressStatus(value.status) ? value.status : 'active',
+    phase: isProgressPhase(value.phase) ? value.phase : 'implementation',
+    currentFocus: normalizeOptionalProgressSingleLineText(value.currentFocus),
+    latestConclusion: normalizeOptionalProgressText(value.latestConclusion),
+    currentBlocker: normalizeOptionalProgressText(value.currentBlocker),
+    nextAction: normalizeOptionalProgressText(value.nextAction),
+    activeArtifacts: normalizeProgressArtifactRef(value.activeArtifacts),
+    todos,
+    milestones,
+    risks,
+    log,
+    stats: computeProgressStats(todos, milestones, risks),
+    render: {
+      rendererVersion: PROGRESS_RENDERER_VERSION,
+      generatedAt: normalizeTimestamp(value.render?.generatedAt, now),
+      bodyHash: normalizeSingleLineText(value.render?.bodyHash),
+    },
+  };
+}
+
+export function getLatestProgressMilestone(
+  metadata: ProgressDocumentMetadataV1
+): ProgressMilestoneRecord | null {
+  return metadata.milestones.length > 0
+    ? metadata.milestones[metadata.milestones.length - 1]
+    : null;
+}
+
+export function buildCurrentProgressText(metadata: ProgressDocumentMetadataV1): string {
+  if (metadata.stats.milestonesTotal <= 0) {
+    return '尚无里程碑记录';
+  }
+
+  const latestMilestone = getLatestProgressMilestone(metadata);
+  return `${metadata.stats.milestonesCompleted}/${metadata.stats.milestonesTotal} 个里程碑已完成${latestMilestone ? `；最新：${latestMilestone.id}` : ''}`;
+}
+
+function renderSummarySection(metadata: ProgressDocumentMetadataV1): string {
+  const lines: string[] = [
+    `- 当前进度：${buildCurrentProgressText(metadata)}`,
+  ];
+
+  if (metadata.currentFocus) {
+    lines.push(`- 当前焦点：${buildInlinePreview(metadata.currentFocus, 120)}`);
+  }
+  if (metadata.latestConclusion) {
+    lines.push(`- 最新结论：${buildInlinePreview(metadata.latestConclusion, 180)}`);
+  }
+  if (metadata.currentBlocker) {
+    lines.push(`- 当前阻塞：${buildInlinePreview(metadata.currentBlocker, 180)}`);
+  }
+  if (metadata.nextAction) {
+    lines.push(`- 下一步：${buildInlinePreview(metadata.nextAction, 180)}`);
+  }
+
+  return [
+    PROGRESS_SUMMARY_SECTION_TITLE,
+    '',
+    PROGRESS_SUMMARY_START,
+    lines.join('\n'),
+    PROGRESS_SUMMARY_END,
+  ].join('\n');
+}
+
+function renderArtifactsSection(metadata: ProgressDocumentMetadataV1): string {
+  const lines: string[] = [];
+  if (metadata.activeArtifacts.design) lines.push(`- 设计：\`${metadata.activeArtifacts.design}\``);
+  if (metadata.activeArtifacts.plan) lines.push(`- 计划：\`${metadata.activeArtifacts.plan}\``);
+  if (metadata.activeArtifacts.review) lines.push(`- 审查：\`${metadata.activeArtifacts.review}\``);
+
+  return [
+    PROGRESS_ARTIFACTS_SECTION_TITLE,
+    '',
+    PROGRESS_ARTIFACTS_START,
+    lines.length > 0 ? lines.join('\n') : '<!-- 暂无关联文档 -->',
+    PROGRESS_ARTIFACTS_END,
+  ].join('\n');
+}
+
+function renderTodoLine(todo: ProgressTodoItem): string {
+  const checkbox = todo.status === 'completed' ? 'x' : ' ';
+  const suffix = todo.status === 'in_progress'
+    ? ' (in_progress)'
+    : todo.status === 'cancelled'
+      ? ' (cancelled)'
+      : '';
+  return `- [${checkbox}] ${todo.content}  \`#${todo.id}\`${suffix}`;
+}
+
+function renderTodosSection(metadata: ProgressDocumentMetadataV1): string {
+  const lines = metadata.todos.map((todo) => renderTodoLine(todo));
+  return [
+    PROGRESS_TODOS_SECTION_TITLE,
+    '',
+    PROGRESS_TODOS_START,
+    lines.length > 0 ? lines.join('\n') : '<!-- 暂无 TODO -->',
+    PROGRESS_TODOS_END,
+  ].join('\n');
+}
+
+function renderMilestone(metadata: ProgressMilestoneRecord): string {
+  const lines: string[] = [
+    `### ${metadata.id} · ${metadata.title}`,
+    `- 状态：${metadata.status}`,
+    `- 记录时间：${metadata.recordedAt}`,
+  ];
+
+  if (metadata.startedAt) {
+    lines.push(`- 开始时间：${metadata.startedAt}`);
+  }
+  if (metadata.completedAt) {
+    lines.push(`- 完成时间：${metadata.completedAt}`);
+  }
+  if (metadata.relatedTodoIds.length > 0) {
+    lines.push(`- 关联 TODO：${metadata.relatedTodoIds.join(', ')}`);
+  }
+  if (metadata.relatedReviewMilestoneIds.length > 0) {
+    lines.push(`- 关联审查里程碑：${metadata.relatedReviewMilestoneIds.join(', ')}`);
+  }
+  if (metadata.relatedArtifacts && Object.keys(metadata.relatedArtifacts).length > 0) {
+    lines.push('- 关联文档：');
+    if (metadata.relatedArtifacts.design) {
+      lines.push(`  - 设计：\`${metadata.relatedArtifacts.design}\``);
+    }
+    if (metadata.relatedArtifacts.plan) {
+      lines.push(`  - 计划：\`${metadata.relatedArtifacts.plan}\``);
+    }
+    if (metadata.relatedArtifacts.review) {
+      lines.push(`  - 审查：\`${metadata.relatedArtifacts.review}\``);
+    }
+  }
+
+  lines.push('- 摘要:');
+  lines.push(metadata.summary);
+
+  if (metadata.nextAction) {
+    lines.push(`- 下一步：${buildInlinePreview(metadata.nextAction, 180)}`);
+  }
+
+  return lines.join('\n');
+}
+
+function renderMilestonesSection(metadata: ProgressDocumentMetadataV1): string {
+  const body = metadata.milestones.length > 0
+    ? metadata.milestones.map((item) => renderMilestone(item)).join('\n\n')
+    : '<!-- 暂无里程碑 -->';
+
+  return [
+    PROGRESS_MILESTONES_SECTION_TITLE,
+    '',
+    PROGRESS_MILESTONES_START,
+    body,
+    PROGRESS_MILESTONES_END,
+  ].join('\n');
+}
+
+function renderRisksSection(metadata: ProgressDocumentMetadataV1): string {
+  const lines = metadata.risks.map((risk) => `- ${risk.id} | ${risk.status} | ${risk.title}：${risk.description}`);
+  return [
+    PROGRESS_RISKS_SECTION_TITLE,
+    '',
+    PROGRESS_RISKS_START,
+    lines.length > 0 ? lines.join('\n') : '<!-- 暂无风险 -->',
+    PROGRESS_RISKS_END,
+  ].join('\n');
+}
+
+function renderLogSection(metadata: ProgressDocumentMetadataV1): string {
+  const lines = metadata.log.map((item) => {
+    const refPart = item.refId ? ` | ${item.refId}` : '';
+    return `- ${item.at} | ${item.type}${refPart} | ${item.message}`;
+  });
+
+  return [
+    PROGRESS_LOG_SECTION_TITLE,
+    '',
+    PROGRESS_LOG_START,
+    lines.length > 0 ? lines.join('\n') : '<!-- 暂无更新 -->',
+    PROGRESS_LOG_END,
+  ].join('\n');
+}
+
+function renderMetadataSection(metadata: ProgressDocumentMetadataV1): string {
+  return [
+    PROGRESS_METADATA_START,
+    JSON.stringify(metadata, null, 2),
+    PROGRESS_METADATA_END,
+  ].join('\n');
+}
+
+function buildVisibleContent(metadata: ProgressDocumentMetadataV1): string {
+  const header = [
+    PROGRESS_DOCUMENT_TITLE,
+    `- Project: ${metadata.projectName || metadata.projectId}`,
+    `- Updated At: ${metadata.updatedAt}`,
+    `- Status: ${metadata.status}`,
+    `- Phase: ${metadata.phase}`,
+  ].join('\n');
+
+  return [
+    header,
+    renderSummarySection(metadata),
+    renderArtifactsSection(metadata),
+    renderTodosSection(metadata),
+    renderMilestonesSection(metadata),
+    renderRisksSection(metadata),
+    renderLogSection(metadata),
+  ].join('\n\n').trimEnd();
+}
+
+export function buildProgressDocument(
+  metadataInput: Partial<ProgressDocumentMetadataV1>,
+  options: { generatedAt?: string } = {}
+): { metadata: ProgressDocumentMetadataV1; content: string } {
+  const now = normalizeSingleLineText(options.generatedAt) || new Date().toISOString();
+  const baseMetadata = normalizeProgressMetadataInput(metadataInput, now);
+  const visibleContent = buildVisibleContent(baseMetadata);
+  const finalizedMetadata: ProgressDocumentMetadataV1 = {
+    ...baseMetadata,
+    render: {
+      rendererVersion: PROGRESS_RENDERER_VERSION,
+      generatedAt: now,
+      bodyHash: computeHash(visibleContent),
+    },
+  };
+
+  const content = `${buildVisibleContent(finalizedMetadata)}\n\n${renderMetadataSection(finalizedMetadata)}\n`;
+  return { metadata: finalizedMetadata, content };
+}
+
+function extractMetadataPayload(content: string): string | null {
+  const normalized = normalizeLineEndingsToLF(content || '');
+  const start = normalized.indexOf(PROGRESS_METADATA_START);
+  const end = start >= 0
+    ? normalized.indexOf(PROGRESS_METADATA_END, start + PROGRESS_METADATA_START.length)
+    : -1;
+
+  if (start < 0 || end < 0 || end < start) {
+    return null;
+  }
+
+  const payload = normalized
+    .slice(start + PROGRESS_METADATA_START.length, end)
+    .trim();
+  return payload || null;
+}
+
+export function extractProgressMetadata(content: string): ProgressDocumentMetadataV1 | null {
+  const payload = extractMetadataPayload(content);
+  if (!payload) return null;
+
+  try {
+    const parsed = JSON.parse(payload) as Partial<ProgressDocumentMetadataV1>;
+    if (!parsed || typeof parsed !== 'object') return null;
+    return normalizeProgressMetadataInput(parsed, new Date().toISOString());
+  } catch {
+    return null;
+  }
+}
+
+function ensureUniqueMarker(content: string, marker: string): { ok: true; index: number } | { ok: false; error: string } {
+  const firstIndex = content.indexOf(marker);
+  if (firstIndex < 0) {
+    return { ok: false, error: `Missing marker: ${marker}` };
+  }
+  const lastIndex = content.lastIndexOf(marker);
+  if (firstIndex !== lastIndex) {
+    return { ok: false, error: `Marker must appear exactly once: ${marker}` };
+  }
+  return { ok: true, index: firstIndex };
+}
+
+function validateRawMetadata(value: unknown): string | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return 'Progress metadata must be a JSON object';
+  }
+
+  const record = value as Record<string, unknown>;
+  if (record.formatVersion !== 1) {
+    return 'Progress metadata formatVersion must be 1';
+  }
+  if (record.kind !== 'limcode.progress') {
+    return 'Progress metadata kind must be "limcode.progress"';
+  }
+
+  const duplicateTodoIds = getDuplicateIds(record.todos, 'todo');
+  if (duplicateTodoIds.length > 0) {
+    return `Duplicate todo ids detected: ${duplicateTodoIds.join(', ')}`;
+  }
+
+  const duplicateMilestoneIds = getDuplicateIds(record.milestones, 'milestone');
+  if (duplicateMilestoneIds.length > 0) {
+    return `Duplicate milestone ids detected: ${duplicateMilestoneIds.join(', ')}`;
+  }
+
+  const duplicateRiskIds = getDuplicateIds(record.risks, 'risk');
+  if (duplicateRiskIds.length > 0) {
+    return `Duplicate risk ids detected: ${duplicateRiskIds.join(', ')}`;
+  }
+
+  return null;
+}
+
+export function buildProgressValidationSummary(content: string): ProgressValidationSummaryV1 {
+  const normalized = normalizeLineEndingsToLF(content || '');
+  const payload = extractMetadataPayload(normalized);
+
+  let formatVersion: number | null = null;
+  if (payload) {
+    try {
+      const parsed = JSON.parse(payload) as Record<string, unknown>;
+      formatVersion = typeof parsed?.formatVersion === 'number' ? parsed.formatVersion : null;
+    } catch {
+      formatVersion = null;
+    }
+  }
+
+  const validation = validateProgressDocument(normalized);
+  if (validation.success) {
+    return {
+      isValid: true,
+      formatVersion: formatVersion ?? validation.metadata.formatVersion,
+      issueCount: 0,
+      errorCount: 0,
+      warningCount: 0,
+      issues: [],
+      metadata: validation.metadata,
+    };
+  }
+
+  const issues: ProgressValidationIssue[] = [{ severity: 'error', code: 'progress_document_invalid', message: 'error' in validation ? validation.error : 'Progress document validation failed' }];
+  return { isValid: false, formatVersion, issueCount: 1, errorCount: 1, warningCount: 0, issues };
+}
+
+export function validateProgressDocument(
+  content: string
+): { success: true; metadata: ProgressDocumentMetadataV1 } | { success: false; error: string } {
+  const normalized = normalizeLineEndingsToLF(content || '');
+
+  const orderedHeadings = [
+    PROGRESS_SUMMARY_SECTION_TITLE,
+    PROGRESS_ARTIFACTS_SECTION_TITLE,
+    PROGRESS_TODOS_SECTION_TITLE,
+    PROGRESS_MILESTONES_SECTION_TITLE,
+    PROGRESS_RISKS_SECTION_TITLE,
+    PROGRESS_LOG_SECTION_TITLE,
+  ];
+
+  let lastIndex = -1;
+  for (const heading of orderedHeadings) {
+    const headingIndex = normalized.indexOf(heading);
+    if (headingIndex < 0) {
+      return { success: false, error: `Missing section heading: ${heading}` };
+    }
+    if (headingIndex <= lastIndex) {
+      return { success: false, error: `Progress document headings are out of order near: ${heading}` };
+    }
+    lastIndex = headingIndex;
+  }
+
+  const orderedMarkers = [
+    PROGRESS_SUMMARY_START,
+    PROGRESS_SUMMARY_END,
+    PROGRESS_ARTIFACTS_START,
+    PROGRESS_ARTIFACTS_END,
+    PROGRESS_TODOS_START,
+    PROGRESS_TODOS_END,
+    PROGRESS_MILESTONES_START,
+    PROGRESS_MILESTONES_END,
+    PROGRESS_RISKS_START,
+    PROGRESS_RISKS_END,
+    PROGRESS_LOG_START,
+    PROGRESS_LOG_END,
+    PROGRESS_METADATA_START,
+    PROGRESS_METADATA_END,
+  ];
+
+  lastIndex = -1;
+  for (const token of orderedMarkers) {
+    const markerCheck = ensureUniqueMarker(normalized, token)
+    if (!markerCheck.ok) {
+      return { success: false, error: 'error' in markerCheck ? markerCheck.error : `Missing marker: ${token}` };
+    }
+    if (markerCheck.index <= lastIndex) {
+      return { success: false, error: `Progress document sections are out of order near token: ${token}` };
+    }
+    lastIndex = markerCheck.index;
+  }
+
+  const metadataPayload = extractMetadataPayload(normalized);
+  if (!metadataPayload) {
+    return { success: false, error: 'Progress document metadata block is missing or empty' };
+  }
+
+  let rawMetadata: unknown;
+  try {
+    rawMetadata = JSON.parse(metadataPayload);
+  } catch (error: any) {
+    return { success: false, error: error?.message || 'Failed to parse progress metadata JSON' };
+  }
+
+  const metadataError = validateRawMetadata(rawMetadata);
+  if (metadataError) {
+    return { success: false, error: metadataError };
+  }
+
+  const metadata = normalizeProgressMetadataInput(rawMetadata as Partial<ProgressDocumentMetadataV1>, new Date().toISOString());
+  const metadataEndIndex = normalized.indexOf(PROGRESS_METADATA_END);
+  const tail = normalized.slice(metadataEndIndex + PROGRESS_METADATA_END.length).trim();
+  if (tail) {
+    return { success: false, error: 'Progress metadata block must be the last section in the document' };
+  }
+
+  return { success: true, metadata };
+}

--- a/backend/tools/progress/index.ts
+++ b/backend/tools/progress/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Progress 工具模块
+ */
+
+import type { Tool, ToolRegistration } from '../types';
+
+export { registerCreateProgress } from './create_progress';
+export { registerUpdateProgress } from './update_progress';
+export { registerRecordProgressMilestone } from './record_progress_milestone';
+export { registerValidateProgressDocument } from './validate_progress_document';
+
+export function getProgressToolRegistrations(): ToolRegistration[] {
+  const { registerCreateProgress } = require('./create_progress');
+  const { registerUpdateProgress } = require('./update_progress');
+  const { registerRecordProgressMilestone } = require('./record_progress_milestone');
+  const { registerValidateProgressDocument } = require('./validate_progress_document');
+  return [registerCreateProgress, registerUpdateProgress, registerRecordProgressMilestone, registerValidateProgressDocument];
+}
+
+export function getAllProgressTools(): Tool[] {
+  const { registerCreateProgress } = require('./create_progress');
+  const { registerUpdateProgress } = require('./update_progress');
+  const { registerRecordProgressMilestone } = require('./record_progress_milestone');
+  const { registerValidateProgressDocument } = require('./validate_progress_document');
+  return [registerCreateProgress(), registerUpdateProgress(), registerRecordProgressMilestone(), registerValidateProgressDocument()];
+}

--- a/backend/tools/progress/pathUtils.ts
+++ b/backend/tools/progress/pathUtils.ts
@@ -1,0 +1,143 @@
+/**
+ * Progress 工具路径辅助函数
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { getAllWorkspaces } from '../utils';
+import {
+  isDesignPathAllowed,
+  isPlanPathAllowed,
+  isProgressPathAllowed,
+  isReviewPathAllowed,
+} from '../../modules/settings/modeToolsPolicy';
+import type { ProgressArtifactRef } from './schema';
+
+const PROGRESS_ARTIFACT_KEYS = ['design', 'plan', 'review'] as const;
+type ProgressArtifactKey = typeof PROGRESS_ARTIFACT_KEYS[number];
+
+function isScopedPathAllowedWithMultiRoot(
+  pathStr: string,
+  validator: (path: string) => boolean
+): boolean {
+  if (validator(pathStr)) return true;
+
+  const workspaces = getAllWorkspaces();
+  if (workspaces.length <= 1) return false;
+
+  const normalized = (pathStr || '').replace(/\\/g, '/');
+  const slashIndex = normalized.indexOf('/');
+  if (slashIndex <= 0) return false;
+
+  const workspacePrefix = normalized.slice(0, slashIndex);
+  if (workspacePrefix === '.' || workspacePrefix === '..') return false;
+  if (workspacePrefix.includes(':')) return false;
+
+  const rest = normalized.slice(slashIndex + 1);
+  return validator(rest);
+}
+
+function getArtifactPathValidator(kind: ProgressArtifactKey): (path: string) => boolean {
+  if (kind === 'design') return isDesignPathAllowed;
+  if (kind === 'plan') return isPlanPathAllowed;
+  return isReviewPathAllowed;
+}
+
+function getArtifactScopeLabel(kind: ProgressArtifactKey): string {
+  if (kind === 'design') return '.limcode/design/**.md';
+  if (kind === 'plan') return '.limcode/plans/**.md';
+  return '.limcode/review/**.md';
+}
+
+export function isProgressModePathAllowedWithMultiRoot(pathStr: string): boolean {
+  return isScopedPathAllowedWithMultiRoot(pathStr, isProgressPathAllowed);
+}
+
+export function isProgressArtifactPathAllowedWithMultiRoot(
+  kind: ProgressArtifactKey,
+  pathStr: string
+): boolean {
+  return isScopedPathAllowedWithMultiRoot(pathStr, getArtifactPathValidator(kind));
+}
+
+export function validateProgressArtifactRefInput(
+  value: unknown,
+  options: {
+    fieldName?: string;
+    allowEmptyString?: boolean;
+  } = {}
+): string | null {
+  if (value === undefined) return null;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return `${options.fieldName || 'artifactRef'} must be an object`;
+  }
+
+  const allowEmptyString = options.allowEmptyString ?? true;
+  for (const key of PROGRESS_ARTIFACT_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+
+    const rawValue = (value as Record<string, unknown>)[key];
+    if (typeof rawValue !== 'string') {
+      return `${options.fieldName || 'artifactRef'}.${key} must be a string`;
+    }
+
+    const normalized = rawValue.trim();
+    if (!normalized) {
+      if (allowEmptyString) continue;
+      return `${options.fieldName || 'artifactRef'}.${key} must be a non-empty string`;
+    }
+
+    if (!isProgressArtifactPathAllowedWithMultiRoot(key, normalized)) {
+      return `${options.fieldName || 'artifactRef'}.${key} must point to ${getArtifactScopeLabel(key)}`;
+    }
+  }
+
+  return null;
+}
+
+export function normalizeProgressArtifactRef(value: unknown): ProgressArtifactRef {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const next: ProgressArtifactRef = {};
+  for (const key of PROGRESS_ARTIFACT_KEYS) {
+    const rawValue = (value as Record<string, unknown>)[key];
+    if (typeof rawValue !== 'string') continue;
+    const normalized = rawValue.trim();
+    if (!normalized) continue;
+    next[key] = normalized;
+  }
+
+  return next;
+}
+
+export function applyProgressArtifactPatch(
+  current: ProgressArtifactRef,
+  patch: unknown
+): ProgressArtifactRef {
+  const next: ProgressArtifactRef = { ...current };
+  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+    return next;
+  }
+
+  for (const key of PROGRESS_ARTIFACT_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(patch, key)) continue;
+
+    const rawValue = (patch as Record<string, unknown>)[key];
+    const normalized = typeof rawValue === 'string' ? rawValue.trim() : '';
+    if (!normalized) {
+      delete next[key];
+      continue;
+    }
+
+    next[key] = normalized;
+  }
+
+  return next;
+}
+
+export async function ensureParentDir(uriFsPath: string): Promise<void> {
+  const dir = path.dirname(uriFsPath);
+  await vscode.workspace.fs.createDirectory(vscode.Uri.file(dir));
+}

--- a/backend/tools/progress/record_progress_milestone.ts
+++ b/backend/tools/progress/record_progress_milestone.ts
@@ -1,0 +1,253 @@
+/**
+ * record_progress_milestone 工具
+ */
+
+import * as vscode from 'vscode';
+import type { Tool, ToolDeclaration, ToolResult } from '../types';
+import { resolveUriWithInfo } from '../utils';
+import {
+  buildProgressDocument,
+  isProgressMilestoneStatus,
+  normalizeOptionalProgressSingleLineText,
+  validateProgressDocument,
+} from './documentLayout';
+import {
+  ensureParentDir,
+  isProgressModePathAllowedWithMultiRoot,
+  normalizeProgressArtifactRef,
+  validateProgressArtifactRefInput,
+} from './pathUtils';
+import { projectProgressToolResultData } from './resultProjection';
+import type {
+  ProgressArtifactRef,
+  ProgressMilestoneRecord,
+  ProgressMilestoneStatus,
+} from './schema';
+
+export interface RecordProgressMilestoneArgs {
+  path?: string;
+  milestoneId?: string;
+  title: string;
+  status?: ProgressMilestoneStatus;
+  summary: string;
+  relatedTodoIds?: string[];
+  relatedReviewMilestoneIds?: string[];
+  relatedArtifacts?: Partial<ProgressArtifactRef>;
+  startedAt?: string;
+  completedAt?: string;
+  nextAction?: string;
+  latestConclusion?: string;
+  currentBlocker?: string;
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => typeof item === 'string' ? item.trim() : '')
+    .filter(Boolean);
+}
+
+function validateStringList(value: unknown, fieldName: string): string | null {
+  if (!Array.isArray(value)) {
+    return `${fieldName} must be an array`;
+  }
+  for (const item of value) {
+    if (typeof item !== 'string' || !item.trim()) {
+      return `${fieldName} entries must be non-empty strings`;
+    }
+  }
+  return null;
+}
+
+function generateNextMilestoneId(existing: ProgressMilestoneRecord[]): string {
+  let max = 0;
+  for (const milestone of existing) {
+    const match = /^PG(\d+)$/i.exec(milestone.id);
+    if (!match) continue;
+    const numeric = Number(match[1]);
+    if (Number.isFinite(numeric)) {
+      max = Math.max(max, numeric);
+    }
+  }
+  return `PG${max > 0 ? max + 1 : existing.length + 1}`;
+}
+
+export function createRecordProgressMilestoneToolDeclaration(): ToolDeclaration {
+  return {
+    name: 'record_progress_milestone',
+    strict: true,
+    description:
+      'Record a project milestone into .limcode/progress.md and refresh the latest progress snapshot. This is for project-level progress nodes, not for full review findings or plan documents.',
+    category: 'progress',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Optional target path. Must be .limcode/progress.md (or multi-root: workspace/.limcode/progress.md).'
+        },
+        milestoneId: { type: 'string' },
+        title: { type: 'string' },
+        status: { type: 'string', enum: ['in_progress', 'completed'] },
+        summary: { type: 'string' },
+        relatedTodoIds: { type: 'array', items: { type: 'string' } },
+        relatedReviewMilestoneIds: { type: 'array', items: { type: 'string' } },
+        relatedArtifacts: {
+          type: 'object',
+          properties: {
+            design: { type: 'string' },
+            plan: { type: 'string' },
+            review: { type: 'string' }
+          }
+        },
+        startedAt: { type: 'string' },
+        completedAt: { type: 'string' },
+        nextAction: { type: 'string' },
+        latestConclusion: { type: 'string' },
+        currentBlocker: { type: 'string' }
+      },
+      required: ['title', 'summary']
+    }
+  };
+}
+
+export function createRecordProgressMilestoneTool(): Tool {
+  return {
+    declaration: createRecordProgressMilestoneToolDeclaration(),
+    handler: async (rawArgs: Record<string, unknown>): Promise<ToolResult> => {
+      const args = rawArgs as unknown as RecordProgressMilestoneArgs;
+      const targetPath = typeof args.path === 'string' && args.path.trim()
+        ? args.path.trim()
+        : '.limcode/progress.md';
+      const title = typeof args.title === 'string' ? args.title.trim() : '';
+      const summary = typeof args.summary === 'string' ? args.summary.trim() : '';
+
+      if (!isProgressModePathAllowedWithMultiRoot(targetPath)) {
+        return { success: false, error: `Invalid progress path. Only ".limcode/progress.md" is allowed. Rejected path: ${targetPath}` };
+      }
+      if (!title) {
+        return { success: false, error: 'title is required and must be a non-empty string' };
+      }
+      if (!summary) {
+        return { success: false, error: 'summary is required and must be a non-empty string' };
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'status') && !isProgressMilestoneStatus(args.status)) {
+        return { success: false, error: 'status must be one of: in_progress, completed' };
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'relatedTodoIds')) {
+        const error = validateStringList(args.relatedTodoIds, 'relatedTodoIds');
+        if (error) return { success: false, error };
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'relatedReviewMilestoneIds')) {
+        const error = validateStringList(args.relatedReviewMilestoneIds, 'relatedReviewMilestoneIds');
+        if (error) return { success: false, error };
+      }
+      const artifactsError = validateProgressArtifactRefInput(args.relatedArtifacts, {
+        fieldName: 'relatedArtifacts',
+        allowEmptyString: true,
+      });
+      if (artifactsError) {
+        return { success: false, error: artifactsError };
+      }
+
+      const { uri, error } = resolveUriWithInfo(targetPath);
+      if (!uri) {
+        return { success: false, error: error || 'No workspace folder open' };
+      }
+
+      let existingContent = '';
+      try {
+        const existingBytes = await vscode.workspace.fs.readFile(uri);
+        existingContent = Buffer.from(existingBytes).toString('utf-8');
+      } catch (e: any) {
+        return { success: false, error: e?.message || `Progress document does not exist: ${targetPath}` };
+      }
+
+      const validation = validateProgressDocument(existingContent);
+      if (!validation.success) {
+        return { success: false, error: 'error' in validation ? validation.error : 'Failed to validate progress document' };
+      }
+
+      const currentMetadata = validation.metadata;
+      const requestedMilestoneId = typeof args.milestoneId === 'string' && args.milestoneId.trim()
+        ? args.milestoneId.trim()
+        : '';
+      const milestoneId = requestedMilestoneId || generateNextMilestoneId(currentMetadata.milestones);
+      if (currentMetadata.milestones.some((item) => item.id === milestoneId)) {
+        return { success: false, error: `Milestone id already exists: ${milestoneId}` };
+      }
+
+      const now = new Date().toISOString();
+      const milestoneStatus: ProgressMilestoneStatus = isProgressMilestoneStatus(args.status)
+        ? args.status
+        : 'completed';
+
+      const milestone: ProgressMilestoneRecord = {
+        id: milestoneId,
+        title,
+        status: milestoneStatus,
+        summary,
+        relatedTodoIds: normalizeStringList(args.relatedTodoIds),
+        relatedReviewMilestoneIds: normalizeStringList(args.relatedReviewMilestoneIds),
+        relatedArtifacts: normalizeProgressArtifactRef(args.relatedArtifacts),
+        startedAt: normalizeOptionalProgressSingleLineText(args.startedAt) || undefined,
+        completedAt: milestoneStatus === 'completed'
+          ? (normalizeOptionalProgressSingleLineText(args.completedAt) || now)
+          : undefined,
+        recordedAt: now,
+        nextAction: typeof args.nextAction === 'string' && args.nextAction.trim()
+          ? args.nextAction.trim()
+          : null,
+      };
+
+      const nextMetadata = {
+        ...currentMetadata,
+        updatedAt: now,
+        latestConclusion: Object.prototype.hasOwnProperty.call(rawArgs, 'latestConclusion')
+          ? args.latestConclusion
+          : currentMetadata.latestConclusion,
+        currentBlocker: Object.prototype.hasOwnProperty.call(rawArgs, 'currentBlocker')
+          ? args.currentBlocker
+          : currentMetadata.currentBlocker,
+        nextAction: Object.prototype.hasOwnProperty.call(rawArgs, 'nextAction')
+          ? args.nextAction
+          : currentMetadata.nextAction,
+        milestones: [...currentMetadata.milestones, milestone],
+        log: [
+          ...currentMetadata.log,
+          {
+            at: now,
+            type: 'milestone_recorded' as const,
+            refId: milestoneId,
+            message: `记录里程碑：${title}`,
+          } satisfies import('./schema').ProgressLogItem
+        ],
+      };
+
+      try {
+        await ensureParentDir(uri.fsPath);
+        const { metadata, content } = buildProgressDocument(nextMetadata, { generatedAt: now });
+        await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(content));
+
+        return {
+          success: true,
+          data: projectProgressToolResultData({
+            path: targetPath,
+            metadata,
+            delta: {
+              type: 'milestone_recorded',
+              milestoneId,
+              changedFields: ['milestones', 'summary', 'log']
+            }
+          })
+        };
+      } catch (e: any) {
+        return { success: false, error: e?.message || String(e) };
+      }
+    }
+  };
+}
+
+export function registerRecordProgressMilestone(): Tool {
+  return createRecordProgressMilestoneTool();
+}

--- a/backend/tools/progress/resultProjection.ts
+++ b/backend/tools/progress/resultProjection.ts
@@ -1,0 +1,75 @@
+/**
+ * Progress tool result projection helpers
+ */
+
+import type {
+  ProgressDocumentMetadataV1,
+  ProgressSummarySnapshotV1,
+  ProgressToolDeltaV1,
+  ProgressToolStructuredResultV1,
+} from './schema';
+import { buildCurrentProgressText, getLatestProgressMilestone } from './documentLayout';
+
+export interface ProjectProgressToolResultOptions {
+  path: string;
+  metadata: ProgressDocumentMetadataV1;
+  delta?: ProgressToolDeltaV1;
+  warnings?: string[];
+}
+
+export function buildProgressSummarySnapshot(
+  path: string,
+  metadata: ProgressDocumentMetadataV1
+): ProgressSummarySnapshotV1 {
+  const latestMilestone = getLatestProgressMilestone(metadata);
+  return {
+    formatVersion: 1,
+    kind: 'limcode.progress',
+    path,
+    projectId: metadata.projectId,
+    projectName: metadata.projectName,
+    status: metadata.status,
+    phase: metadata.phase,
+    currentFocus: metadata.currentFocus,
+    currentProgress: buildCurrentProgressText(metadata),
+    latestConclusion: metadata.latestConclusion,
+    currentBlocker: metadata.currentBlocker,
+    nextAction: metadata.nextAction,
+    updatedAt: metadata.updatedAt,
+    activeArtifacts: { ...metadata.activeArtifacts },
+    stats: { ...metadata.stats },
+    latestMilestone: latestMilestone
+      ? {
+        id: latestMilestone.id,
+        title: latestMilestone.title,
+        status: latestMilestone.status,
+        recordedAt: latestMilestone.recordedAt,
+      }
+      : undefined,
+  };
+}
+
+export function projectProgressToolResultData(
+  options: ProjectProgressToolResultOptions
+): ProgressToolStructuredResultV1 {
+  const snapshot = buildProgressSummarySnapshot(options.path, options.metadata);
+  return {
+    path: options.path,
+    progressSnapshot: snapshot,
+    progressDelta: options.delta,
+    projectId: snapshot.projectId,
+    projectName: snapshot.projectName,
+    status: snapshot.status,
+    phase: snapshot.phase,
+    currentFocus: snapshot.currentFocus,
+    currentProgress: snapshot.currentProgress,
+    latestConclusion: snapshot.latestConclusion,
+    currentBlocker: snapshot.currentBlocker,
+    nextAction: snapshot.nextAction,
+    updatedAt: snapshot.updatedAt,
+    activeArtifacts: snapshot.activeArtifacts,
+    stats: snapshot.stats,
+    latestMilestone: snapshot.latestMilestone,
+    warnings: options.warnings && options.warnings.length > 0 ? options.warnings : undefined,
+  };
+}

--- a/backend/tools/progress/schema.ts
+++ b/backend/tools/progress/schema.ts
@@ -1,0 +1,185 @@
+/**
+ * Progress 文档与工具共享 schema
+ */
+
+export type ProgressStatus = 'active' | 'blocked' | 'completed' | 'archived';
+export type ProgressPhase = 'design' | 'plan' | 'implementation' | 'review' | 'maintenance';
+export type ProgressTodoStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled';
+export type ProgressMilestoneStatus = 'in_progress' | 'completed';
+export type ProgressRiskStatus = 'active' | 'resolved' | 'accepted';
+export type ProgressLogType = 'created' | 'updated' | 'milestone_recorded' | 'artifact_changed' | 'risk_changed';
+
+export interface ProgressArtifactRef {
+  design?: string;
+  plan?: string;
+  review?: string;
+}
+
+export interface ProgressTodoItem {
+  id: string;
+  content: string;
+  status: ProgressTodoStatus;
+}
+
+export interface ProgressMilestoneRecord {
+  id: string;
+  title: string;
+  status: ProgressMilestoneStatus;
+  summary: string;
+  relatedTodoIds: string[];
+  relatedReviewMilestoneIds: string[];
+  relatedArtifacts?: ProgressArtifactRef;
+  startedAt?: string;
+  completedAt?: string;
+  recordedAt: string;
+  nextAction?: string | null;
+}
+
+export interface ProgressRiskItem {
+  id: string;
+  title: string;
+  status: ProgressRiskStatus;
+  description: string;
+}
+
+export interface ProgressLogItem {
+  at: string;
+  type: ProgressLogType;
+  refId?: string;
+  message: string;
+}
+
+export interface ProgressStats {
+  milestonesTotal: number;
+  milestonesCompleted: number;
+  todosTotal: number;
+  todosCompleted: number;
+  todosInProgress: number;
+  todosCancelled: number;
+  activeRisks: number;
+}
+
+export interface ProgressDocumentMetadataV1 {
+  formatVersion: 1;
+  kind: 'limcode.progress';
+  projectId: string;
+  projectName?: string;
+  createdAt: string;
+  updatedAt: string;
+  status: ProgressStatus;
+  phase: ProgressPhase;
+  currentFocus?: string | null;
+  latestConclusion?: string | null;
+  currentBlocker?: string | null;
+  nextAction?: string | null;
+  activeArtifacts: ProgressArtifactRef;
+  todos: ProgressTodoItem[];
+  milestones: ProgressMilestoneRecord[];
+  risks: ProgressRiskItem[];
+  log: ProgressLogItem[];
+  stats: ProgressStats;
+  render: {
+    rendererVersion: number;
+    generatedAt: string;
+    bodyHash: string;
+  };
+}
+
+export interface ProgressSummarySnapshotV1 {
+  formatVersion: 1;
+  kind: 'limcode.progress';
+  path: string;
+  projectId: string;
+  projectName?: string;
+  status: ProgressStatus;
+  phase: ProgressPhase;
+  currentFocus?: string | null;
+  currentProgress?: string | null;
+  latestConclusion?: string | null;
+  currentBlocker?: string | null;
+  nextAction?: string | null;
+  updatedAt: string;
+  activeArtifacts: ProgressArtifactRef;
+  stats: ProgressStats;
+  latestMilestone?: {
+    id: string;
+    title: string;
+    status: ProgressMilestoneStatus;
+    recordedAt: string;
+  };
+}
+
+export interface ProgressValidationIssue {
+  severity: 'error' | 'warning';
+  code: string;
+  message: string;
+}
+
+export interface ProgressValidationSummaryV1 {
+  isValid: boolean;
+  formatVersion: number | null;
+  issueCount: number;
+  errorCount: number;
+  warningCount: number;
+  issues: ProgressValidationIssue[];
+  metadata?: ProgressDocumentMetadataV1;
+}
+
+export interface ProgressToolDeltaV1 {
+  type: 'created' | 'updated' | 'milestone_recorded' | 'validated';
+  milestoneId?: string;
+  changedFields?: string[];
+}
+
+export interface ProgressToolStructuredResultV1 {
+  path: string;
+  progressSnapshot?: ProgressSummarySnapshotV1;
+  progressValidation?: ProgressValidationSummaryV1;
+  progressDelta?: ProgressToolDeltaV1;
+  projectId?: string;
+  projectName?: string;
+  status?: ProgressStatus;
+  phase?: ProgressPhase;
+  currentFocus?: string | null;
+  currentProgress?: string | null;
+  latestConclusion?: string | null;
+  currentBlocker?: string | null;
+  nextAction?: string | null;
+  updatedAt?: string;
+  activeArtifacts?: ProgressArtifactRef;
+  stats?: ProgressStats;
+  latestMilestone?: ProgressSummarySnapshotV1['latestMilestone'];
+  formatVersion?: number | null;
+  isValid?: boolean;
+  issueCount?: number;
+  errorCount?: number;
+  warningCount?: number;
+  issues?: ProgressValidationIssue[];
+  warnings?: string[];
+}
+
+export const PROGRESS_RENDERER_VERSION = 1;
+export const MAX_PROGRESS_LOG_ENTRIES = 20;
+
+export const PROGRESS_DOCUMENT_TITLE = '# 项目进度';
+export const PROGRESS_SUMMARY_SECTION_TITLE = '## 当前摘要';
+export const PROGRESS_ARTIFACTS_SECTION_TITLE = '## 关联文档';
+export const PROGRESS_TODOS_SECTION_TITLE = '## 当前 TODO 快照';
+export const PROGRESS_MILESTONES_SECTION_TITLE = '## 项目里程碑';
+export const PROGRESS_RISKS_SECTION_TITLE = '## 风险与阻塞';
+export const PROGRESS_LOG_SECTION_TITLE = '## 最近更新';
+
+export const PROGRESS_SUMMARY_START = '<!-- LIMCODE_PROGRESS_SUMMARY_START -->';
+export const PROGRESS_SUMMARY_END = '<!-- LIMCODE_PROGRESS_SUMMARY_END -->';
+export const PROGRESS_ARTIFACTS_START = '<!-- LIMCODE_PROGRESS_ARTIFACTS_START -->';
+export const PROGRESS_ARTIFACTS_END = '<!-- LIMCODE_PROGRESS_ARTIFACTS_END -->';
+export const PROGRESS_TODOS_START = '<!-- LIMCODE_PROGRESS_TODOS_START -->';
+export const PROGRESS_TODOS_END = '<!-- LIMCODE_PROGRESS_TODOS_END -->';
+export const PROGRESS_MILESTONES_START = '<!-- LIMCODE_PROGRESS_MILESTONES_START -->';
+export const PROGRESS_MILESTONES_END = '<!-- LIMCODE_PROGRESS_MILESTONES_END -->';
+export const PROGRESS_RISKS_START = '<!-- LIMCODE_PROGRESS_RISKS_START -->';
+export const PROGRESS_RISKS_END = '<!-- LIMCODE_PROGRESS_RISKS_END -->';
+export const PROGRESS_LOG_START = '<!-- LIMCODE_PROGRESS_LOG_START -->';
+export const PROGRESS_LOG_END = '<!-- LIMCODE_PROGRESS_LOG_END -->';
+export const PROGRESS_METADATA_START = '<!-- LIMCODE_PROGRESS_METADATA_START -->';
+export const PROGRESS_METADATA_END = '<!-- LIMCODE_PROGRESS_METADATA_END -->';

--- a/backend/tools/progress/update_progress.ts
+++ b/backend/tools/progress/update_progress.ts
@@ -1,0 +1,281 @@
+/**
+ * update_progress 工具
+ */
+
+import * as vscode from 'vscode';
+import type { Tool, ToolDeclaration, ToolResult } from '../types';
+import { resolveUriWithInfo } from '../utils';
+import {
+  buildProgressDocument,
+  isProgressPhase,
+  isProgressStatus,
+  normalizeOptionalProgressSingleLineText,
+  validateProgressDocument,
+  validateProgressLogAppendInput,
+  validateProgressRisksInput,
+  validateProgressTodosInput,
+} from './documentLayout';
+import {
+  applyProgressArtifactPatch,
+  ensureParentDir,
+  isProgressModePathAllowedWithMultiRoot,
+  validateProgressArtifactRefInput,
+} from './pathUtils';
+import { projectProgressToolResultData } from './resultProjection';
+import type {
+  ProgressArtifactRef,
+  ProgressLogItem,
+  ProgressLogType,
+  ProgressPhase,
+  ProgressRiskItem,
+  ProgressStatus,
+  ProgressTodoItem,
+} from './schema';
+
+export interface UpdateProgressArgs {
+  path?: string;
+  status?: ProgressStatus;
+  phase?: ProgressPhase;
+  currentFocus?: string;
+  latestConclusion?: string;
+  currentBlocker?: string;
+  nextAction?: string;
+  activeArtifacts?: ProgressArtifactRef;
+  todos?: ProgressTodoItem[];
+  risks?: ProgressRiskItem[];
+  appendLog?: Array<{ type: ProgressLogType; refId?: string; message: string }>;
+}
+
+function buildAppendedLogEntries(
+  value: UpdateProgressArgs['appendLog'],
+  at: string
+): ProgressLogItem[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => ({
+    at,
+    type: item.type,
+    refId: typeof item.refId === 'string' && item.refId.trim() ? item.refId.trim() : undefined,
+    message: item.message.trim(),
+  }));
+}
+
+export function createUpdateProgressToolDeclaration(): ToolDeclaration {
+  return {
+    name: 'update_progress',
+    strict: true,
+    description:
+      'Update the project progress document at .limcode/progress.md. This refreshes summary fields, artifacts, TODO snapshot, risks, and recent log entries while returning a lightweight progress snapshot.',
+    category: 'progress',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Optional target path. Must be .limcode/progress.md (or multi-root: workspace/.limcode/progress.md).'
+        },
+        status: { type: 'string', enum: ['active', 'blocked', 'completed', 'archived'] },
+        phase: { type: 'string', enum: ['design', 'plan', 'implementation', 'review', 'maintenance'] },
+        currentFocus: { type: 'string' },
+        latestConclusion: { type: 'string' },
+        currentBlocker: { type: 'string' },
+        nextAction: { type: 'string' },
+        activeArtifacts: {
+          type: 'object',
+          properties: {
+            design: { type: 'string' },
+            plan: { type: 'string' },
+            review: { type: 'string' }
+          }
+        },
+        todos: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              content: { type: 'string' },
+              status: { type: 'string', enum: ['pending', 'in_progress', 'completed', 'cancelled'] }
+            },
+            required: ['id', 'content', 'status']
+          }
+        },
+        risks: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              title: { type: 'string' },
+              status: { type: 'string', enum: ['active', 'resolved', 'accepted'] },
+              description: { type: 'string' }
+            },
+            required: ['id', 'title', 'status', 'description']
+          }
+        },
+        appendLog: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              type: { type: 'string', enum: ['created', 'updated', 'milestone_recorded', 'artifact_changed', 'risk_changed'] },
+              refId: { type: 'string' },
+              message: { type: 'string' }
+            },
+            required: ['type', 'message']
+          }
+        }
+      }
+    }
+  };
+}
+
+export function createUpdateProgressTool(): Tool {
+  return {
+    declaration: createUpdateProgressToolDeclaration(),
+    handler: async (rawArgs: Record<string, unknown>): Promise<ToolResult> => {
+      const args = rawArgs as unknown as UpdateProgressArgs;
+      const targetPath = typeof args.path === 'string' && args.path.trim()
+        ? args.path.trim()
+        : '.limcode/progress.md';
+
+      if (!isProgressModePathAllowedWithMultiRoot(targetPath)) {
+        return { success: false, error: `Invalid progress path. Only ".limcode/progress.md" is allowed. Rejected path: ${targetPath}` };
+      }
+
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'status') && !isProgressStatus(args.status)) {
+        return { success: false, error: 'status must be one of: active, blocked, completed, archived' };
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'phase') && !isProgressPhase(args.phase)) {
+        return { success: false, error: 'phase must be one of: design, plan, implementation, review, maintenance' };
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'todos')) {
+        const todosError = validateProgressTodosInput(args.todos);
+        if (todosError) return { success: false, error: todosError };
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'risks')) {
+        const risksError = validateProgressRisksInput(args.risks);
+        if (risksError) return { success: false, error: risksError };
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'appendLog')) {
+        const logError = validateProgressLogAppendInput(args.appendLog);
+        if (logError) return { success: false, error: logError };
+      }
+      const artifactsError = validateProgressArtifactRefInput(args.activeArtifacts, {
+        fieldName: 'activeArtifacts',
+        allowEmptyString: true,
+      });
+      if (artifactsError) {
+        return { success: false, error: artifactsError };
+      }
+
+      const { uri, error } = resolveUriWithInfo(targetPath);
+      if (!uri) {
+        return { success: false, error: error || 'No workspace folder open' };
+      }
+
+      let existingContent = '';
+      try {
+        const existingBytes = await vscode.workspace.fs.readFile(uri);
+        existingContent = Buffer.from(existingBytes).toString('utf-8');
+      } catch (e: any) {
+        return { success: false, error: e?.message || `Progress document does not exist: ${targetPath}` };
+      }
+
+      const validation = validateProgressDocument(existingContent);
+      if (!validation.success) {
+        return { success: false, error: 'error' in validation ? validation.error : 'Failed to validate progress document' };
+      }
+
+      const now = new Date().toISOString();
+      const currentMetadata = validation.metadata;
+      const nextLog = Object.prototype.hasOwnProperty.call(rawArgs, 'appendLog')
+        ? [...currentMetadata.log, ...buildAppendedLogEntries(args.appendLog, now)]
+        : currentMetadata.log;
+
+      const nextMetadata = {
+        ...currentMetadata,
+        updatedAt: now,
+        status: Object.prototype.hasOwnProperty.call(rawArgs, 'status')
+          ? args.status
+          : currentMetadata.status,
+        phase: Object.prototype.hasOwnProperty.call(rawArgs, 'phase')
+          ? args.phase
+          : currentMetadata.phase,
+        currentFocus: Object.prototype.hasOwnProperty.call(rawArgs, 'currentFocus')
+          ? normalizeOptionalProgressSingleLineText(args.currentFocus)
+          : currentMetadata.currentFocus,
+        latestConclusion: Object.prototype.hasOwnProperty.call(rawArgs, 'latestConclusion')
+          ? args.latestConclusion
+          : currentMetadata.latestConclusion,
+        currentBlocker: Object.prototype.hasOwnProperty.call(rawArgs, 'currentBlocker')
+          ? args.currentBlocker
+          : currentMetadata.currentBlocker,
+        nextAction: Object.prototype.hasOwnProperty.call(rawArgs, 'nextAction')
+          ? args.nextAction
+          : currentMetadata.nextAction,
+        activeArtifacts: Object.prototype.hasOwnProperty.call(rawArgs, 'activeArtifacts')
+          ? applyProgressArtifactPatch(currentMetadata.activeArtifacts, args.activeArtifacts)
+          : currentMetadata.activeArtifacts,
+        todos: Object.prototype.hasOwnProperty.call(rawArgs, 'todos')
+          ? args.todos
+          : currentMetadata.todos,
+        risks: Object.prototype.hasOwnProperty.call(rawArgs, 'risks')
+          ? args.risks
+          : currentMetadata.risks,
+        log: nextLog,
+      };
+
+      const changedFields = new Set<string>();
+      if (
+        Object.prototype.hasOwnProperty.call(rawArgs, 'status') ||
+        Object.prototype.hasOwnProperty.call(rawArgs, 'phase')
+      ) {
+        changedFields.add('header');
+      }
+      if (
+        Object.prototype.hasOwnProperty.call(rawArgs, 'currentFocus') ||
+        Object.prototype.hasOwnProperty.call(rawArgs, 'latestConclusion') ||
+        Object.prototype.hasOwnProperty.call(rawArgs, 'currentBlocker') ||
+        Object.prototype.hasOwnProperty.call(rawArgs, 'nextAction')
+      ) {
+        changedFields.add('summary');
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'activeArtifacts')) {
+        changedFields.add('artifacts');
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'todos')) {
+        changedFields.add('todos');
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'risks')) {
+        changedFields.add('risks');
+      }
+      if (Object.prototype.hasOwnProperty.call(rawArgs, 'appendLog')) {
+        changedFields.add('log');
+      }
+
+      try {
+        await ensureParentDir(uri.fsPath);
+        const { metadata, content } = buildProgressDocument(nextMetadata, { generatedAt: now });
+        await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(content));
+
+        return {
+          success: true,
+          data: projectProgressToolResultData({
+            path: targetPath,
+            metadata,
+            delta: {
+              type: 'updated',
+              changedFields: Array.from(changedFields.values())
+            }
+          })
+        };
+      } catch (e: any) {
+        return { success: false, error: e?.message || String(e) };
+      }
+    }
+  };
+}
+
+export function registerUpdateProgress(): Tool {
+  return createUpdateProgressTool();
+}

--- a/backend/tools/progress/validate_progress_document.ts
+++ b/backend/tools/progress/validate_progress_document.ts
@@ -1,0 +1,101 @@
+/**
+ * validate_progress_document 工具
+ *
+ * 目标：只读校验 progress 文档的格式与基础不变量。
+ */
+
+import * as vscode from 'vscode';
+import type { Tool, ToolDeclaration, ToolResult } from '../types';
+import { normalizeLineEndingsToLF, resolveUriWithInfo } from '../utils';
+import { isProgressModePathAllowedWithMultiRoot } from './pathUtils';
+import { buildProgressValidationSummary } from './documentLayout';
+import { projectProgressToolResultData } from './resultProjection';
+
+export interface ValidateProgressDocumentArgs {
+  path: string;
+}
+
+export function createValidateProgressDocumentToolDeclaration(): ToolDeclaration {
+  return {
+    name: 'validate_progress_document',
+    strict: true,
+    description:
+      'Validate the fixed progress document at .limcode/progress.md without modifying it. Reports metadata health, section ordering, and basic invariants.',
+    category: 'progress',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Target progress document path. Must be .limcode/progress.md (or multi-root: workspace/.limcode/progress.md).'
+        }
+      },
+      required: ['path']
+    }
+  };
+}
+
+export function createValidateProgressDocumentTool(): Tool {
+  return {
+    declaration: createValidateProgressDocumentToolDeclaration(),
+    handler: async (rawArgs: Record<string, unknown>): Promise<ToolResult> => {
+      const args = rawArgs as unknown as ValidateProgressDocumentArgs;
+      const targetPath = typeof args.path === 'string' ? args.path.trim() : '';
+
+      if (!targetPath) {
+        return { success: false, error: 'path is required and must be a non-empty string' };
+      }
+      if (!isProgressModePathAllowedWithMultiRoot(targetPath)) {
+        return { success: false, error: `Invalid progress path. Only ".limcode/progress.md" is allowed. Rejected path: ${targetPath}` };
+      }
+
+      const { uri, error } = resolveUriWithInfo(targetPath);
+      if (!uri) {
+        return { success: false, error: error || 'No workspace folder open' };
+      }
+
+      try {
+        const contentBytes = await vscode.workspace.fs.readFile(uri);
+        const content = normalizeLineEndingsToLF(new TextDecoder().decode(contentBytes));
+        const progressValidation = buildProgressValidationSummary(content);
+
+        return {
+          success: true,
+          data: {
+            path: targetPath,
+            ...(progressValidation.metadata
+              ? projectProgressToolResultData({
+                path: targetPath,
+                metadata: progressValidation.metadata,
+                delta: {
+                  type: 'validated',
+                  changedFields: []
+                }
+              })
+              : {
+                path: targetPath,
+                progressDelta: {
+                  type: 'validated',
+                  changedFields: []
+                }
+              }
+            ),
+            progressValidation,
+            formatVersion: progressValidation.formatVersion,
+            isValid: progressValidation.isValid,
+            issueCount: progressValidation.issueCount,
+            errorCount: progressValidation.errorCount,
+            warningCount: progressValidation.warningCount,
+            issues: progressValidation.issues,
+          }
+        };
+      } catch (e: any) {
+        return { success: false, error: e?.message || String(e) };
+      }
+    }
+  };
+}
+
+export function registerValidateProgressDocument(): Tool {
+  return createValidateProgressDocumentTool();
+}

--- a/backend/tools/review/create_review.ts
+++ b/backend/tools/review/create_review.ts
@@ -17,6 +17,7 @@ import {
 } from './reviewDocumentSection';
 import { projectReviewToolResultData } from './resultProjection';
 import { ensureNoActiveReviewSession, saveReviewSessionState } from './sessionState';
+import { syncProgressFromReviewArtifact } from '../progress/autoSync';
 
 export interface CreateReviewArgs {
   title?: string;
@@ -121,6 +122,11 @@ export function createCreateReviewTool(): Tool {
         const summary = summarizeReviewDocument(content);
         const bytes = new TextEncoder().encode(content);
         await vscode.workspace.fs.writeFile(uri, bytes);
+        const progressWarnings = await syncProgressFromReviewArtifact({
+          reviewPath: outPath,
+          title: summary.title || title || undefined,
+          eventMessage: `同步审查文档：${outPath}`
+        });
 
         if (summary.reviewSnapshot) {
           await saveReviewSessionState(context, {
@@ -140,7 +146,8 @@ export function createCreateReviewTool(): Tool {
             delta: {
               type: 'created',
               changedFields: ['header', 'scope', 'reviewSnapshot', 'reviewSession']
-            }
+            },
+            extra: progressWarnings.length > 0 ? { warnings: progressWarnings } : undefined
           })
         };
       } catch (e: any) {

--- a/backend/tools/review/finalize_review.ts
+++ b/backend/tools/review/finalize_review.ts
@@ -15,6 +15,7 @@ import {
 } from './reviewDocumentSection';
 import { projectReviewToolResultData } from './resultProjection';
 import { ensureMatchingActiveReviewSession, saveReviewSessionState } from './sessionState';
+import { syncProgressFromReviewArtifact } from '../progress/autoSync';
 
 export interface FinalizeReviewArgs {
   path: string;
@@ -114,6 +115,13 @@ export function createFinalizeReviewTool(): Tool {
         }, locale);
 
         await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(next.content));
+        const progressWarnings = await syncProgressFromReviewArtifact({
+          reviewPath: path,
+          title: next.reviewSnapshot.header.title,
+          latestConclusion: next.reviewSnapshot.summary.latestConclusion || undefined,
+          nextAction: next.reviewSnapshot.summary.recommendedNextAction || undefined,
+          eventMessage: `同步审查结论：${path}`
+        });
 
         await saveReviewSessionState(context, {
           reviewRunId: next.reviewSnapshot.reviewRunId,
@@ -134,7 +142,8 @@ export function createFinalizeReviewTool(): Tool {
             },
             extra: {
               findings: next.findings,
-              structuredFindings: next.structuredFindings
+              structuredFindings: next.structuredFindings,
+              ...(progressWarnings.length > 0 ? { warnings: progressWarnings } : {})
             }
           })
         };

--- a/backend/tools/review/record_review_milestone.ts
+++ b/backend/tools/review/record_review_milestone.ts
@@ -16,6 +16,7 @@ import {
 } from './reviewDocumentSection';
 import { projectReviewToolResultData } from './resultProjection';
 import { ensureMatchingActiveReviewSession, saveReviewSessionState } from './sessionState';
+import { syncProgressFromReviewArtifact } from '../progress/autoSync';
 
 export interface RecordReviewMilestoneArgs {
   path: string;
@@ -193,6 +194,13 @@ export function createRecordReviewMilestoneTool(): Tool {
         }, locale);
 
         await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(next.content));
+        const progressWarnings = await syncProgressFromReviewArtifact({
+          reviewPath: path,
+          title: next.reviewSnapshot.header.title,
+          latestConclusion: next.reviewSnapshot.summary.latestConclusion || undefined,
+          nextAction: next.reviewSnapshot.summary.recommendedNextAction || undefined,
+          eventMessage: `同步审查里程碑：${next.milestoneId}`
+        });
 
         await saveReviewSessionState(context, {
           reviewRunId: next.reviewSnapshot.reviewRunId,
@@ -216,7 +224,8 @@ export function createRecordReviewMilestoneTool(): Tool {
             extra: {
               milestoneId: next.milestoneId,
               findings: next.findings,
-              structuredFindings: next.structuredFindings
+              structuredFindings: next.structuredFindings,
+              ...(progressWarnings.length > 0 ? { warnings: progressWarnings } : {})
             }
           })
         };

--- a/backend/tools/review/reopen_review.ts
+++ b/backend/tools/review/reopen_review.ts
@@ -14,6 +14,7 @@ import {
 } from './reviewDocumentSection';
 import { projectReviewToolResultData } from './resultProjection';
 import { loadReviewSessionState, saveReviewSessionState } from './sessionState';
+import { syncProgressFromReviewArtifact } from '../progress/autoSync';
 
 export interface ReopenReviewArgs {
   path: string;
@@ -88,6 +89,11 @@ export function createReopenReviewTool(): Tool {
         const next = reopenReviewDocument(originalContent, locale);
 
         await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(next.content));
+        const progressWarnings = await syncProgressFromReviewArtifact({
+          reviewPath: path,
+          title: next.reviewSnapshot.header.title,
+          eventMessage: `重新打开审查：${path}`
+        });
         await saveReviewSessionState(context, {
           reviewRunId: next.reviewSnapshot.reviewRunId,
           reviewPath: path,
@@ -107,7 +113,8 @@ export function createReopenReviewTool(): Tool {
             },
             extra: {
               findings: next.findings,
-              structuredFindings: next.structuredFindings
+              structuredFindings: next.structuredFindings,
+              ...(progressWarnings.length > 0 ? { warnings: progressWarnings } : {})
             }
           })
         };

--- a/frontend/src/components/message/MessageTaskCards.vue
+++ b/frontend/src/components/message/MessageTaskCards.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 /**
- * MessageTaskCards - 在消息正文里显示 Design / Plan / Review 卡片
+ * MessageTaskCards - 在消息正文里显示 Design / Plan / Review / Progress 卡片
  *
- * 当前同时承载 design、plan 与 review 的结果摘要展示。
+ * 当前同时承载 design、plan、review 与 progress 的结果摘要展示。
  */
 import { computed, ref, onMounted, watch } from 'vue'
 import { sendToExtension, loadState, saveState, showNotification } from '@/utils/vscode'
 import type { ToolUsage } from '../../types'
 import ReviewTaskCard from './ReviewTaskCard.vue'
+import ProgressTaskCard from './ProgressTaskCard.vue'
 import { MarkdownRenderer, CustomScrollbar } from '../common'
 import ModeSelector from '../input/ModeSelector.vue'
 import ChannelSelector from '../input/ChannelSelector.vue'
@@ -22,6 +23,12 @@ import {
   isReviewToolName,
   type ReviewCardData
 } from '../../utils/reviewCards'
+import {
+  extractProgressCardData,
+  formatProgressToolFallbackContent,
+  isProgressToolName,
+  type ProgressCardData
+} from '../../utils/progressCards'
 import { useChatStore, useSettingsStore } from '@/stores'
 import * as configService from '@/services/config'
 import { useI18n } from '../../i18n'
@@ -37,7 +44,7 @@ const settingsStore = useSettingsStore()
 const { t } = useI18n()
 
 type CardStatus = 'pending' | 'running' | 'success' | 'error'
-type TaskCardKind = 'design' | 'plan' | 'review'
+type TaskCardKind = 'design' | 'plan' | 'review' | 'progress'
 
 type TaskEntry = {
   kind: TaskCardKind
@@ -47,6 +54,9 @@ type TaskEntry = {
   continuationPrompt?: string
   updateMode?: PlanUpdateMode
   reviewCardData?: ReviewCardData
+  progressCardData?: ProgressCardData
+  error?: string
+  warnings?: string[]
 }
 
 type TaskCardItem = {
@@ -62,6 +72,9 @@ type TaskCardItem = {
   continuationPrompt?: string
   updateMode?: PlanUpdateMode
   reviewCardData?: ReviewCardData
+  progressCardData?: ProgressCardData
+  error?: string
+  warnings?: string[]
 }
 
 type PlanSourceStatus = 'up_to_date' | 'mismatched' | 'missing_source' | 'untracked'
@@ -277,6 +290,7 @@ function isCardExpanded(key: string): boolean {
 function getCreateFallbackTitle(kind: TaskCardKind): string {
   if (kind === 'plan') return t('components.message.tool.createPlan.fallbackTitle')
   if (kind === 'design') return t('components.message.tool.createDesign.fallbackTitle')
+  if (kind === 'progress') return t('components.message.tool.createProgress.fallbackTitle')
   return t('components.message.tool.createReview.fallbackTitle')
 }
 
@@ -672,7 +686,7 @@ function handleCardAction(card: TaskCardItem) {
 async function autoOpenPendingCardTabs(cards: TaskCardItem[]) {
   for (const card of cards) {
     if (!card?.path) continue
-    if (card.kind === 'review') continue
+    if (card.kind === 'review' || card.kind === 'progress') continue
     if (isCardActionCompleted(card)) continue
     if (card.status === 'error') continue
     if (autoOpenedCardKeys.value.has(card.key)) continue
@@ -898,12 +912,42 @@ function getReviewTaskEntries(tool: ToolUsage): TaskEntry[] {
   }]
 }
 
+function getProgressTaskEntries(tool: ToolUsage): TaskEntry[] {
+  if (!isProgressToolName(tool.name)) return []
+
+  const args = (tool.args || {}) as Record<string, unknown>
+  const result = getToolResult(tool)
+  if (!result || typeof result !== 'object') return []
+  const progressResult = result as Record<string, unknown>
+
+  const progressCardData = extractProgressCardData(tool.name, args, progressResult)
+  const error = typeof progressResult.error === 'string' && progressResult.error.trim()
+    ? progressResult.error.trim()
+    : undefined
+  const warnings = Array.isArray((progressResult as any)?.data?.warnings)
+    ? ((progressResult as any).data.warnings as unknown[])
+      .filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : []
+  if (!progressCardData) return []
+
+  return [{
+    kind: 'progress',
+    path: progressCardData.path || '',
+    content: formatProgressToolFallbackContent(tool.name, args, progressResult),
+    success: typeof progressResult.success === 'boolean' ? progressResult.success : undefined,
+    progressCardData,
+    error,
+    warnings
+  }]
+}
+
 function getTaskEntries(tool: ToolUsage): TaskEntry[] {
   if (tool.name === 'write_file') return getWriteFileTaskEntries(tool)
   if (tool.name === 'create_plan') return getCreatePlanEntries(tool)
   if (tool.name === 'update_plan') return getUpdatePlanEntries(tool)
   if (tool.name === 'create_design') return getCreateDesignEntries(tool)
   if (tool.name === 'update_design') return getUpdateDesignEntries(tool)
+  if (isProgressToolName(tool.name)) return getProgressTaskEntries(tool)
   if (isReviewToolName(tool.name)) return getReviewTaskEntries(tool)
   return []
 }
@@ -924,6 +968,8 @@ const taskCards = computed<TaskCardItem[]>(() => {
 
       const title = entry.kind === 'review'
         ? (entry.reviewCardData?.title || getDocumentTitle(entry.content, entry.path, entry.kind))
+        : entry.kind === 'progress'
+          ? (entry.progressCardData?.title || getDocumentTitle(entry.content, entry.path, entry.kind))
         : getDocumentTitle(entry.content, entry.path, entry.kind)
 
       cards.push({
@@ -938,7 +984,10 @@ const taskCards = computed<TaskCardItem[]>(() => {
         isActionCompleted: !!entry.continuationPrompt,
         continuationPrompt: entry.continuationPrompt,
         updateMode: entry.updateMode,
-        reviewCardData: entry.reviewCardData
+        reviewCardData: entry.reviewCardData,
+        progressCardData: entry.progressCardData,
+        error: entry.error,
+        warnings: entry.warnings
       })
     }
   }
@@ -969,6 +1018,14 @@ const hasAny = computed(() => taskCards.value.length > 0)
         :content="c.content"
         :status="c.status"
         @generate-plan="generatePlanFromReview(c)"
+      />
+      <ProgressTaskCard
+        v-else-if="c.kind === 'progress' && c.progressCardData"
+        :card="c.progressCardData"
+        :error="c.error"
+        :warnings="c.warnings"
+        :content="c.content"
+        :status="c.status"
       />
       <div v-else class="task-panel">
       <div class="task-header">

--- a/frontend/src/components/message/ProgressTaskCard.vue
+++ b/frontend/src/components/message/ProgressTaskCard.vue
@@ -1,0 +1,675 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref } from 'vue'
+import { useI18n } from '../../i18n'
+import { TaskCard, MarkdownRenderer } from '../common'
+import type {
+  ProgressCardData,
+  ProgressCardPhase,
+  ProgressCardStatus,
+  ProgressToolName,
+} from '../../utils/progressCards'
+import { copyToClipboard } from '../../utils/format'
+import { sendToExtension, showNotification } from '../../utils/vscode'
+
+const props = withDefaults(defineProps<{
+  card: ProgressCardData
+  content?: string
+  status?: 'pending' | 'running' | 'success' | 'error'
+  defaultExpanded?: boolean
+  error?: string
+  warnings?: string[]
+  showRawResult?: boolean
+}>(), {
+  content: '',
+  status: 'success',
+  defaultExpanded: false,
+  error: '',
+  warnings: () => [],
+  showRawResult: false,
+})
+
+const { t } = useI18n()
+
+const copied = ref(false)
+let copyResetTimer: ReturnType<typeof setTimeout> | undefined
+
+function getSourceToolLabel(sourceTool: ProgressToolName): string {
+  switch (sourceTool) {
+    case 'create_progress':
+      return t('components.message.tool.progressCard.sourceCreate')
+    case 'update_progress':
+      return t('components.message.tool.progressCard.sourceUpdate')
+    case 'record_progress_milestone':
+      return t('components.message.tool.progressCard.sourceMilestone')
+    case 'validate_progress_document':
+      return t('components.message.tool.progressCard.sourceValidate')
+  }
+}
+
+function getCardIcon(sourceTool: ProgressToolName): string {
+  switch (sourceTool) {
+    case 'create_progress':
+      return 'codicon-book'
+    case 'update_progress':
+      return 'codicon-sync'
+    case 'record_progress_milestone':
+      return 'codicon-checklist'
+    case 'validate_progress_document':
+      return 'codicon-verified'
+  }
+}
+
+function getStatusLabel(status?: ProgressCardStatus): string {
+  switch (status) {
+    case 'active':
+      return t('components.message.tool.progressCard.statusActive')
+    case 'blocked':
+      return t('components.message.tool.progressCard.statusBlocked')
+    case 'completed':
+      return t('components.message.tool.progressCard.statusCompleted')
+    case 'archived':
+      return t('components.message.tool.progressCard.statusArchived')
+    default:
+      return ''
+  }
+}
+
+function getPhaseLabel(phase?: ProgressCardPhase): string {
+  switch (phase) {
+    case 'design':
+      return t('components.message.tool.progressCard.phaseDesign')
+    case 'plan':
+      return t('components.message.tool.progressCard.phasePlan')
+    case 'implementation':
+      return t('components.message.tool.progressCard.phaseImplementation')
+    case 'review':
+      return t('components.message.tool.progressCard.phaseReview')
+    case 'maintenance':
+      return t('components.message.tool.progressCard.phaseMaintenance')
+    default:
+      return ''
+  }
+}
+
+function getMilestoneStatusLabel(status?: ProgressCardData['latestMilestoneStatus']): string {
+  if (status === 'completed') return t('components.message.tool.progressCard.milestoneStatusCompleted')
+  if (status === 'in_progress') return t('components.message.tool.progressCard.milestoneStatusInProgress')
+  return ''
+}
+
+function getValidationLabel(card: ProgressCardData): string {
+  if (card.isValid === false) return t('components.message.tool.progressCard.validationInvalid')
+  if ((card.warningCount || 0) > 0) return t('components.message.tool.progressCard.validationWarning')
+  if (card.isValid === true) return t('components.message.tool.progressCard.validationValid')
+  return ''
+}
+
+function getIssueSeverityLabel(severity?: 'error' | 'warning'): string {
+  return severity === 'error'
+    ? t('components.message.tool.progressCard.issueError')
+    : t('components.message.tool.progressCard.issueWarning')
+}
+
+type ProgressSummaryItem = {
+  key: string
+  label: string
+  value: string
+}
+
+const title = computed(() => props.card.title || t('components.message.tool.progressCard.defaultTitle'))
+const subtitle = computed(() => props.card.path || undefined)
+const footerRight = computed(() => {
+  const parts = [getSourceToolLabel(props.card.sourceTool), props.card.updatedAt || ''].filter(Boolean)
+  return parts.length > 0 ? parts.join(' · ') : undefined
+})
+
+const metaChips = computed(() => {
+  const chips: string[] = []
+  const statusLabel = getStatusLabel(props.card.status)
+  if (statusLabel) chips.push(statusLabel)
+  const phaseLabel = getPhaseLabel(props.card.phase)
+  if (phaseLabel) chips.push(phaseLabel)
+
+  const validationLabel = getValidationLabel(props.card)
+  if (validationLabel) chips.push(validationLabel)
+
+  return chips
+})
+
+const preview = computed(() => {
+  const blocks: string[] = []
+  if (props.card.currentFocus) {
+    blocks.push([
+      t('components.message.tool.progressCard.currentFocus'),
+      props.card.currentFocus
+    ].join('\n'))
+  }
+  if (props.card.currentProgress) {
+    blocks.push([
+      t('components.message.tool.progressCard.currentProgress'),
+      props.card.currentProgress
+    ].join('\n'))
+  }
+  if (props.card.latestConclusionPreview) {
+    blocks.push([
+      t('components.message.tool.progressCard.latestConclusion'),
+      props.card.latestConclusionPreview
+    ].join('\n'))
+  }
+  if (props.card.currentBlockerPreview) {
+    blocks.push([
+      t('components.message.tool.progressCard.currentBlocker'),
+      props.card.currentBlockerPreview
+    ].join('\n'))
+  }
+  if (props.card.nextActionPreview) {
+    blocks.push([
+      t('components.message.tool.progressCard.nextAction'),
+      props.card.nextActionPreview
+    ].join('\n'))
+  }
+  return blocks.join('\n\n')
+})
+
+const summaryItems = computed<ProgressSummaryItem[]>(() => {
+  const items: ProgressSummaryItem[] = []
+
+  const statusLabel = getStatusLabel(props.card.status)
+  if (statusLabel) {
+    items.push({
+      key: 'status',
+      label: t('components.message.tool.progressCard.status'),
+      value: statusLabel
+    })
+  }
+
+  const phaseLabel = getPhaseLabel(props.card.phase)
+  if (phaseLabel) {
+    items.push({
+      key: 'phase',
+      label: t('components.message.tool.progressCard.phase'),
+      value: phaseLabel
+    })
+  }
+
+  if (props.card.currentProgress) {
+    items.push({
+      key: 'progress',
+      label: t('components.message.tool.progressCard.currentProgress'),
+      value: props.card.currentProgress
+    })
+  }
+
+  if (typeof props.card.milestonesTotal === 'number') {
+    items.push({
+      key: 'milestones',
+      label: t('components.message.tool.progressCard.milestones'),
+      value: `${props.card.milestonesCompleted || 0}/${props.card.milestonesTotal}`
+    })
+  }
+
+  if (typeof props.card.todosTotal === 'number') {
+    items.push({
+      key: 'todos',
+      label: t('components.message.tool.progressCard.todos'),
+      value: `${props.card.todosCompleted || 0}/${props.card.todosTotal} · ${t('components.message.tool.todoPanel.statusInProgress')} ${props.card.todosInProgress || 0}`
+    })
+  }
+
+  if (typeof props.card.activeRisks === 'number') {
+    items.push({
+      key: 'activeRisks',
+      label: t('components.message.tool.progressCard.activeRisks'),
+      value: String(props.card.activeRisks)
+    })
+  }
+
+  const validationLabel = getValidationLabel(props.card)
+  if (validationLabel || typeof props.card.issueCount === 'number') {
+    items.push({
+      key: 'validation',
+      label: t('components.message.tool.progressCard.validation'),
+      value: typeof props.card.issueCount === 'number'
+        ? t('components.message.tool.progressCard.issueSummary', { count: props.card.issueCount, errors: props.card.errorCount || 0, warnings: props.card.warningCount || 0 })
+        : validationLabel
+    })
+  }
+
+  if (props.card.updatedAt) {
+    items.push({
+      key: 'updatedAt',
+      label: t('components.message.tool.progressCard.updatedAt'),
+      value: props.card.updatedAt
+    })
+  }
+
+  return items
+})
+
+const artifactTags = computed(() => {
+  const items: Array<{ key: string; label: string; value: string }> = []
+  if (props.card.activeDesignPath) {
+    items.push({
+      key: 'design',
+      label: t('components.message.tool.progressCard.activeDesign'),
+      value: props.card.activeDesignPath
+    })
+  }
+  if (props.card.activePlanPath) {
+    items.push({
+      key: 'plan',
+      label: t('components.message.tool.progressCard.activePlan'),
+      value: props.card.activePlanPath
+    })
+  }
+  if (props.card.activeReviewPath) {
+    items.push({
+      key: 'review',
+      label: t('components.message.tool.progressCard.activeReview'),
+      value: props.card.activeReviewPath
+    })
+  }
+  return items
+})
+
+const showRawContent = computed(() => props.showRawResult && (props.content || '').trim().length > 0)
+
+async function openProgressFile(): Promise<void> {
+  if (!props.card.path) return
+
+  try {
+    await sendToExtension('openWorkspaceFileAt', {
+      path: props.card.path,
+      highlight: false,
+      preview: false
+    })
+  } catch (error) {
+    console.error('[progress-card] Failed to open progress file:', error)
+    await showNotification(t('components.message.tool.progressCard.openFileFailed'), 'error')
+  }
+}
+
+async function copyProgressPath(): Promise<void> {
+  if (!props.card.path) return
+
+  const success = await copyToClipboard(props.card.path)
+  if (!success) {
+    await showNotification(t('components.message.tool.progressCard.copyFailed'), 'error')
+    return
+  }
+
+  copied.value = true
+  if (copyResetTimer) clearTimeout(copyResetTimer)
+  copyResetTimer = setTimeout(() => {
+    copied.value = false
+    copyResetTimer = undefined
+  }, 1500)
+}
+
+onBeforeUnmount(() => {
+  if (copyResetTimer) {
+    clearTimeout(copyResetTimer)
+    copyResetTimer = undefined
+  }
+})
+</script>
+
+<template>
+  <TaskCard
+    :title="title"
+    :subtitle="subtitle"
+    :icon="getCardIcon(card.sourceTool)"
+    :status="status"
+    :preview="preview"
+    :preview-is-markdown="false"
+    :meta-chips="metaChips"
+    :footer-right="footerRight"
+    :default-expanded="props.defaultExpanded"
+  >
+    <template #expanded>
+      <div class="progress-card-expanded">
+        <div class="progress-card-actions">
+          <button
+            class="progress-card-btn"
+            :disabled="!card.path"
+            @click="openProgressFile"
+          >
+            <span class="codicon codicon-go-to-file"></span>
+            <span>{{ t('components.message.tool.progressCard.openFile') }}</span>
+          </button>
+          <button
+            class="progress-card-btn secondary"
+            :disabled="!card.path"
+            @click="copyProgressPath"
+          >
+            <span class="codicon codicon-copy"></span>
+            <span>{{ copied ? t('components.message.tool.progressCard.copied') : t('components.message.tool.progressCard.copyPath') }}</span>
+          </button>
+        </div>
+
+        <div v-if="summaryItems.length > 0" class="progress-summary-grid">
+          <div
+            v-for="item in summaryItems"
+            :key="item.key"
+            class="progress-summary-item"
+          >
+            <div class="progress-summary-label">{{ item.label }}</div>
+            <div class="progress-summary-value">{{ item.value }}</div>
+          </div>
+        </div>
+
+        <div v-if="artifactTags.length > 0" class="progress-block">
+          <div class="progress-label">{{ t('components.message.tool.progressCard.activeArtifacts') }}</div>
+          <div class="progress-artifact-tags">
+            <span v-for="artifact in artifactTags" :key="artifact.key" class="progress-artifact-tag">
+              <strong>{{ artifact.label }}</strong>
+              <span>{{ artifact.value }}</span>
+            </span>
+          </div>
+        </div>
+
+        <div v-if="card.latestMilestoneId || card.latestMilestoneTitle" class="progress-block">
+          <div class="progress-label">{{ t('components.message.tool.progressCard.latestMilestone') }}</div>
+          <div class="progress-latest-milestone">
+            <div class="progress-latest-milestone-title">
+              {{ card.latestMilestoneId || '' }}<span v-if="card.latestMilestoneTitle"> · {{ card.latestMilestoneTitle }}</span>
+            </div>
+            <div class="progress-latest-milestone-meta">
+              <span v-if="getMilestoneStatusLabel(card.latestMilestoneStatus)" class="progress-meta-chip">
+                {{ getMilestoneStatusLabel(card.latestMilestoneStatus) }}
+              </span>
+              <span v-if="card.latestMilestoneRecordedAt" class="progress-meta-chip">
+                {{ card.latestMilestoneRecordedAt }}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="card.latestConclusion" class="progress-block">
+          <div class="progress-label">{{ t('components.message.tool.progressCard.latestConclusion') }}</div>
+          <div class="progress-rich-content">
+            <MarkdownRenderer :content="card.latestConclusion" />
+          </div>
+        </div>
+
+        <div v-if="card.currentBlocker" class="progress-block">
+          <div class="progress-label">{{ t('components.message.tool.progressCard.currentBlocker') }}</div>
+          <div class="progress-rich-content">
+            <MarkdownRenderer :content="card.currentBlocker" />
+          </div>
+        </div>
+
+        <div v-if="card.nextAction" class="progress-block">
+          <div class="progress-label">{{ t('components.message.tool.progressCard.nextAction') }}</div>
+          <div class="progress-rich-content">
+            <MarkdownRenderer :content="card.nextAction" />
+          </div>
+        </div>
+
+        <div v-if="props.warnings && props.warnings.length > 0" class="progress-block">
+          <div v-for="(warning, index) in props.warnings" :key="`warning-${index}`" class="progress-warning-item">
+            <span class="codicon codicon-warning progress-warning-icon"></span>
+            <span class="progress-warning-text">{{ warning }}</span>
+          </div>
+        </div>
+
+        <div v-if="props.error" class="progress-block">
+          <div class="progress-label">{{ t('components.message.tool.error') }}</div>
+          <div class="progress-error-box">{{ props.error }}</div>
+        </div>
+
+        <div v-if="card.issues && card.issues.length > 0" class="progress-block">
+          <div class="progress-label">{{ t('components.message.tool.progressCard.validation') }}</div>
+          <ul class="progress-issues">
+            <li v-for="(issue, index) in card.issues" :key="`${issue.code || 'issue'}-${index}`" class="progress-issue-item">
+              <span :class="['progress-issue-badge', issue.severity || 'warning']">{{ getIssueSeverityLabel(issue.severity) }}</span>
+              <span class="progress-issue-text">{{ issue.message }}</span>
+            </li>
+          </ul>
+        </div>
+
+        <div v-if="showRawContent" class="progress-block">
+          <div class="progress-label">{{ t('components.message.tool.progressCard.rawResult') }}</div>
+          <div class="progress-raw-result">
+            <MarkdownRenderer :content="props.content" />
+          </div>
+        </div>
+      </div>
+    </template>
+  </TaskCard>
+</template>
+
+<style scoped>
+.progress-card-expanded {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.progress-card-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.progress-card-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 6px;
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.progress-card-btn:hover:not(:disabled) {
+  background: var(--vscode-button-hoverBackground);
+}
+
+.progress-card-btn.secondary {
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+}
+
+.progress-card-btn.secondary:hover:not(:disabled) {
+  background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-secondaryBackground));
+}
+
+.progress-card-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.progress-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+}
+
+.progress-summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 8px;
+  background: var(--vscode-sideBar-background);
+}
+
+.progress-summary-label {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--vscode-descriptionForeground);
+}
+
+.progress-summary-value {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--vscode-foreground);
+  word-break: break-word;
+}
+
+.progress-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.progress-label {
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vscode-descriptionForeground);
+}
+
+.progress-artifact-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.progress-artifact-tag,
+.progress-meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--vscode-panel-border);
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+  font-size: 11px;
+  line-height: 1.4;
+  max-width: 100%;
+  word-break: break-word;
+}
+
+.progress-latest-milestone {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 8px;
+  background: var(--vscode-sideBar-background);
+}
+
+.progress-latest-milestone-title {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--vscode-foreground);
+  font-weight: 600;
+}
+
+.progress-latest-milestone-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.progress-rich-content,
+.progress-raw-result {
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 8px;
+  background: var(--vscode-sideBar-background);
+  overflow: hidden;
+}
+
+.progress-rich-content :deep(.markdown-content),
+.progress-raw-result :deep(.markdown-content) {
+  padding: 8px 10px;
+}
+
+.progress-rich-content :deep(.markdown-content > :first-child),
+.progress-raw-result :deep(.markdown-content > :first-child) {
+  margin-top: 0;
+}
+
+.progress-rich-content :deep(.markdown-content > :last-child),
+.progress-raw-result :deep(.markdown-content > :last-child) {
+  margin-bottom: 0;
+}
+
+.progress-issues {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.progress-issue-item {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  padding: 8px 10px;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 8px;
+  background: var(--vscode-sideBar-background);
+}
+
+.progress-issue-badge {
+  flex-shrink: 0;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 10px;
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+}
+
+.progress-issue-badge.error {
+  background: var(--vscode-inputValidation-errorBackground);
+  color: var(--vscode-errorForeground);
+}
+
+.progress-issue-badge.warning {
+  background: var(--vscode-inputValidation-warningBackground);
+  color: var(--vscode-editorWarning-foreground);
+}
+
+.progress-issue-text {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--vscode-foreground);
+}
+
+.progress-warning-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--vscode-inputValidation-warningBorder, var(--vscode-panel-border));
+  border-radius: 8px;
+  background: var(--vscode-inputValidation-warningBackground, var(--vscode-sideBar-background));
+}
+
+.progress-warning-icon {
+  color: var(--vscode-editorWarning-foreground);
+  flex-shrink: 0;
+}
+
+.progress-warning-text {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--vscode-foreground);
+  word-break: break-word;
+}
+
+.progress-error-box {
+  padding: 8px 10px;
+  border: 1px solid var(--vscode-inputValidation-errorBorder, var(--vscode-panel-border));
+  border-radius: 8px;
+  background: var(--vscode-inputValidation-errorBackground, var(--vscode-sideBar-background));
+  color: var(--vscode-errorForeground);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+</style>

--- a/frontend/src/components/message/ResponseViewerDialog.vue
+++ b/frontend/src/components/message/ResponseViewerDialog.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from 'vue'
 import { JsonViewerDialog, MarkdownRenderer, Modal } from '../common'
 import ReviewTaskCard from './ReviewTaskCard.vue'
+import ProgressTaskCard from './ProgressTaskCard.vue'
 import { useI18n } from '../../i18n'
 import { copyToClipboard, formatTime } from '../../utils/format'
 import { showNotification } from '../../utils/vscode'
@@ -575,8 +576,17 @@ function formatJsonInline(value: unknown): string {
               :key="tool.id || `${tool.name}-${index}`"
               class="tool-entry"
             >
-              <div v-if="tool.reviewCardData" class="response-viewer-review-block">
+              <div v-if="tool.reviewCardData || tool.progressCardData" class="response-viewer-review-block">
+                <ProgressTaskCard
+                  v-if="tool.progressCardData"
+                  class="response-viewer-review-card"
+                  :card="tool.progressCardData"
+                  :content="tool.progressFallbackContent"
+                  :status="getReviewCardStatus(tool.status)"
+                  :show-raw-result="false"
+                />
                 <ReviewTaskCard
+                  v-else-if="tool.reviewCardData"
                   class="response-viewer-review-card"
                   :card="tool.reviewCardData"
                   :content="tool.reviewFallbackContent"
@@ -870,6 +880,14 @@ function formatJsonInline(value: unknown): string {
                   class="response-viewer-review-card embedded"
                   :card="tool.reviewCardData"
                   :content="tool.reviewFallbackContent"
+                  :status="getReviewCardStatus(tool.status)"
+                  :show-raw-result="false"
+                />
+                <ProgressTaskCard
+                  v-else-if="tool.progressCardData"
+                  class="response-viewer-review-card embedded"
+                  :card="tool.progressCardData"
+                  :content="tool.progressFallbackContent"
                   :status="getReviewCardStatus(tool.status)"
                   :show-raw-result="false"
                 />

--- a/frontend/src/components/message/ToolMessage.vue
+++ b/frontend/src/components/message/ToolMessage.vue
@@ -860,7 +860,26 @@ function renderToolContent(tool: ToolUsage) {
   // 如果有内容格式化器，使用格式化器
   if (config?.contentFormatter) {
     const content = config.contentFormatter(tool.args, tool.result)
-    return h('div', { class: 'tool-content-text' }, content)
+    const children: any[] = []
+
+    if (content) {
+      children.push(h('div', { class: 'tool-content-text' }, content))
+    }
+
+    if (tool.error) {
+      children.push(
+        h('div', { class: 'content-section error-section' }, [
+          h('div', { class: 'section-label' }, t('components.message.tool.error') + ':'),
+          h('div', { class: 'error-message' }, tool.error)
+        ])
+      )
+    }
+
+    if (children.length === 0) {
+      return h('div', { class: 'tool-content-text' }, '')
+    }
+
+    return h('div', { class: 'tool-content-default' }, children)
   }
   
   // 默认显示：参数和结果的 JSON

--- a/frontend/src/components/message/responseViewer/buildResponseViewerData.ts
+++ b/frontend/src/components/message/responseViewer/buildResponseViewerData.ts
@@ -12,6 +12,12 @@ import {
   isReviewToolName,
   type ReviewCardData
 } from '../../../utils/reviewCards'
+import {
+  extractProgressCardData,
+  formatProgressToolFallbackContent,
+  isProgressToolName,
+  type ProgressCardData
+} from '../../../utils/progressCards'
 import { isAwaitingToolUserConfirmation } from '../../../utils/toolContinuations'
 
 export type ResponseViewerMode = 'common' | 'advanced'
@@ -59,6 +65,8 @@ export interface ResponseViewerToolPreview {
   hasLargeResult: boolean
   reviewCardData?: ReviewCardData
   reviewFallbackContent?: string
+  progressCardData?: ProgressCardData
+  progressFallbackContent?: string
 }
 
 export interface ResponseViewerAttachmentPreview {
@@ -283,7 +291,7 @@ function buildToolPreviews(
       const argsSummary = typeof displayedArgs === 'string'
         ? summarizeText(displayedArgs, MAX_PREVIEW_LENGTH)
         : summarizeValue(displayedArgs, MAX_PREVIEW_LENGTH)
-      const reviewExtras = buildReviewToolPreviewExtras(tool.name, tool.args || {}, resolvedResult.result)
+      const taskExtras = buildTaskToolPreviewExtras(tool.name, tool.args || {}, resolvedResult.result)
 
       return {
         id: tool.id,
@@ -301,8 +309,10 @@ function buildToolPreviews(
         duration: tool.duration,
         hasLargeArgs: isLargeValue(displayedArgs),
         hasLargeResult: isLargeValue(resolvedError || resolvedResult.result),
-        reviewCardData: reviewExtras.reviewCardData,
-        reviewFallbackContent: reviewExtras.reviewFallbackContent
+        reviewCardData: taskExtras.reviewCardData,
+        reviewFallbackContent: taskExtras.reviewFallbackContent,
+        progressCardData: taskExtras.progressCardData,
+        progressFallbackContent: taskExtras.progressFallbackContent
       }
     })
   }
@@ -321,7 +331,7 @@ function buildToolPreviews(
       const argsSummary = typeof displayedArgs === 'string'
         ? summarizeText(displayedArgs, MAX_PREVIEW_LENGTH)
         : summarizeValue(displayedArgs, MAX_PREVIEW_LENGTH)
-      const reviewExtras = buildReviewToolPreviewExtras(functionCall.name, functionCall.args || {}, resolvedResult.result)
+      const taskExtras = buildTaskToolPreviewExtras(functionCall.name, functionCall.args || {}, resolvedResult.result)
 
       return {
         id: functionCall.id || `${functionCall.name}-${index}`,
@@ -339,8 +349,10 @@ function buildToolPreviews(
         duration: undefined,
         hasLargeArgs: isLargeValue(displayedArgs),
         hasLargeResult: isLargeValue(resolvedError || resolvedResult.result),
-        reviewCardData: reviewExtras.reviewCardData,
-        reviewFallbackContent: reviewExtras.reviewFallbackContent
+        reviewCardData: taskExtras.reviewCardData,
+        reviewFallbackContent: taskExtras.reviewFallbackContent,
+        progressCardData: taskExtras.progressCardData,
+        progressFallbackContent: taskExtras.progressFallbackContent
       }
     })
 }
@@ -456,25 +468,35 @@ function buildPartPreviews(
   })
 }
 
-function buildReviewToolPreviewExtras(
+function buildTaskToolPreviewExtras(
   toolName: string,
   args: Record<string, unknown>,
   result?: unknown
-): Pick<ResponseViewerToolPreview, 'reviewCardData' | 'reviewFallbackContent'> {
-  if (!isReviewToolName(toolName)) {
-    return {}
-  }
+): Pick<ResponseViewerToolPreview, 'reviewCardData' | 'reviewFallbackContent' | 'progressCardData' | 'progressFallbackContent'> {
 
   const resultRecord = result && typeof result === 'object'
     ? result as Record<string, unknown>
     : undefined
 
-  const reviewFallbackContent = formatReviewToolFallbackContent(toolName, args || {}, resultRecord).trim()
+  if (isReviewToolName(toolName)) {
+    const reviewFallbackContent = formatReviewToolFallbackContent(toolName, args || {}, resultRecord).trim()
 
-  return {
-    reviewCardData: extractReviewCardData(toolName, args || {}, resultRecord) || undefined,
-    reviewFallbackContent: reviewFallbackContent || undefined
+    return {
+      reviewCardData: extractReviewCardData(toolName, args || {}, resultRecord) || undefined,
+      reviewFallbackContent: reviewFallbackContent || undefined
+    }
   }
+
+  if (isProgressToolName(toolName)) {
+    const progressFallbackContent = formatProgressToolFallbackContent(toolName, args || {}, resultRecord).trim()
+
+    return {
+      progressCardData: extractProgressCardData(toolName, args || {}, resultRecord) || undefined,
+      progressFallbackContent: progressFallbackContent || undefined
+    }
+  }
+
+  return {}
 }
 
 function collectPartFunctionResponseMatches(parts?: ContentPart[]): Map<string, FunctionResponseMatch> {

--- a/frontend/src/i18n/langs/en.ts
+++ b/frontend/src/i18n/langs/en.ts
@@ -537,6 +537,22 @@ const en: LanguageMessages = {
                     label: 'Update Design',
                     fallbackTitle: 'Design'
                 },
+                createProgress: {
+                    label: 'Create Progress',
+                    fallbackTitle: 'Project Progress'
+                },
+                updateProgress: {
+                    label: 'Update Progress',
+                    fallbackTitle: 'Project Progress'
+                },
+                validateProgressDocument: {
+                    label: 'Validate Progress Document',
+                    fallbackTitle: 'Progress Validation'
+                },
+                recordProgressMilestone: {
+                    label: 'Record Progress Milestone',
+                    fallbackTitle: 'Progress Milestone'
+                },
                 createReview: {
                     label: 'Create Review',
                     fallbackTitle: 'Review'
@@ -701,6 +717,53 @@ const en: LanguageMessages = {
                     generatingPlan: 'Generating Plan...',
                     planGenerated: 'Plan Generated',
                     generatePlanFailed: 'Failed to generate plan'
+                },
+                progressCard: {
+                    sourceCreate: 'Create',
+                    sourceUpdate: 'Update',
+                    sourceMilestone: 'Milestone',
+                    sourceValidate: 'Validate',
+                    defaultTitle: 'Project Progress',
+                    validation: 'Validation',
+                    validationInvalid: 'Invalid',
+                    validationWarning: 'Warnings',
+                    validationValid: 'Valid',
+                    issueError: 'Error',
+                    issueWarning: 'Warning',
+                    issueSummary: '{count} issues · {errors} errors · {warnings} warnings',
+                    status: 'Status',
+                    phase: 'Phase',
+                    statusActive: 'Active',
+                    statusBlocked: 'Blocked',
+                    statusCompleted: 'Completed',
+                    statusArchived: 'Archived',
+                    phaseDesign: 'Design',
+                    phasePlan: 'Plan',
+                    phaseImplementation: 'Implementation',
+                    phaseReview: 'Review',
+                    phaseMaintenance: 'Maintenance',
+                    milestoneStatusCompleted: 'Completed',
+                    milestoneStatusInProgress: 'In Progress',
+                    currentFocus: 'Current Focus',
+                    currentProgress: 'Current Progress',
+                    latestConclusion: 'Latest Conclusion',
+                    currentBlocker: 'Current Blocker',
+                    nextAction: 'Next Action',
+                    updatedAt: 'Updated At',
+                    milestones: 'Milestones',
+                    todos: 'TODOs',
+                    activeRisks: 'Active Risks',
+                    activeArtifacts: 'Related Artifacts',
+                    activeDesign: 'Design',
+                    activePlan: 'Plan',
+                    activeReview: 'Review',
+                    latestMilestone: 'Latest Milestone',
+                    openFile: 'Open Document',
+                    openFileFailed: 'Failed to open progress document',
+                    copyFailed: 'Failed to copy path',
+                    copyPath: 'Copy Path',
+                    copied: 'Copied',
+                    rawResult: 'Full Result'
                 }
             },
             attachment: {

--- a/frontend/src/i18n/langs/ja.ts
+++ b/frontend/src/i18n/langs/ja.ts
@@ -537,6 +537,22 @@ const ja: LanguageMessages = {
                     label: '設計を更新',
                     fallbackTitle: '設計'
                 },
+                createProgress: {
+                    label: '進捗を作成',
+                    fallbackTitle: 'プロジェクト進捗'
+                },
+                updateProgress: {
+                    label: '進捗を更新',
+                    fallbackTitle: 'プロジェクト進捗'
+                },
+                validateProgressDocument: {
+                    label: '進捗文書を検証',
+                    fallbackTitle: '進捗検証'
+                },
+                recordProgressMilestone: {
+                    label: '進捗マイルストーンを記録',
+                    fallbackTitle: '進捗マイルストーン'
+                },
                 createReview: {
                     label: 'レビュー文書を作成',
                     fallbackTitle: 'レビュー'
@@ -701,6 +717,53 @@ const ja: LanguageMessages = {
                     generatingPlan: 'プランを生成中...',
                     planGenerated: 'プラン生成済み',
                     generatePlanFailed: 'プラン生成に失敗しました'
+                },
+                progressCard: {
+                    sourceCreate: '作成',
+                    sourceUpdate: '更新',
+                    sourceMilestone: 'マイルストーン',
+                    sourceValidate: '検証',
+                    defaultTitle: 'プロジェクト進捗',
+                    validation: '検証情報',
+                    validationInvalid: '無効',
+                    validationWarning: '警告あり',
+                    validationValid: '正常',
+                    issueError: 'エラー',
+                    issueWarning: '警告',
+                    issueSummary: '{count} 件の問題 · エラー {errors} · 警告 {warnings}',
+                    status: '状態',
+                    phase: '段階',
+                    statusActive: '進行中',
+                    statusBlocked: 'ブロック中',
+                    statusCompleted: '完了',
+                    statusArchived: 'アーカイブ済み',
+                    phaseDesign: '設計',
+                    phasePlan: '計画',
+                    phaseImplementation: '実装',
+                    phaseReview: 'レビュー',
+                    phaseMaintenance: '保守',
+                    milestoneStatusCompleted: '完了',
+                    milestoneStatusInProgress: '進行中',
+                    currentFocus: '現在の焦点',
+                    currentProgress: '現在の進捗',
+                    latestConclusion: '最新の結論',
+                    currentBlocker: '現在のブロッカー',
+                    nextAction: '次の対応',
+                    updatedAt: '更新日時',
+                    milestones: 'マイルストーン',
+                    todos: 'TODO',
+                    activeRisks: 'アクティブなリスク',
+                    activeArtifacts: '関連文書',
+                    activeDesign: '設計',
+                    activePlan: '計画',
+                    activeReview: 'レビュー',
+                    latestMilestone: '最新マイルストーン',
+                    openFile: '文書を開く',
+                    openFileFailed: '進捗文書を開けませんでした',
+                    copyFailed: 'パスのコピーに失敗しました',
+                    copyPath: 'パスをコピー',
+                    copied: 'コピー済み',
+                    rawResult: '完全な結果'
                 }
             },
             attachment: {

--- a/frontend/src/i18n/langs/zh-CN.ts
+++ b/frontend/src/i18n/langs/zh-CN.ts
@@ -537,6 +537,22 @@ const zhCN: LanguageMessages = {
                     label: '更新设计',
                     fallbackTitle: '设计'
                 },
+                createProgress: {
+                    label: '创建进度',
+                    fallbackTitle: '项目进度'
+                },
+                updateProgress: {
+                    label: '更新进度',
+                    fallbackTitle: '项目进度'
+                },
+                validateProgressDocument: {
+                    label: '校验进度文档',
+                    fallbackTitle: '进度校验'
+                },
+                recordProgressMilestone: {
+                    label: '记录进度里程碑',
+                    fallbackTitle: '进度里程碑'
+                },
                 createReview: {
                     label: '创建审查文档',
                     fallbackTitle: '审查'
@@ -701,6 +717,53 @@ const zhCN: LanguageMessages = {
                     generatingPlan: '生成计划中...',
                     planGenerated: '已生成计划',
                     generatePlanFailed: '生成计划失败'
+                },
+                progressCard: {
+                    sourceCreate: '创建',
+                    sourceUpdate: '更新',
+                    sourceMilestone: '里程碑',
+                    sourceValidate: '校验',
+                    defaultTitle: '项目进度',
+                    validation: '校验信息',
+                    validationInvalid: '无效',
+                    validationWarning: '有警告',
+                    validationValid: '正常',
+                    issueError: '错误',
+                    issueWarning: '警告',
+                    issueSummary: '{count} 个问题 · 错误 {errors} · 警告 {warnings}',
+                    status: '状态',
+                    phase: '阶段',
+                    statusActive: '进行中',
+                    statusBlocked: '阻塞',
+                    statusCompleted: '已完成',
+                    statusArchived: '已归档',
+                    phaseDesign: '设计',
+                    phasePlan: '计划',
+                    phaseImplementation: '实现',
+                    phaseReview: '审查',
+                    phaseMaintenance: '维护',
+                    milestoneStatusCompleted: '已完成',
+                    milestoneStatusInProgress: '进行中',
+                    currentFocus: '当前焦点',
+                    currentProgress: '当前进度',
+                    latestConclusion: '最新结论',
+                    currentBlocker: '当前阻塞',
+                    nextAction: '下一步',
+                    updatedAt: '更新时间',
+                    milestones: '里程碑',
+                    todos: 'TODO',
+                    activeRisks: '活跃风险',
+                    activeArtifacts: '关联文档',
+                    activeDesign: '设计',
+                    activePlan: '计划',
+                    activeReview: '审查',
+                    latestMilestone: '最新里程碑',
+                    openFile: '打开文档',
+                    openFileFailed: '打开进度文档失败',
+                    copyFailed: '复制路径失败',
+                    copyPath: '复制路径',
+                    copied: '已复制',
+                    rawResult: '完整结果'
                 }
             },
             attachment: {

--- a/frontend/src/i18n/types.ts
+++ b/frontend/src/i18n/types.ts
@@ -459,6 +459,22 @@ export interface LanguageMessages {
                     label: string;
                     fallbackTitle: string;
                 };
+                createProgress: {
+                    label: string;
+                    fallbackTitle: string;
+                };
+                updateProgress: {
+                    label: string;
+                    fallbackTitle: string;
+                };
+                validateProgressDocument: {
+                    label: string;
+                    fallbackTitle: string;
+                };
+                recordProgressMilestone: {
+                    label: string;
+                    fallbackTitle: string;
+                };
                 createReview: {
                     label: string;
                     fallbackTitle: string;
@@ -623,6 +639,53 @@ export interface LanguageMessages {
                     generatingPlan: string;
                     planGenerated: string;
                     generatePlanFailed: string;
+                };
+                progressCard: {
+                    sourceCreate: string;
+                    sourceUpdate: string;
+                    sourceMilestone: string;
+                    sourceValidate: string;
+                    defaultTitle: string;
+                    validation: string;
+                    validationInvalid: string;
+                    validationWarning: string;
+                    validationValid: string;
+                    issueError: string;
+                    issueWarning: string;
+                    issueSummary: string;
+                    status: string;
+                    phase: string;
+                    statusActive: string;
+                    statusBlocked: string;
+                    statusCompleted: string;
+                    statusArchived: string;
+                    phaseDesign: string;
+                    phasePlan: string;
+                    phaseImplementation: string;
+                    phaseReview: string;
+                    phaseMaintenance: string;
+                    milestoneStatusCompleted: string;
+                    milestoneStatusInProgress: string;
+                    currentFocus: string;
+                    currentProgress: string;
+                    latestConclusion: string;
+                    currentBlocker: string;
+                    nextAction: string;
+                    updatedAt: string;
+                    milestones: string;
+                    todos: string;
+                    activeRisks: string;
+                    activeArtifacts: string;
+                    activeDesign: string;
+                    activePlan: string;
+                    activeReview: string;
+                    latestMilestone: string;
+                    openFile: string;
+                    openFileFailed: string;
+                    copyFailed: string;
+                    copyPath: string;
+                    copied: string;
+                    rawResult: string;
                 };
             };
             attachment: {

--- a/frontend/src/utils/progressCards.ts
+++ b/frontend/src/utils/progressCards.ts
@@ -1,0 +1,274 @@
+import { extractPreviewText, isProgressDocPath } from './taskCards'
+
+export type ProgressToolName =
+  | 'create_progress'
+  | 'update_progress'
+  | 'record_progress_milestone'
+  | 'validate_progress_document'
+
+export type ProgressCardStatus = 'active' | 'blocked' | 'completed' | 'archived'
+export type ProgressCardPhase = 'design' | 'plan' | 'implementation' | 'review' | 'maintenance'
+export type ProgressCardMilestoneStatus = 'in_progress' | 'completed'
+export type ProgressValidationIssueSeverity = 'error' | 'warning'
+
+export interface ProgressCardValidationIssue {
+  severity?: ProgressValidationIssueSeverity
+  code?: string
+  message: string
+}
+
+export interface ProgressCardData {
+  path?: string
+  title?: string
+  projectId?: string
+  projectName?: string
+  status?: ProgressCardStatus
+  phase?: ProgressCardPhase
+  currentFocus?: string
+  currentProgress?: string
+  latestConclusion?: string
+  latestConclusionPreview?: string
+  currentBlocker?: string
+  currentBlockerPreview?: string
+  nextAction?: string
+  nextActionPreview?: string
+  updatedAt?: string
+  milestonesTotal?: number
+  milestonesCompleted?: number
+  todosTotal?: number
+  todosCompleted?: number
+  todosInProgress?: number
+  todosCancelled?: number
+  activeRisks?: number
+  activeDesignPath?: string
+  activePlanPath?: string
+  activeReviewPath?: string
+  latestMilestoneId?: string
+  latestMilestoneTitle?: string
+  latestMilestoneStatus?: ProgressCardMilestoneStatus
+  latestMilestoneRecordedAt?: string
+  isValid?: boolean
+  formatVersion?: number | null
+  issueCount?: number
+  errorCount?: number
+  warningCount?: number
+  issues?: ProgressCardValidationIssue[]
+  sourceTool: ProgressToolName
+}
+
+type LooseRecord = Record<string, unknown>
+
+const PROGRESS_TOOL_NAMES = new Set<ProgressToolName>([
+  'create_progress',
+  'update_progress',
+  'record_progress_milestone',
+  'validate_progress_document'
+])
+
+function asRecord(value: unknown): LooseRecord | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as LooseRecord
+    : undefined
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim()
+  return normalized || undefined
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return undefined
+}
+
+function normalizeStatus(value: unknown): ProgressCardStatus | undefined {
+  return value === 'active' || value === 'blocked' || value === 'completed' || value === 'archived'
+    ? value
+    : undefined
+}
+
+function normalizePhase(value: unknown): ProgressCardPhase | undefined {
+  return value === 'design' || value === 'plan' || value === 'implementation' || value === 'review' || value === 'maintenance'
+    ? value
+    : undefined
+}
+
+function normalizeMilestoneStatus(value: unknown): ProgressCardMilestoneStatus | undefined {
+  return value === 'in_progress' || value === 'completed'
+    ? value
+    : undefined
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined
+}
+
+function normalizeIssues(value: unknown): ProgressCardValidationIssue[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => asRecord(item))
+    .filter((item): item is LooseRecord => !!item && !!asString(item.message))
+    .map((item) => ({
+      severity: item.severity === 'error' || item.severity === 'warning' ? item.severity : undefined,
+      code: asString(item.code),
+      message: asString(item.message) || ''
+    }))
+}
+
+function getResultData(result?: Record<string, unknown>): LooseRecord {
+  const data = asRecord((result as any)?.data)
+  return data || {}
+}
+
+function buildCurrentProgressFromSnapshot(snapshot: LooseRecord): string | undefined {
+  const stats = asRecord(snapshot.stats)
+  const latestMilestone = asRecord(snapshot.latestMilestone)
+  const total = asNumber(stats?.milestonesTotal)
+  const completed = asNumber(stats?.milestonesCompleted)
+  const latestId = asString(latestMilestone?.id)
+
+  if (typeof total === 'number' && typeof completed === 'number' && total > 0) {
+    return `${completed}/${total} 个里程碑已完成${latestId ? `；最新：${latestId}` : ''}`
+  }
+
+  return undefined
+}
+
+export function isProgressToolName(name: string): name is ProgressToolName {
+  return PROGRESS_TOOL_NAMES.has(name as ProgressToolName)
+}
+
+export function formatProgressToolFallbackContent(
+  toolName: ProgressToolName,
+  args: Record<string, unknown> = {},
+  result?: Record<string, unknown>
+): string {
+  const data = getResultData(result)
+  const snapshot = asRecord(data.progressSnapshot)
+
+  if (toolName === 'record_progress_milestone') {
+    return asString(args.summary)
+      || asString(snapshot?.latestConclusion)
+      || asString(data.latestConclusion)
+      || ''
+  }
+
+  if (toolName === 'validate_progress_document') {
+    const validation = asRecord(data.progressValidation)
+    const isValid = asBoolean(validation?.isValid)
+    const issueCount = asNumber(validation?.issueCount) || 0
+    const errorCount = asNumber(validation?.errorCount) || 0
+    const warningCount = asNumber(validation?.warningCount) || 0
+    return [
+      `Valid: ${isValid === true ? 'true' : isValid === false ? 'false' : 'unknown'}`,
+      `Issues: ${issueCount}`,
+      `Errors: ${errorCount}`,
+      `Warnings: ${warningCount}`,
+    ].join('\n')
+  }
+
+  const blocks: string[] = []
+  const currentFocus = asString(snapshot?.currentFocus) || asString(data.currentFocus) || asString(args.currentFocus)
+  const currentProgress = asString(snapshot?.currentProgress) || asString(data.currentProgress) || buildCurrentProgressFromSnapshot(snapshot || {})
+  const latestConclusion = asString(snapshot?.latestConclusion) || asString(data.latestConclusion) || asString(args.latestConclusion)
+  const currentBlocker = asString(snapshot?.currentBlocker) || asString(data.currentBlocker) || asString(args.currentBlocker)
+  const nextAction = asString(snapshot?.nextAction) || asString(data.nextAction) || asString(args.nextAction)
+
+  if (currentFocus) blocks.push(`当前焦点\n${currentFocus}`)
+  if (currentProgress) blocks.push(`当前进度\n${currentProgress}`)
+  if (latestConclusion) blocks.push(`最新结论\n${latestConclusion}`)
+  if (currentBlocker) blocks.push(`当前阻塞\n${currentBlocker}`)
+  if (nextAction) blocks.push(`下一步\n${nextAction}`)
+
+  return blocks.join('\n\n')
+}
+
+export function extractProgressCardData(
+  toolName: ProgressToolName,
+  args: Record<string, unknown> = {},
+  result?: Record<string, unknown>
+): ProgressCardData | null {
+  const data = getResultData(result)
+  const snapshot = asRecord(data.progressSnapshot)
+  const stats = asRecord(snapshot?.stats || data.stats)
+  const activeArtifacts = asRecord(snapshot?.activeArtifacts || data.activeArtifacts)
+  const validation = asRecord(data.progressValidation)
+  const latestMilestone = asRecord(snapshot?.latestMilestone || data.latestMilestone)
+
+  const rawPath = asString(data.path) || asString(snapshot?.path) || asString(args.path) || '.limcode/progress.md'
+  const path = isProgressDocPath(rawPath) ? rawPath : undefined
+
+  const projectName = asString(snapshot?.projectName) || asString(data.projectName) || asString(args.projectName)
+  const projectId = asString(snapshot?.projectId) || asString(data.projectId) || asString(args.projectId)
+  const title = projectName || projectId || undefined
+
+  const latestConclusion = asString(snapshot?.latestConclusion) || asString(data.latestConclusion) || asString(args.latestConclusion)
+  const currentBlocker = asString(snapshot?.currentBlocker) || asString(data.currentBlocker) || asString(args.currentBlocker)
+  const nextAction = asString(snapshot?.nextAction) || asString(data.nextAction) || asString(args.nextAction)
+
+  const card: ProgressCardData = {
+    path,
+    title,
+    projectId,
+    projectName,
+    status: normalizeStatus(snapshot?.status || data.status),
+    phase: normalizePhase(snapshot?.phase || data.phase),
+    currentFocus: asString(snapshot?.currentFocus) || asString(data.currentFocus) || asString(args.currentFocus),
+    currentProgress: asString(snapshot?.currentProgress) || asString(data.currentProgress) || buildCurrentProgressFromSnapshot(snapshot || {}),
+    latestConclusion,
+    latestConclusionPreview: latestConclusion
+      ? extractPreviewText(latestConclusion, { maxLines: 3, maxChars: 220 })
+      : undefined,
+    currentBlocker,
+    currentBlockerPreview: currentBlocker
+      ? extractPreviewText(currentBlocker, { maxLines: 2, maxChars: 180 })
+      : undefined,
+    nextAction,
+    nextActionPreview: nextAction
+      ? extractPreviewText(nextAction, { maxLines: 2, maxChars: 180 })
+      : undefined,
+    updatedAt: asString(snapshot?.updatedAt) || asString(data.updatedAt),
+    milestonesTotal: asNumber(stats?.milestonesTotal),
+    milestonesCompleted: asNumber(stats?.milestonesCompleted),
+    todosTotal: asNumber(stats?.todosTotal),
+    todosCompleted: asNumber(stats?.todosCompleted),
+    todosInProgress: asNumber(stats?.todosInProgress),
+    todosCancelled: asNumber(stats?.todosCancelled),
+    activeRisks: asNumber(stats?.activeRisks),
+    activeDesignPath: asString(activeArtifacts?.design),
+    activePlanPath: asString(activeArtifacts?.plan),
+    activeReviewPath: asString(activeArtifacts?.review),
+    latestMilestoneId: asString(latestMilestone?.id),
+    latestMilestoneTitle: asString(latestMilestone?.title),
+    latestMilestoneStatus: normalizeMilestoneStatus(latestMilestone?.status),
+    latestMilestoneRecordedAt: asString(latestMilestone?.recordedAt),
+    isValid: asBoolean(validation?.isValid ?? data.isValid),
+    formatVersion: asNumber(validation?.formatVersion ?? data.formatVersion),
+    issueCount: asNumber(validation?.issueCount ?? data.issueCount),
+    errorCount: asNumber(validation?.errorCount ?? data.errorCount),
+    warningCount: asNumber(validation?.warningCount ?? data.warningCount),
+    issues: normalizeIssues(validation?.issues || data.issues),
+    sourceTool: toolName,
+  }
+
+  const hasMeaningfulData = Boolean(
+    card.path
+    || card.title
+    || card.status
+    || card.phase
+    || card.currentFocus
+    || card.currentProgress
+    || card.latestConclusion
+    || card.currentBlocker
+    || card.nextAction
+    || typeof card.milestonesTotal === 'number'
+    || typeof card.todosTotal === 'number'
+  )
+
+  return hasMeaningfulData ? card : null
+}

--- a/frontend/src/utils/taskCards.ts
+++ b/frontend/src/utils/taskCards.ts
@@ -98,6 +98,26 @@ export function isReviewDocPath(path: string): boolean {
   return isScopedMarkdownDocPath(path, '.limcode/review/')
 }
 
+/**
+ * Whether a path looks like the fixed progress doc at .limcode/progress.md
+ * (supports multi-root prefix like "workspace/.limcode/progress.md").
+ */
+export function isProgressDocPath(path: string): boolean {
+  const normalized = (path || '').replace(/\\/g, '/')
+  const lower = normalized.toLowerCase()
+
+  if (lower === '.limcode/progress.md') return true
+
+  const slashIndex = normalized.indexOf('/')
+  if (slashIndex <= 0) return false
+
+  const workspacePrefix = normalized.slice(0, slashIndex)
+  if (workspacePrefix === '.' || workspacePrefix === '..') return false
+  if (workspacePrefix.includes(':')) return false
+
+  return normalized.slice(slashIndex + 1).toLowerCase() === '.limcode/progress.md'
+}
+
 const PLAN_SOURCE_ARTIFACT_SECTION_START = '<!-- LIMCODE_SOURCE_ARTIFACT_START -->'
 const PLAN_SOURCE_ARTIFACT_SECTION_END = '<!-- LIMCODE_SOURCE_ARTIFACT_END -->'
 

--- a/frontend/src/utils/tools/index.ts
+++ b/frontend/src/utils/tools/index.ts
@@ -59,6 +59,12 @@ import './review/validate_review_document'
 import './review/reopen_review'
 import './review/compare_review_documents'
 
+// Progress 工具
+import './progress/create_progress'
+import './progress/update_progress'
+import './progress/record_progress_milestone'
+import './progress/validate_progress_document'
+
 // History 工具
 import './history/history_search'
 

--- a/frontend/src/utils/tools/progress/create_progress.ts
+++ b/frontend/src/utils/tools/progress/create_progress.ts
@@ -1,0 +1,21 @@
+/**
+ * create_progress 工具注册（前端展示）
+ */
+
+import { registerTool } from '../../toolRegistry'
+import { t } from '../../../i18n'
+import { formatProgressToolFallbackContent } from '../../progressCards'
+
+registerTool('create_progress', {
+  name: 'create_progress',
+  label: t('components.message.tool.createProgress.label'),
+  icon: 'codicon-book',
+  descriptionFormatter: (args) => {
+    const path = (args as any)?.path as string | undefined
+    const projectName = (args as any)?.projectName as string | undefined
+    if (path && path.trim()) return path.trim()
+    if (projectName && projectName.trim()) return projectName.trim()
+    return t('components.message.tool.createProgress.fallbackTitle')
+  },
+  contentFormatter: (args, result) => formatProgressToolFallbackContent('create_progress', args, result)
+})

--- a/frontend/src/utils/tools/progress/record_progress_milestone.ts
+++ b/frontend/src/utils/tools/progress/record_progress_milestone.ts
@@ -1,0 +1,21 @@
+/**
+ * record_progress_milestone 工具注册（前端展示）
+ */
+
+import { registerTool } from '../../toolRegistry'
+import { t } from '../../../i18n'
+import { formatProgressToolFallbackContent } from '../../progressCards'
+
+registerTool('record_progress_milestone', {
+  name: 'record_progress_milestone',
+  label: t('components.message.tool.recordProgressMilestone.label'),
+  icon: 'codicon-checklist',
+  descriptionFormatter: (args) => {
+    const title = (args as any)?.title as string | undefined
+    const path = (args as any)?.path as string | undefined
+    if (title && title.trim()) return title.trim()
+    if (path && path.trim()) return path.trim()
+    return t('components.message.tool.recordProgressMilestone.fallbackTitle')
+  },
+  contentFormatter: (args, result) => formatProgressToolFallbackContent('record_progress_milestone', args, result)
+})

--- a/frontend/src/utils/tools/progress/update_progress.ts
+++ b/frontend/src/utils/tools/progress/update_progress.ts
@@ -1,0 +1,21 @@
+/**
+ * update_progress 工具注册（前端展示）
+ */
+
+import { registerTool } from '../../toolRegistry'
+import { t } from '../../../i18n'
+import { formatProgressToolFallbackContent } from '../../progressCards'
+
+registerTool('update_progress', {
+  name: 'update_progress',
+  label: t('components.message.tool.updateProgress.label'),
+  icon: 'codicon-sync',
+  descriptionFormatter: (args) => {
+    const path = (args as any)?.path as string | undefined
+    const currentFocus = (args as any)?.currentFocus as string | undefined
+    if (path && path.trim()) return path.trim()
+    if (currentFocus && currentFocus.trim()) return currentFocus.trim()
+    return t('components.message.tool.updateProgress.fallbackTitle')
+  },
+  contentFormatter: (args, result) => formatProgressToolFallbackContent('update_progress', args, result)
+})

--- a/frontend/src/utils/tools/progress/validate_progress_document.ts
+++ b/frontend/src/utils/tools/progress/validate_progress_document.ts
@@ -1,0 +1,19 @@
+/**
+ * validate_progress_document 工具注册（前端展示）
+ */
+
+import { registerTool } from '../../toolRegistry'
+import { t } from '../../../i18n'
+import { formatProgressToolFallbackContent } from '../../progressCards'
+
+registerTool('validate_progress_document', {
+  name: 'validate_progress_document',
+  label: t('components.message.tool.validateProgressDocument.label'),
+  icon: 'codicon-verified',
+  descriptionFormatter: (args) => {
+    const path = (args as any)?.path as string | undefined
+    if (path && path.trim()) return path.trim()
+    return t('components.message.tool.validateProgressDocument.fallbackTitle')
+  },
+  contentFormatter: (args, result) => formatProgressToolFallbackContent('validate_progress_document', args, result)
+})

--- a/test/unit/settings/progressToolModeConfig.test.ts
+++ b/test/unit/settings/progressToolModeConfig.test.ts
@@ -1,0 +1,71 @@
+import { SettingsManager, type SettingsStorage } from '../../../backend/modules/settings/SettingsManager'
+import {
+  ASK_PROMPT_MODE,
+  DESIGN_PROMPT_MODE,
+  PLAN_PROMPT_MODE,
+  REVIEW_PROMPT_MODE,
+} from '../../../backend/modules/settings/types'
+
+class MemorySettingsStorage implements SettingsStorage {
+  constructor(private readonly loaded: any = null) {}
+
+  async load() {
+    return this.loaded
+  }
+
+  async save() {
+    return undefined
+  }
+}
+
+const PROGRESS_TOOLS = ['create_progress', 'update_progress', 'record_progress_milestone', 'validate_progress_document']
+
+describe('progress tool mode config', () => {
+  it('adds progress tools to design, plan, and review modes but not ask mode', () => {
+    expect(DESIGN_PROMPT_MODE.toolPolicy).toEqual(expect.arrayContaining(PROGRESS_TOOLS))
+    expect(PLAN_PROMPT_MODE.toolPolicy).toEqual(expect.arrayContaining(PROGRESS_TOOLS))
+    expect(REVIEW_PROMPT_MODE.toolPolicy).toEqual(expect.arrayContaining(PROGRESS_TOOLS))
+
+    for (const toolName of PROGRESS_TOOLS) {
+      expect(ASK_PROMPT_MODE.toolPolicy).not.toContain(toolName)
+    }
+  })
+
+  it('SettingsManager synchronizes built-in mode toolPolicy updates for progress tools', async () => {
+    const storage = new MemorySettingsStorage({
+      toolsConfig: {
+        system_prompt: {
+          currentModeId: 'code',
+          modes: {
+            code: { id: 'code', name: 'Code', icon: 'code', template: 'code', dynamicTemplateEnabled: true, dynamicTemplate: '' },
+            design: {
+              ...DESIGN_PROMPT_MODE,
+              toolPolicy: ['read_file']
+            },
+            plan: {
+              ...PLAN_PROMPT_MODE,
+              toolPolicy: ['read_file']
+            },
+            ask: {
+              ...ASK_PROMPT_MODE,
+              toolPolicy: ['read_file', 'create_progress']
+            },
+            review: {
+              ...REVIEW_PROMPT_MODE,
+              toolPolicy: ['read_file']
+            }
+          }
+        }
+      }
+    })
+
+    const manager = new SettingsManager(storage)
+    await manager.initialize()
+
+    const config = manager.getSystemPromptConfig()
+    expect(config.modes.design.toolPolicy).toEqual(DESIGN_PROMPT_MODE.toolPolicy)
+    expect(config.modes.plan.toolPolicy).toEqual(PLAN_PROMPT_MODE.toolPolicy)
+    expect(config.modes.review.toolPolicy).toEqual(REVIEW_PROMPT_MODE.toolPolicy)
+    expect(config.modes.ask.toolPolicy).toEqual(ASK_PROMPT_MODE.toolPolicy)
+  })
+})

--- a/test/unit/settings/reviewModeConfig.test.ts
+++ b/test/unit/settings/reviewModeConfig.test.ts
@@ -1,0 +1,98 @@
+import { SettingsManager, type SettingsStorage } from '../../../backend/modules/settings/SettingsManager'
+import {
+  DEFAULT_SYSTEM_PROMPT_CONFIG,
+  REVIEW_MODE_ID,
+  REVIEW_MODE_TEMPLATE,
+  REVIEW_MODE_TOOL_POLICY,
+  REVIEW_PROMPT_MODE
+} from '../../../backend/modules/settings/types'
+
+class MemorySettingsStorage implements SettingsStorage {
+  constructor(private readonly loaded: any = null) {}
+
+  async load() {
+    return this.loaded
+  }
+
+  async save() {
+    return undefined
+  }
+}
+
+describe('review mode config', () => {
+  it('adds review mode to the default system prompt config', () => {
+    expect(DEFAULT_SYSTEM_PROMPT_CONFIG.modes[REVIEW_MODE_ID]).toEqual(REVIEW_PROMPT_MODE)
+    expect(REVIEW_PROMPT_MODE.toolPolicy).toEqual([
+      'read_file',
+      'list_files',
+      'find_files',
+      'search_in_files',
+      'goto_definition',
+      'find_references',
+      'get_symbols',
+      'history_search',
+      'subagents',
+      'create_review',
+      'validate_review_document',
+      'create_progress',
+      'update_progress',
+      'record_progress_milestone',
+      'validate_progress_document',
+      'record_review_milestone',
+      'finalize_review',
+      'reopen_review'
+    ])
+    expect(REVIEW_PROMPT_MODE.toolPolicy).toEqual(REVIEW_MODE_TOOL_POLICY)
+    expect(REVIEW_MODE_TEMPLATE).toContain('do the work incrementally instead of reading everything first and writing the review only at the end')
+    expect(REVIEW_MODE_TEMPLATE).toContain('Do not postpone review writing until after you have read the entire target area or the entire workspace.')
+    expect(REVIEW_MODE_TEMPLATE).toContain('Work step by step: after you finish reviewing one meaningful module-level or system-level review unit')
+    expect(REVIEW_MODE_TEMPLATE).toContain('Do not batch many completed modules into one delayed update.')
+    expect(REVIEW_PROMPT_MODE.template).toContain('do the work incrementally instead of reading everything first and writing the review only at the end')
+    expect(REVIEW_PROMPT_MODE.template).toContain('Do not postpone review writing until after you have read the entire target area or the entire workspace.')
+    expect(REVIEW_PROMPT_MODE.template).toContain('Work step by step: after you finish reviewing one meaningful module-level or system-level review unit')
+    expect(REVIEW_PROMPT_MODE.template).toContain('Do not batch many completed modules into one delayed update.')
+  })
+
+  it('SettingsManager fills missing review mode and synchronizes toolPolicy', async () => {
+    const storage = new MemorySettingsStorage({
+      toolsConfig: {
+        system_prompt: {
+          currentModeId: 'code',
+          modes: {
+            code: DEFAULT_SYSTEM_PROMPT_CONFIG.modes.code,
+            design: DEFAULT_SYSTEM_PROMPT_CONFIG.modes.design,
+            plan: DEFAULT_SYSTEM_PROMPT_CONFIG.modes.plan,
+            ask: DEFAULT_SYSTEM_PROMPT_CONFIG.modes.ask,
+            review: {
+              ...REVIEW_PROMPT_MODE,
+              toolPolicy: ['read_file']
+            }
+          }
+        }
+      }
+    })
+
+    const manager = new SettingsManager(storage)
+    await manager.initialize()
+
+    const config = manager.getSystemPromptConfig()
+    expect(config.modes.review).toBeDefined()
+    expect(config.modes.review.toolPolicy).toEqual(REVIEW_PROMPT_MODE.toolPolicy)
+  })
+
+  it('SettingsManager migrates old configs by adding review mode', async () => {
+    const storage = new MemorySettingsStorage({
+      toolsConfig: {
+        system_prompt: {
+          template: 'legacy'
+        }
+      }
+    })
+
+    const manager = new SettingsManager(storage)
+    await manager.initialize()
+
+    const config = manager.getSystemPromptConfig()
+    expect(config.modes.review).toEqual(REVIEW_PROMPT_MODE)
+  })
+})

--- a/test/unit/tools/buildResponseViewerData.progress.test.ts
+++ b/test/unit/tools/buildResponseViewerData.progress.test.ts
@@ -1,0 +1,160 @@
+import { buildResponseViewerData } from '../../../frontend/src/components/message/responseViewer/buildResponseViewerData'
+import type { Message, ToolUsage } from '../../../frontend/src/types'
+
+describe('buildResponseViewerData progress integration', () => {
+  function createAssistantMessage(overrides: Partial<Message> = {}): Message {
+    return {
+      id: 'assistant-message',
+      role: 'assistant',
+      content: '',
+      timestamp: 1710000000000,
+      parts: [],
+      tools: [],
+      ...overrides
+    }
+  }
+
+  it('builds progress card data from direct tool results', () => {
+    const tool: ToolUsage = {
+      id: 'progress-tool-1',
+      name: 'record_progress_milestone',
+      status: 'success',
+      args: {
+        title: '完成后端基础层',
+        summary: '已完成 schema 与工具骨架。'
+      },
+      result: {
+        success: true,
+        data: {
+          path: '.limcode/progress.md',
+          progressSnapshot: {
+            formatVersion: 1,
+            kind: 'limcode.progress',
+            path: '.limcode/progress.md',
+            projectId: 'workspace',
+            projectName: 'Workspace',
+            status: 'active',
+            phase: 'implementation',
+            currentFocus: '实现 Progress 工具',
+            currentProgress: '1/1 个里程碑已完成；最新：PG1',
+            latestConclusion: '后端基础层已经完成。',
+            currentBlocker: null,
+            nextAction: '开始接入前端摘要卡片。',
+            updatedAt: '2026-04-03T12:00:00.000Z',
+            activeArtifacts: {
+              plan: '.limcode/plans/project-progress-document-tools-and-summary-card.plan.md'
+            },
+            stats: {
+              milestonesTotal: 1,
+              milestonesCompleted: 1,
+              todosTotal: 4,
+              todosCompleted: 1,
+              todosInProgress: 2,
+              todosCancelled: 0,
+              activeRisks: 0
+            },
+            latestMilestone: {
+              id: 'PG1',
+              title: '完成后端基础层',
+              status: 'completed',
+              recordedAt: '2026-04-03T12:00:00.000Z'
+            }
+          }
+        }
+      }
+    }
+
+    const viewerData = buildResponseViewerData(createAssistantMessage({ tools: [tool] }))
+    const progressTool = viewerData.common.tools[0]
+
+    expect(progressTool.resultSource).toBe('tool')
+    expect(progressTool.progressCardData).toMatchObject({
+      path: '.limcode/progress.md',
+      title: 'Workspace',
+      phase: 'implementation',
+      currentProgress: '1/1 个里程碑已完成；最新：PG1',
+      latestMilestoneId: 'PG1',
+      sourceTool: 'record_progress_milestone'
+    })
+    expect(progressTool.progressFallbackContent).toContain('已完成 schema 与工具骨架。')
+  })
+
+  it('builds progress validation card data from hidden function response messages', () => {
+    const assistantMessage = createAssistantMessage({
+      id: 'assistant-message-2',
+      tools: [{
+        id: 'progress-tool-2',
+        name: 'validate_progress_document',
+        args: {
+          path: '.limcode/progress.md'
+        }
+      }]
+    })
+
+    const hiddenFunctionResponseMessage: Message = {
+      id: 'function-response-message',
+      role: 'tool',
+      content: '',
+      timestamp: 1710000000500,
+      backendIndex: 18,
+      isFunctionResponse: true,
+      parts: [{
+        functionResponse: {
+          id: 'progress-tool-2',
+          name: 'validate_progress_document',
+          response: {
+            success: true,
+            data: {
+              path: '.limcode/progress.md',
+              progressValidation: {
+                isValid: true,
+                formatVersion: 1,
+                issueCount: 0,
+                errorCount: 0,
+                warningCount: 0,
+                issues: []
+              },
+              progressSnapshot: {
+                formatVersion: 1,
+                kind: 'limcode.progress',
+                path: '.limcode/progress.md',
+                projectId: 'workspace',
+                projectName: 'Workspace',
+                status: 'active',
+                phase: 'plan',
+                currentProgress: '尚无里程碑记录',
+                updatedAt: '2026-04-03T12:30:00.000Z',
+                activeArtifacts: {},
+                stats: {
+                  milestonesTotal: 0,
+                  milestonesCompleted: 0,
+                  todosTotal: 0,
+                  todosCompleted: 0,
+                  todosInProgress: 0,
+                  todosCancelled: 0,
+                  activeRisks: 0
+                }
+              }
+            }
+          }
+        }
+      }]
+    }
+
+    const viewerData = buildResponseViewerData(assistantMessage, {
+      allMessages: [assistantMessage, hiddenFunctionResponseMessage]
+    })
+    const progressTool = viewerData.common.tools[0]
+
+    expect(progressTool.resultSource).toBe('hiddenFunctionResponse')
+    expect(progressTool.sourceBackendIndex).toBe(18)
+    expect(progressTool.progressCardData).toMatchObject({
+      path: '.limcode/progress.md',
+      status: 'active',
+      phase: 'plan',
+      isValid: true,
+      issueCount: 0,
+      sourceTool: 'validate_progress_document'
+    })
+  })
+})

--- a/test/unit/tools/create_design.test.ts
+++ b/test/unit/tools/create_design.test.ts
@@ -1,0 +1,82 @@
+const mockCreateDirectory = jest.fn().mockResolvedValue(undefined)
+const mockWriteFile = jest.fn().mockResolvedValue(undefined)
+const mockGetAllWorkspaces = jest.fn()
+const mockResolveUriWithInfo = jest.fn()
+const mockNormalizeLineEndingsToLF = jest.fn((input: string) => input.replace(/\r\n?/g, '\n'))
+const mockSyncProgressFromDesignArtifact = jest.fn().mockResolvedValue([])
+
+jest.mock('vscode', () => ({
+  workspace: {
+    fs: {
+      createDirectory: mockCreateDirectory,
+      writeFile: mockWriteFile
+    }
+  },
+  Uri: {
+    file: (fsPath: string) => ({ fsPath })
+  }
+}))
+
+jest.mock('../../../backend/tools/utils', () => ({
+  getAllWorkspaces: (...args: any[]) => mockGetAllWorkspaces(...args),
+  resolveUriWithInfo: (...args: any[]) => mockResolveUriWithInfo(...args),
+  normalizeLineEndingsToLF: (input: string) => mockNormalizeLineEndingsToLF(input)
+}))
+
+jest.mock('../../../backend/tools/progress/autoSync', () => ({
+  syncProgressFromDesignArtifact: (...args: any[]) => mockSyncProgressFromDesignArtifact(...args)
+}))
+
+import { createCreateDesignTool } from '../../../backend/tools/design/create_design'
+
+describe('create_design tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAllWorkspaces.mockReturnValue([{ name: 'workspace' }])
+    mockResolveUriWithInfo.mockReturnValue({
+      uri: { fsPath: 'D:/workspace/.limcode/design/api-design.md' },
+      error: undefined
+    })
+  })
+
+  it('writes design markdown under .limcode/design and returns requiresUserConfirmation', async () => {
+    const tool = createCreateDesignTool()
+    const result = await tool.handler({
+      title: 'API Design',
+      design: '# API Design\r\n\r\n- scope'
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.requiresUserConfirmation).toBe(true)
+    expect(result.data).toEqual({
+      path: '.limcode/design/api-design.md',
+      content: '# API Design\n\n- scope'
+    })
+
+    expect(mockCreateDirectory).toHaveBeenCalledWith({
+      fsPath: 'D:/workspace/.limcode/design'
+    })
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    expect(mockResolveUriWithInfo).toHaveBeenCalledWith('.limcode/design/api-design.md')
+    expect(mockSyncProgressFromDesignArtifact).toHaveBeenCalledWith({
+      designPath: '.limcode/design/api-design.md',
+      title: 'API Design'
+    })
+
+    const writtenBytes = mockWriteFile.mock.calls[0][1] as Uint8Array
+    expect(new TextDecoder().decode(writtenBytes)).toBe('# API Design\n\n- scope')
+  })
+
+  it('rejects paths outside .limcode/design', async () => {
+    const tool = createCreateDesignTool()
+    const result = await tool.handler({
+      design: '# Invalid',
+      path: '.limcode/plans/not-allowed.md'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('.limcode/design/**.md')
+    expect(mockResolveUriWithInfo).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/tools/create_plan.test.ts
+++ b/test/unit/tools/create_plan.test.ts
@@ -1,0 +1,126 @@
+const mockCreateDirectory = jest.fn().mockResolvedValue(undefined)
+const mockReadFile = jest.fn()
+const mockWriteFile = jest.fn().mockResolvedValue(undefined)
+const mockGetAllWorkspaces = jest.fn()
+const mockResolveUriWithInfo = jest.fn()
+const mockNormalizeLineEndingsToLF = jest.fn((input: string) => input.replace(/\r\n?/g, '\n'))
+const mockSyncProgressFromPlanArtifact = jest.fn().mockResolvedValue([])
+
+jest.mock('vscode', () => ({
+  workspace: {
+    fs: {
+      createDirectory: mockCreateDirectory,
+      readFile: mockReadFile,
+      writeFile: mockWriteFile
+    }
+  },
+  Uri: {
+    file: (fsPath: string) => ({ fsPath })
+  }
+}))
+
+jest.mock('../../../backend/tools/utils', () => ({
+  getAllWorkspaces: (...args: any[]) => mockGetAllWorkspaces(...args),
+  resolveUriWithInfo: (...args: any[]) => mockResolveUriWithInfo(...args),
+  normalizeLineEndingsToLF: (input: string) => mockNormalizeLineEndingsToLF(input)
+}))
+
+jest.mock('../../../backend/tools/progress/autoSync', () => ({
+  syncProgressFromPlanArtifact: (...args: any[]) => mockSyncProgressFromPlanArtifact(...args)
+}))
+
+import { createCreatePlanTool } from '../../../backend/tools/plan/create_plan'
+
+describe('create_plan tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAllWorkspaces.mockReturnValue([{ name: 'workspace' }])
+    mockResolveUriWithInfo.mockImplementation((targetPath: string) => ({
+      uri: { fsPath: `D:/workspace/${targetPath}` },
+      error: undefined
+    }))
+    mockReadFile.mockResolvedValue(new TextEncoder().encode('# Source Document'))
+  })
+
+  it('writes a normalized plan markdown document with TODO section and requires confirmation', async () => {
+    const tool = createCreatePlanTool()
+    const result = await tool.handler({
+      title: 'API Plan',
+      plan: '# API Plan\r\n\r\n- implement endpoint',
+      todos: [
+        { id: 'api-1', content: '实现接口', status: 'pending' },
+        { id: 'api-2', content: '补充测试', status: 'completed' }
+      ]
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.requiresUserConfirmation).toBe(true)
+    expect(result.data).toEqual({
+      path: '.limcode/plans/api-plan.plan.md',
+      content: expect.stringContaining('# API Plan\n\n- implement endpoint'),
+      todos: [
+        { id: 'api-1', content: '实现接口', status: 'pending' },
+        { id: 'api-2', content: '补充测试', status: 'completed' }
+      ],
+      sourceArtifact: undefined
+    })
+    expect((result.data as any).content).toContain('## TODO LIST')
+    expect((result.data as any).content).toContain('`#api-1`')
+    expect((result.data as any).content).toContain('`#api-2`')
+
+    expect(mockCreateDirectory).toHaveBeenCalledWith({
+      fsPath: 'D:/workspace/.limcode/plans'
+    })
+    expect(mockResolveUriWithInfo).toHaveBeenCalledWith('.limcode/plans/api-plan.plan.md')
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    expect(mockSyncProgressFromPlanArtifact).toHaveBeenCalledWith({
+      planPath: '.limcode/plans/api-plan.plan.md',
+      title: 'API Plan',
+      todos: [
+        { id: 'api-1', content: '实现接口', status: 'pending' },
+        { id: 'api-2', content: '补充测试', status: 'completed' }
+      ],
+      updateMode: 'revision'
+    })
+  })
+
+  it('writes tracked source artifact metadata when sourceArtifact is provided', async () => {
+    const tool = createCreatePlanTool()
+    const result = await tool.handler({
+      title: 'Tracked Plan',
+      plan: '# Tracked Plan\n\n- step',
+      todos: [
+        { id: 'tracked-1', content: '执行步骤', status: 'pending' }
+      ],
+      sourceArtifact: {
+        type: 'design',
+        path: '.limcode/design/tracked.md'
+      }
+    })
+
+    expect(result.success).toBe(true)
+    expect((result.data as any).sourceArtifact).toEqual({
+      type: 'design',
+      path: '.limcode/design/tracked.md',
+      contentHash: expect.stringMatching(/^sha256:/)
+    })
+    expect((result.data as any).content).toContain('<!-- LIMCODE_SOURCE_ARTIFACT_START -->')
+    expect((result.data as any).content).toContain('"type":"design"')
+    expect((result.data as any).content).toContain('"path":".limcode/design/tracked.md"')
+    expect(mockResolveUriWithInfo).toHaveBeenCalledWith('.limcode/design/tracked.md')
+  })
+
+  it('rejects paths outside .limcode/plans', async () => {
+    const tool = createCreatePlanTool()
+    const result = await tool.handler({
+      plan: '# Invalid',
+      todos: [{ id: 'x', content: 'x', status: 'pending' }],
+      path: '.limcode/design/not-allowed.md'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('.limcode/plans/**.md')
+    expect(mockResolveUriWithInfo).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/tools/create_progress.test.ts
+++ b/test/unit/tools/create_progress.test.ts
@@ -1,0 +1,133 @@
+const mockCreateDirectory = jest.fn().mockResolvedValue(undefined)
+const mockReadFile = jest.fn()
+const mockWriteFile = jest.fn().mockResolvedValue(undefined)
+const mockGetAllWorkspaces = jest.fn()
+const mockResolveUriWithInfo = jest.fn()
+const mockNormalizeLineEndingsToLF = jest.fn((input: string) => input.replace(/\r\n?/g, '\n'))
+
+jest.mock('vscode', () => ({
+  workspace: {
+    fs: {
+      createDirectory: mockCreateDirectory,
+      readFile: mockReadFile,
+      writeFile: mockWriteFile
+    }
+  },
+  Uri: {
+    file: (fsPath: string) => ({ fsPath })
+  }
+}))
+
+jest.mock('../../../backend/tools/utils', () => ({
+  getAllWorkspaces: (...args: any[]) => mockGetAllWorkspaces(...args),
+  resolveUriWithInfo: (...args: any[]) => mockResolveUriWithInfo(...args),
+  normalizeLineEndingsToLF: (input: string) => mockNormalizeLineEndingsToLF(input)
+}))
+
+import { buildProgressDocument } from '../../../backend/tools/progress/documentLayout'
+import { createCreateProgressTool } from '../../../backend/tools/progress/create_progress'
+
+describe('create_progress tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAllWorkspaces.mockReturnValue([{ name: 'workspace' }])
+    mockResolveUriWithInfo.mockImplementation((targetPath: string) => ({
+      uri: { fsPath: `D:/workspace/${targetPath}` },
+      error: undefined
+    }))
+    mockReadFile.mockRejectedValue(new Error('File not found'))
+  })
+
+  it('creates the progress document and returns a lightweight snapshot', async () => {
+    const tool = createCreateProgressTool()
+    const result = await tool.handler({
+      projectName: 'Workspace',
+      phase: 'plan',
+      currentFocus: '整理项目实现范围',
+      latestConclusion: '已确认需要新增 Progress 能力。',
+      nextAction: '开始实现后端基础结构。',
+      activeArtifacts: {
+        plan: '.limcode/plans/project-progress-document-tools-and-summary-card.plan.md'
+      },
+      todos: [
+        { id: 'progress-01', content: '实现后端基础层', status: 'pending' }
+      ],
+      risks: [
+        { id: 'risk-01', title: '范围控制', status: 'active', description: '需要避免无关范围膨胀' }
+      ]
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.requiresUserConfirmation).toBeUndefined()
+    expect(result.data).toMatchObject({
+      path: '.limcode/progress.md',
+      status: 'active',
+      phase: 'plan',
+      currentFocus: '整理项目实现范围',
+      latestConclusion: '已确认需要新增 Progress 能力。',
+      nextAction: '开始实现后端基础结构。'
+    })
+    expect((result.data as any).progressSnapshot).toMatchObject({
+      path: '.limcode/progress.md',
+      projectName: 'Workspace',
+      status: 'active',
+      phase: 'plan',
+      currentFocus: '整理项目实现范围',
+      currentProgress: '尚无里程碑记录'
+    })
+
+    expect(mockCreateDirectory).toHaveBeenCalledWith({
+      fsPath: 'D:/workspace/.limcode'
+    })
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+
+    const writtenContent = Buffer.from(mockWriteFile.mock.calls[0][1]).toString('utf-8')
+    expect(writtenContent).toContain('# 项目进度')
+    expect(writtenContent).toContain('## 当前摘要')
+    expect(writtenContent).toContain('## 关联文档')
+    expect(writtenContent).toContain('## 当前 TODO 快照')
+    expect(writtenContent).toContain('## 项目里程碑')
+    expect(writtenContent).toContain('## 风险与阻塞')
+    expect(writtenContent).toContain('## 最近更新')
+    expect(writtenContent).toContain('<!-- LIMCODE_PROGRESS_METADATA_START -->')
+  })
+
+  it('returns the existing snapshot when the progress document already exists and is valid', async () => {
+    const existing = buildProgressDocument({
+      projectId: 'workspace',
+      projectName: 'Workspace',
+      createdAt: '2026-04-03T00:00:00.000Z',
+      updatedAt: '2026-04-03T00:00:00.000Z',
+      status: 'active',
+      phase: 'design',
+      activeArtifacts: {},
+      todos: [],
+      milestones: [],
+      risks: [],
+      log: []
+    }).content
+    mockReadFile.mockResolvedValue(new TextEncoder().encode(existing))
+
+    const tool = createCreateProgressTool()
+    const result = await tool.handler({ projectName: 'Workspace' })
+
+    expect(result.success).toBe(true)
+    expect((result.data as any).progressSnapshot).toMatchObject({ path: '.limcode/progress.md', projectName: 'Workspace' })
+    expect((result.data as any).warnings).toEqual([
+      'Progress document already exists at .limcode/progress.md. Returned the existing snapshot instead of creating a second file.'
+    ])
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid paths outside .limcode/progress.md', async () => {
+    const tool = createCreateProgressTool()
+    const result = await tool.handler({
+      path: '.limcode/review/not-allowed.md'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('.limcode/progress.md')
+    expect(mockResolveUriWithInfo).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/tools/create_review.test.ts
+++ b/test/unit/tools/create_review.test.ts
@@ -1,0 +1,126 @@
+const mockCreateDirectory = jest.fn().mockResolvedValue(undefined)
+const mockWriteFile = jest.fn().mockResolvedValue(undefined)
+const mockGetAllWorkspaces = jest.fn()
+const mockResolveUriWithInfo = jest.fn()
+const mockSyncProgressFromReviewArtifact = jest.fn().mockResolvedValue([])
+
+jest.mock('vscode', () => ({
+  workspace: {
+    fs: {
+      createDirectory: mockCreateDirectory,
+      writeFile: mockWriteFile
+    }
+  },
+  Uri: {
+    file: (fsPath: string) => ({ fsPath })
+  }
+}))
+
+jest.mock('../../../backend/tools/utils', () => ({
+  getAllWorkspaces: (...args: any[]) => mockGetAllWorkspaces(...args),
+  resolveUriWithInfo: (...args: any[]) => mockResolveUriWithInfo(...args)
+}))
+
+jest.mock('../../../backend/tools/progress/autoSync', () => ({
+  syncProgressFromReviewArtifact: (...args: any[]) => mockSyncProgressFromReviewArtifact(...args)
+}))
+
+import { createCreateReviewTool } from '../../../backend/tools/review/create_review'
+
+describe('create_review tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAllWorkspaces.mockReturnValue([{ name: 'workspace' }])
+    mockResolveUriWithInfo.mockReturnValue({
+      uri: { fsPath: 'D:/workspace/.limcode/review/workspace-review.md' },
+      error: undefined
+    })
+  })
+
+  it('writes a V4 review markdown document and returns snapshot-driven summary fields', async () => {
+    const tool = createCreateReviewTool()
+    const setCustomMetadata = jest.fn().mockResolvedValue(undefined)
+    const result = await tool.handler({
+      title: 'Workspace Review',
+      overview: 'Review the current workspace end-to-end',
+      review: 'Initial review scope'
+    }, {
+      conversationId: 'conversation-1',
+      conversationStore: {
+        getCustomMetadata: jest.fn().mockResolvedValue(null),
+        setCustomMetadata
+      }
+    } as any)
+
+    expect(result.success).toBe(true)
+    expect(result.requiresUserConfirmation).toBeUndefined()
+    expect((result.data as any).path).toBe('.limcode/review/workspace-review.md')
+    expect((result.data as any).content).toContain('# Workspace Review')
+    expect((result.data as any).content).toContain('## 评审快照')
+    expect((result.data as any).content).toContain('```json')
+    expect((result.data as any).content).toContain('"formatVersion": 4')
+    expect((result.data as any).reviewSnapshot.formatVersion).toBe(4)
+    expect((result.data as any).reviewSnapshot.render.locale).toBe('zh-CN')
+    expect((result.data as any).reviewValidation.detectedFormat).toBe('v4')
+    expect((result.data as any).reviewDelta).toMatchObject({ type: 'created' })
+    expect((result.data as any).title).toBe('Workspace Review')
+    expect((result.data as any).status).toBe('in_progress')
+    expect((result.data as any).totalMilestones).toBe(0)
+    expect((result.data as any).totalFindings).toBe(0)
+
+    expect(setCustomMetadata).toHaveBeenCalledWith(
+      'conversation-1',
+      'reviewSession',
+      expect.objectContaining({
+        reviewPath: '.limcode/review/workspace-review.md',
+        status: 'in_progress'
+      })
+    )
+    expect(mockCreateDirectory).toHaveBeenCalledWith({
+      fsPath: 'D:/workspace/.limcode/review'
+    })
+    expect(mockResolveUriWithInfo).toHaveBeenCalledWith('.limcode/review/workspace-review.md')
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    expect(mockSyncProgressFromReviewArtifact).toHaveBeenCalledWith({
+      reviewPath: '.limcode/review/workspace-review.md',
+      title: 'Workspace Review',
+      eventMessage: '同步审查文档：.limcode/review/workspace-review.md'
+    })
+  })
+
+  it('rejects create_review when the conversation already has an active review session', async () => {
+    const tool = createCreateReviewTool()
+    const result = await tool.handler({
+      review: '# Review'
+    }, {
+      conversationId: 'conversation-1',
+      conversationStore: {
+        getCustomMetadata: jest.fn().mockResolvedValue({
+          reviewRunId: 'review-1',
+          reviewPath: '.limcode/review/existing.md',
+          status: 'in_progress',
+          createdAt: '2026-03-17T00:00:00.000Z',
+          finalizedAt: null
+        }),
+        setCustomMetadata: jest.fn()
+      }
+    } as any)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('active review session already exists')
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects paths outside .limcode/review', async () => {
+    const tool = createCreateReviewTool()
+    const result = await tool.handler({
+      review: '# Invalid',
+      path: '.limcode/plans/not-allowed.md'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('.limcode/review/**.md')
+    expect(mockResolveUriWithInfo).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/tools/finalize_review.test.ts
+++ b/test/unit/tools/finalize_review.test.ts
@@ -1,0 +1,127 @@
+const mockReadFile = jest.fn()
+const mockWriteFile = jest.fn().mockResolvedValue(undefined)
+const mockGetAllWorkspaces = jest.fn()
+const mockResolveUriWithInfo = jest.fn()
+const mockNormalizeLineEndingsToLF = jest.fn((input: string) => input.replace(/\r\n?/g, '\n'))
+const mockSyncProgressFromReviewArtifact = jest.fn().mockResolvedValue([])
+
+jest.mock('vscode', () => ({
+  workspace: {
+    fs: {
+      readFile: mockReadFile,
+      writeFile: mockWriteFile
+    }
+  }
+}))
+
+jest.mock('../../../backend/tools/utils', () => ({
+  getAllWorkspaces: (...args: any[]) => mockGetAllWorkspaces(...args),
+  resolveUriWithInfo: (...args: any[]) => mockResolveUriWithInfo(...args),
+  normalizeLineEndingsToLF: (input: string) => mockNormalizeLineEndingsToLF(input)
+}))
+
+jest.mock('../../../backend/tools/progress/autoSync', () => ({
+  syncProgressFromReviewArtifact: (...args: any[]) => mockSyncProgressFromReviewArtifact(...args)
+}))
+
+import { appendReviewMilestone, buildInitialReviewDocument } from '../../../backend/tools/review/reviewDocumentSection'
+import { createFinalizeReviewTool } from '../../../backend/tools/review/finalize_review'
+
+describe('finalize_review tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAllWorkspaces.mockReturnValue([{ name: 'workspace' }])
+    mockResolveUriWithInfo.mockReturnValue({
+      uri: { fsPath: 'D:/workspace/.limcode/review/workspace-review.md' },
+      error: undefined
+    })
+  })
+
+  it('finalizes a V4 review document and updates reviewSession state', async () => {
+    const initialContent = buildInitialReviewDocument({
+      title: 'Workspace Review',
+      overview: 'End-to-end review',
+      review: 'Initial scope'
+    })
+    const withMilestones = appendReviewMilestone(initialContent, {
+      milestoneTitle: 'Review tools module',
+      summary: 'Checked review tool registration.',
+      status: 'in_progress',
+      reviewedModules: ['tools'],
+      structuredFindings: [
+        {
+          severity: 'medium',
+          category: 'maintainability',
+          title: 'Need backend review tools.'
+        }
+      ]
+    }).content
+
+    mockReadFile.mockResolvedValueOnce(new TextEncoder().encode(withMilestones))
+
+    const tool = createFinalizeReviewTool()
+    const setCustomMetadata = jest.fn().mockResolvedValue(undefined)
+    const result = await tool.handler({
+      path: '.limcode/review/workspace-review.md',
+      conclusion: 'Static review passed with one medium-risk follow-up item.',
+      overallDecision: 'conditionally_accepted',
+      recommendedNextAction: 'Fix the medium-risk item and run manual browser validation.',
+      reviewedModules: ['integration']
+    }, {
+      conversationId: 'conversation-1',
+      conversationStore: {
+        getCustomMetadata: jest.fn().mockResolvedValue({
+          reviewRunId: 'review-1',
+          reviewPath: '.limcode/review/workspace-review.md',
+          status: 'in_progress',
+          createdAt: '2026-03-17T00:00:00.000Z',
+          finalizedAt: null
+        }),
+        setCustomMetadata
+      }
+    } as any)
+
+    expect(result.success).toBe(true)
+    expect((result.data as any).reviewSnapshot.status).toBe('completed')
+    expect((result.data as any).reviewSnapshot.finalizedAt).toBeTruthy()
+    expect((result.data as any).reviewSnapshot.render.locale).toBe('zh-CN')
+    expect((result.data as any).reviewDelta).toMatchObject({ type: 'finalized' })
+    expect((result.data as any).status).toBe('completed')
+    expect((result.data as any).overallDecision).toBe('conditionally_accepted')
+    expect((result.data as any).totalMilestones).toBe(1)
+    expect((result.data as any).totalFindings).toBe(1)
+    expect((result.data as any).reviewedModules).toEqual(['tools', 'integration'])
+    expect((result.data as any).content).toContain('## 最终结论')
+    expect((result.data as any).content).toContain('Static review passed with one medium-risk follow-up item.')
+    expect((result.data as any).content).toContain('## 评审快照')
+
+    expect(setCustomMetadata).toHaveBeenCalledWith(
+      'conversation-1',
+      'reviewSession',
+      expect.objectContaining({
+        reviewPath: '.limcode/review/workspace-review.md',
+        status: 'completed'
+      })
+    )
+    expect(mockSyncProgressFromReviewArtifact).toHaveBeenCalledWith({
+      reviewPath: '.limcode/review/workspace-review.md',
+      title: 'Workspace Review',
+      latestConclusion: 'Static review passed with one medium-risk follow-up item.',
+      nextAction: 'Fix the medium-risk item and run manual browser validation.',
+      eventMessage: '同步审查结论：.limcode/review/workspace-review.md'
+    })
+  })
+
+  it('rejects invalid review paths', async () => {
+    const tool = createFinalizeReviewTool()
+    const result = await tool.handler({
+      path: '.limcode/design/not-allowed.md',
+      conclusion: 'Should fail.'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('.limcode/review/**.md')
+    expect(mockResolveUriWithInfo).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/tools/progressCards.test.ts
+++ b/test/unit/tools/progressCards.test.ts
@@ -1,0 +1,217 @@
+import {
+  extractProgressCardData,
+  formatProgressToolFallbackContent
+} from '../../../frontend/src/utils/progressCards'
+
+describe('progressCards utility', () => {
+  it('extracts create_progress card data from progressSnapshot first', () => {
+    const card = extractProgressCardData(
+      'create_progress',
+      { projectName: 'Workspace' },
+      {
+        success: true,
+        data: {
+          path: '.limcode/progress.md',
+          progressSnapshot: {
+            formatVersion: 1,
+            kind: 'limcode.progress',
+            path: '.limcode/progress.md',
+            projectId: 'workspace',
+            projectName: 'Workspace',
+            status: 'active',
+            phase: 'plan',
+            currentFocus: '整理范围',
+            currentProgress: '尚无里程碑记录',
+            latestConclusion: '准备开始实现。',
+            currentBlocker: null,
+            nextAction: '开始实现后端。',
+            updatedAt: '2026-04-03T12:00:00.000Z',
+            activeArtifacts: {
+              plan: '.limcode/plans/project-progress-document-tools-and-summary-card.plan.md'
+            },
+            stats: {
+              milestonesTotal: 0,
+              milestonesCompleted: 0,
+              todosTotal: 2,
+              todosCompleted: 0,
+              todosInProgress: 1,
+              todosCancelled: 0,
+              activeRisks: 1
+            }
+          }
+        }
+      }
+    )
+
+    expect(card).toMatchObject({
+      path: '.limcode/progress.md',
+      title: 'Workspace',
+      projectId: 'workspace',
+      projectName: 'Workspace',
+      status: 'active',
+      phase: 'plan',
+      currentFocus: '整理范围',
+      currentProgress: '尚无里程碑记录',
+      latestConclusion: '准备开始实现。',
+      nextAction: '开始实现后端。',
+      milestonesTotal: 0,
+      todosTotal: 2,
+      todosInProgress: 1,
+      activeRisks: 1,
+      activePlanPath: '.limcode/plans/project-progress-document-tools-and-summary-card.plan.md',
+      sourceTool: 'create_progress'
+    })
+  })
+
+  it('extracts record_progress_milestone card data from milestone snapshot', () => {
+    const card = extractProgressCardData(
+      'record_progress_milestone',
+      { title: '完成后端基础层' },
+      {
+        success: true,
+        data: {
+          path: '.limcode/progress.md',
+          progressSnapshot: {
+            formatVersion: 1,
+            kind: 'limcode.progress',
+            path: '.limcode/progress.md',
+            projectId: 'workspace',
+            projectName: 'Workspace',
+            status: 'active',
+            phase: 'implementation',
+            currentFocus: '实现 Progress 工具',
+            currentProgress: '1/1 个里程碑已完成；最新：PG1',
+            latestConclusion: '后端基础层已经完成。',
+            nextAction: '开始接入前端摘要卡片。',
+            updatedAt: '2026-04-03T12:10:00.000Z',
+            activeArtifacts: {
+              review: '.limcode/review/project-progress-review.md'
+            },
+            stats: {
+              milestonesTotal: 1,
+              milestonesCompleted: 1,
+              todosTotal: 4,
+              todosCompleted: 1,
+              todosInProgress: 2,
+              todosCancelled: 0,
+              activeRisks: 0
+            },
+            latestMilestone: {
+              id: 'PG1',
+              title: '完成后端基础层',
+              status: 'completed',
+              recordedAt: '2026-04-03T12:10:00.000Z'
+            }
+          },
+          progressDelta: {
+            type: 'milestone_recorded',
+            milestoneId: 'PG1'
+          }
+        }
+      }
+    )
+
+    expect(card).toMatchObject({
+      path: '.limcode/progress.md',
+      status: 'active',
+      phase: 'implementation',
+      currentProgress: '1/1 个里程碑已完成；最新：PG1',
+      latestConclusion: '后端基础层已经完成。',
+      nextAction: '开始接入前端摘要卡片。',
+      milestonesTotal: 1,
+      milestonesCompleted: 1,
+      latestMilestoneId: 'PG1',
+      latestMilestoneTitle: '完成后端基础层',
+      latestMilestoneStatus: 'completed',
+      activeReviewPath: '.limcode/review/project-progress-review.md',
+      sourceTool: 'record_progress_milestone'
+    })
+    expect(card?.latestConclusionPreview).toContain('后端基础层已经完成。')
+  })
+
+  it('extracts validate_progress_document card data from validation summary', () => {
+    const card = extractProgressCardData(
+      'validate_progress_document',
+      { path: '.limcode/progress.md' },
+      {
+        success: true,
+        data: {
+          path: '.limcode/progress.md',
+          progressValidation: {
+            isValid: false,
+            formatVersion: 1,
+            issueCount: 1,
+            errorCount: 1,
+            warningCount: 0,
+            issues: [
+              { severity: 'error', code: 'progress_document_invalid', message: 'Progress document metadata block is missing or empty' }
+            ]
+          },
+          progressSnapshot: {
+            formatVersion: 1,
+            kind: 'limcode.progress',
+            path: '.limcode/progress.md',
+            projectId: 'workspace',
+            projectName: 'Workspace',
+            status: 'blocked',
+            phase: 'plan',
+            currentProgress: '尚无里程碑记录',
+            updatedAt: '2026-04-03T12:20:00.000Z',
+            activeArtifacts: {},
+            stats: { milestonesTotal: 0, milestonesCompleted: 0, todosTotal: 0, todosCompleted: 0, todosInProgress: 0, todosCancelled: 0, activeRisks: 0 }
+          }
+        }
+      }
+    )
+
+    expect(card).toMatchObject({
+      path: '.limcode/progress.md',
+      status: 'blocked',
+      phase: 'plan',
+      isValid: false,
+      issueCount: 1,
+      errorCount: 1,
+      sourceTool: 'validate_progress_document'
+    })
+    expect(card?.issues).toEqual([
+      expect.objectContaining({ code: 'progress_document_invalid', severity: 'error' })
+    ])
+  })
+
+  it('formats progress fallback content from snapshot or args', () => {
+    expect(formatProgressToolFallbackContent(
+      'update_progress',
+      {},
+      {
+        data: {
+          progressSnapshot: {
+            currentFocus: '实现前端卡片',
+            currentProgress: '1/2 个里程碑已完成；最新：PG1',
+            latestConclusion: '后端已完成。',
+            nextAction: '继续实现前端。'
+          }
+        }
+      }
+    )).toContain('实现前端卡片')
+
+    expect(formatProgressToolFallbackContent(
+      'record_progress_milestone',
+      { summary: '完成后端基础层。' }
+    )).toBe('完成后端基础层。')
+
+    expect(formatProgressToolFallbackContent(
+      'validate_progress_document',
+      {},
+      {
+        data: {
+          progressValidation: {
+            isValid: true,
+            issueCount: 0,
+            errorCount: 0,
+            warningCount: 0,
+          }
+        }
+      }
+    )).toContain('Valid: true')
+  })
+})

--- a/test/unit/tools/progressToolRegistration.test.ts
+++ b/test/unit/tools/progressToolRegistration.test.ts
@@ -1,0 +1,43 @@
+import { getToolConfig, toolRegistry } from '../../../frontend/src/utils/toolRegistry'
+
+import '../../../frontend/src/utils/tools/progress/create_progress'
+import '../../../frontend/src/utils/tools/progress/update_progress'
+import '../../../frontend/src/utils/tools/progress/record_progress_milestone'
+import '../../../frontend/src/utils/tools/progress/validate_progress_document'
+
+describe('progress tool frontend registration', () => {
+  afterAll(() => {
+    toolRegistry.unregister('create_progress')
+    toolRegistry.unregister('update_progress')
+    toolRegistry.unregister('record_progress_milestone')
+    toolRegistry.unregister('validate_progress_document')
+  })
+
+  it('registers create_progress for frontend display', () => {
+    const config = getToolConfig('create_progress')
+    expect(config).toBeDefined()
+    expect(config?.name).toBe('create_progress')
+    expect(config?.descriptionFormatter({ projectName: 'Workspace' })).toBe('Workspace')
+  })
+
+  it('registers update_progress for frontend display', () => {
+    const config = getToolConfig('update_progress')
+    expect(config).toBeDefined()
+    expect(config?.name).toBe('update_progress')
+    expect(config?.descriptionFormatter({ currentFocus: '实现前端卡片' })).toBe('实现前端卡片')
+  })
+
+  it('registers record_progress_milestone for frontend display', () => {
+    const config = getToolConfig('record_progress_milestone')
+    expect(config).toBeDefined()
+    expect(config?.name).toBe('record_progress_milestone')
+    expect(config?.descriptionFormatter({ title: '完成后端基础层' })).toBe('完成后端基础层')
+  })
+
+  it('registers validate_progress_document for frontend display', () => {
+    const config = getToolConfig('validate_progress_document')
+    expect(config).toBeDefined()
+    expect(config?.name).toBe('validate_progress_document')
+    expect(config?.descriptionFormatter({ path: '.limcode/progress.md' })).toBe('.limcode/progress.md')
+  })
+})

--- a/test/unit/tools/record_progress_milestone.test.ts
+++ b/test/unit/tools/record_progress_milestone.test.ts
@@ -1,0 +1,144 @@
+const mockCreateDirectory = jest.fn().mockResolvedValue(undefined)
+const mockReadFile = jest.fn()
+const mockWriteFile = jest.fn().mockResolvedValue(undefined)
+const mockResolveUriWithInfo = jest.fn()
+const mockNormalizeLineEndingsToLF = jest.fn((input: string) => input.replace(/\r\n?/g, '\n'))
+const mockGetAllWorkspaces = jest.fn()
+
+jest.mock('vscode', () => ({
+  workspace: {
+    fs: {
+      createDirectory: mockCreateDirectory,
+      readFile: mockReadFile,
+      writeFile: mockWriteFile
+    }
+  },
+  Uri: {
+    file: (fsPath: string) => ({ fsPath })
+  }
+}))
+
+jest.mock('../../../backend/tools/utils', () => ({
+  getAllWorkspaces: (...args: any[]) => mockGetAllWorkspaces(...args),
+  resolveUriWithInfo: (...args: any[]) => mockResolveUriWithInfo(...args),
+  normalizeLineEndingsToLF: (input: string) => mockNormalizeLineEndingsToLF(input)
+}))
+
+import { buildProgressDocument } from '../../../backend/tools/progress/documentLayout'
+import { createRecordProgressMilestoneTool } from '../../../backend/tools/progress/record_progress_milestone'
+
+describe('record_progress_milestone tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAllWorkspaces.mockReturnValue([{ name: 'workspace' }])
+    mockResolveUriWithInfo.mockImplementation((targetPath: string) => ({
+      uri: { fsPath: `D:/workspace/${targetPath}` },
+      error: undefined
+    }))
+
+    const existing = buildProgressDocument({
+      projectId: 'workspace',
+      projectName: 'Workspace',
+      createdAt: '2026-04-03T00:00:00.000Z',
+      updatedAt: '2026-04-03T00:00:00.000Z',
+      status: 'active',
+      phase: 'implementation',
+      currentFocus: '实现 Progress 工具',
+      activeArtifacts: {
+        plan: '.limcode/plans/project-progress-document-tools-and-summary-card.plan.md'
+      },
+      todos: [
+        { id: 'progress-01', content: '实现后端基础层', status: 'in_progress' }
+      ],
+      risks: [],
+      milestones: [],
+      log: []
+    }).content
+
+    mockReadFile.mockResolvedValue(new TextEncoder().encode(existing))
+  })
+
+  it('records a project milestone and returns the latest milestone snapshot', async () => {
+    const tool = createRecordProgressMilestoneTool()
+    const result = await tool.handler({
+      title: '完成后端基础层',
+      summary: '已完成 schema、documentLayout 与工具骨架。',
+      status: 'completed',
+      relatedTodoIds: ['progress-01'],
+      latestConclusion: '后端基础层已经完成。',
+      nextAction: '开始接入前端摘要卡片。'
+    })
+
+    expect(result.success).toBe(true)
+    expect((result.data as any).progressDelta).toMatchObject({
+      type: 'milestone_recorded',
+      milestoneId: 'PG1'
+    })
+    expect((result.data as any).progressSnapshot).toMatchObject({
+      path: '.limcode/progress.md',
+      currentProgress: '1/1 个里程碑已完成；最新：PG1',
+      latestConclusion: '后端基础层已经完成。',
+      nextAction: '开始接入前端摘要卡片。',
+      latestMilestone: {
+        id: 'PG1',
+        title: '完成后端基础层',
+        status: 'completed'
+      }
+    })
+
+    const writtenContent = Buffer.from(mockWriteFile.mock.calls[0][1]).toString('utf-8')
+    expect(writtenContent).toContain('### PG1 · 完成后端基础层')
+    expect(writtenContent).toContain('已完成 schema、documentLayout 与工具骨架。')
+    expect(writtenContent).toContain('后端基础层已经完成。')
+  })
+
+  it('rejects duplicate milestone ids', async () => {
+    const existing = buildProgressDocument({
+      projectId: 'workspace',
+      projectName: 'Workspace',
+      createdAt: '2026-04-03T00:00:00.000Z',
+      updatedAt: '2026-04-03T00:00:00.000Z',
+      status: 'active',
+      phase: 'implementation',
+      activeArtifacts: {},
+      todos: [],
+      risks: [],
+      milestones: [{
+        id: 'PG1',
+        title: '已有里程碑',
+        status: 'completed',
+        summary: '已有摘要',
+        relatedTodoIds: [],
+        relatedReviewMilestoneIds: [],
+        recordedAt: '2026-04-03T00:10:00.000Z',
+        nextAction: null
+      }],
+      log: []
+    }).content
+    mockReadFile.mockResolvedValue(new TextEncoder().encode(existing))
+
+    const tool = createRecordProgressMilestoneTool()
+    const result = await tool.handler({
+      milestoneId: 'PG1',
+      title: '重复里程碑',
+      summary: '不应成功'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('already exists')
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid progress path values', async () => {
+    const tool = createRecordProgressMilestoneTool()
+    const result = await tool.handler({
+      path: '.limcode/review/not-allowed.md',
+      title: '非法路径',
+      summary: '非法路径'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('.limcode/progress.md')
+    expect(mockResolveUriWithInfo).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/tools/record_review_milestone.test.ts
+++ b/test/unit/tools/record_review_milestone.test.ts
@@ -1,0 +1,198 @@
+const mockReadFile = jest.fn()
+const mockWriteFile = jest.fn().mockResolvedValue(undefined)
+const mockGetAllWorkspaces = jest.fn()
+const mockResolveUriWithInfo = jest.fn()
+const mockNormalizeLineEndingsToLF = jest.fn((input: string) => input.replace(/\r\n?/g, '\n'))
+const mockSyncProgressFromReviewArtifact = jest.fn().mockResolvedValue([])
+
+jest.mock('vscode', () => ({
+  workspace: {
+    fs: {
+      readFile: mockReadFile,
+      writeFile: mockWriteFile
+    }
+  }
+}))
+
+jest.mock('../../../backend/tools/utils', () => ({
+  getAllWorkspaces: (...args: any[]) => mockGetAllWorkspaces(...args),
+  resolveUriWithInfo: (...args: any[]) => mockResolveUriWithInfo(...args),
+  normalizeLineEndingsToLF: (input: string) => mockNormalizeLineEndingsToLF(input)
+}))
+
+jest.mock('../../../backend/tools/progress/autoSync', () => ({
+  syncProgressFromReviewArtifact: (...args: any[]) => mockSyncProgressFromReviewArtifact(...args)
+}))
+
+import { buildInitialReviewDocument } from '../../../backend/tools/review/reviewDocumentSection'
+import { createRecordReviewMilestoneTool } from '../../../backend/tools/review/record_review_milestone'
+
+describe('record_review_milestone tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAllWorkspaces.mockReturnValue([{ name: 'workspace' }])
+    mockResolveUriWithInfo.mockReturnValue({
+      uri: { fsPath: 'D:/workspace/.limcode/review/workspace-review.md' },
+      error: undefined
+    })
+  })
+
+  it('appends milestones to a V4 review document and returns snapshot-driven result fields', async () => {
+    const initialContent = buildInitialReviewDocument({
+      title: 'Workspace Review',
+      overview: 'End-to-end review',
+      review: 'Initial scope'
+    })
+
+    mockReadFile.mockResolvedValueOnce(new TextEncoder().encode(initialContent))
+
+    const tool = createRecordReviewMilestoneTool()
+    const setCustomMetadata = jest.fn().mockResolvedValue(undefined)
+
+    const result = await tool.handler({
+      path: '.limcode/review/workspace-review.md',
+      milestoneTitle: 'Review settings module',
+      summary: 'Checked mode config and sync logic.',
+      status: 'completed',
+      conclusion: 'Settings review completed',
+      evidenceFiles: ['backend/modules/settings/types.ts'],
+      reviewedModules: ['settings'],
+      recommendedNextAction: 'Review backend tools next.',
+      findings: ['Review mode is missing.'],
+      structuredFindings: [{
+        title: 'Selection context action lacks evidence details.',
+        category: 'maintainability',
+        severity: 'medium',
+        evidence: [{ path: 'frontend/src/App.vue', lineStart: 10, lineEnd: 12, symbol: 'renderApp' }]
+      }]
+    }, {
+      conversationId: 'conversation-1',
+      conversationStore: {
+        getCustomMetadata: jest.fn().mockResolvedValue({
+          reviewRunId: 'review-1',
+          reviewPath: '.limcode/review/workspace-review.md',
+          status: 'in_progress',
+          createdAt: '2026-03-17T00:00:00.000Z',
+          finalizedAt: null
+        }),
+        setCustomMetadata
+      }
+    } as any)
+
+    expect(result.success).toBe(true)
+    expect((result.data as any).milestoneId).toBe('M1')
+    expect((result.data as any).reviewSnapshot.formatVersion).toBe(4)
+    expect((result.data as any).reviewDelta).toMatchObject({
+      type: 'milestone_recorded',
+      milestoneId: 'M1'
+    })
+    expect((result.data as any).totalMilestones).toBe(1)
+    expect((result.data as any).completedMilestones).toBe(1)
+    expect((result.data as any).totalFindings).toBe(2)
+    expect((result.data as any).findingsBySeverity).toEqual({ high: 0, medium: 1, low: 1 })
+    expect((result.data as any).reviewedModules).toEqual(['settings'])
+    expect((result.data as any).reviewSnapshot.render.locale).toBe('zh-CN')
+    expect((result.data as any).content).toContain('## 评审快照')
+    expect((result.data as any).content).toContain('### M1 · Review settings module')
+    expect((result.data as any).content).toContain('### Review mode is missing.')
+    expect((result.data as any).content).toContain('- ID: F-review-mode-is-missing')
+    expect((result.data as any).content).toContain('frontend/src/App.vue:10-12#renderApp')
+
+    expect(setCustomMetadata).toHaveBeenCalledWith(
+      'conversation-1',
+      'reviewSession',
+      expect.objectContaining({
+        reviewPath: '.limcode/review/workspace-review.md',
+        status: 'in_progress'
+      })
+    )
+    expect(mockSyncProgressFromReviewArtifact).toHaveBeenCalledWith({
+      reviewPath: '.limcode/review/workspace-review.md',
+      title: 'Workspace Review',
+      latestConclusion: 'Settings review completed',
+      nextAction: 'Review backend tools next.',
+      eventMessage: '同步审查里程碑：M1'
+    })
+  })
+
+  it('upgrades legacy review documents to V4 before writing milestones', async () => {
+    mockReadFile.mockResolvedValueOnce(new TextEncoder().encode([
+      '# Review',
+      '- Date: 2025-01-01',
+      '- Overview: Manual review',
+      '- Status: in_progress',
+      '',
+      '## Review Plan',
+      'Inspect frontend output.',
+      '',
+      '## Findings',
+      '- Existing loose note',
+      ''
+    ].join('\n')))
+
+    const tool = createRecordReviewMilestoneTool()
+    const result = await tool.handler({
+      path: '.limcode/review/workspace-review.md',
+      milestoneTitle: 'Review legacy document',
+      summary: 'Backfilled structured sections.'
+    })
+
+    expect(result.success).toBe(true)
+    expect((result.data as any).reviewSnapshot.formatVersion).toBe(4)
+    expect((result.data as any).reviewValidation.detectedFormat).toBe('v4')
+    expect((result.data as any).content).toContain('## 评审范围')
+    expect((result.data as any).content).toContain('Inspect frontend output.')
+    expect((result.data as any).content).toContain('## 评审快照')
+    expect((result.data as any).content).not.toContain('## Review Plan')
+  })
+
+  it('rejects writes to finalized review documents', async () => {
+    const finalizedContent = buildInitialReviewDocument({
+      title: 'Workspace Review',
+      overview: 'End-to-end review',
+      review: 'Initial scope'
+    }).replace('"status": "in_progress"', '"status": "completed"')
+      .replace('"finalizedAt": null', '"finalizedAt": "2025-01-01T01:00:00.000Z"')
+      .replace('"latestConclusion": null', '"latestConclusion": "Done"')
+      .replace('- Status: In Progress', '- Status: Completed')
+      .replace('- Overall decision: Pending', '- Overall decision: Accepted')
+
+    mockReadFile.mockResolvedValueOnce(new TextEncoder().encode(finalizedContent))
+
+    const tool = createRecordReviewMilestoneTool()
+    const result = await tool.handler({
+      path: '.limcode/review/workspace-review.md',
+      milestoneTitle: 'Should fail',
+      summary: 'Should fail.'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('finalized review document')
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects path mismatches against the active review session', async () => {
+    const tool = createRecordReviewMilestoneTool()
+    const result = await tool.handler({
+      path: '.limcode/review/workspace-review.md',
+      milestoneTitle: 'Invalid session path',
+      summary: 'Should fail.'
+    }, {
+      conversationId: 'conversation-1',
+      conversationStore: {
+        getCustomMetadata: jest.fn().mockResolvedValue({
+          reviewRunId: 'review-1',
+          reviewPath: '.limcode/review/other-review.md',
+          status: 'in_progress',
+          createdAt: '2026-03-17T00:00:00.000Z',
+          finalizedAt: null
+        }),
+        setCustomMetadata: jest.fn()
+      }
+    } as any)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('path mismatch')
+    expect(mockReadFile).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/tools/reopen_review.test.ts
+++ b/test/unit/tools/reopen_review.test.ts
@@ -1,0 +1,140 @@
+const mockReadFile = jest.fn()
+const mockWriteFile = jest.fn().mockResolvedValue(undefined)
+const mockGetAllWorkspaces = jest.fn()
+const mockResolveUriWithInfo = jest.fn()
+const mockNormalizeLineEndingsToLF = jest.fn((input: string) => input.replace(/\r\n?/g, '\n'))
+const mockSyncProgressFromReviewArtifact = jest.fn().mockResolvedValue([])
+
+jest.mock('vscode', () => ({
+  workspace: {
+    fs: {
+      readFile: mockReadFile,
+      writeFile: mockWriteFile
+    }
+  }
+}))
+
+jest.mock('../../../backend/tools/utils', () => ({
+  getAllWorkspaces: (...args: any[]) => mockGetAllWorkspaces(...args),
+  resolveUriWithInfo: (...args: any[]) => mockResolveUriWithInfo(...args),
+  normalizeLineEndingsToLF: (input: string) => mockNormalizeLineEndingsToLF(input)
+}))
+
+jest.mock('../../../backend/tools/progress/autoSync', () => ({
+  syncProgressFromReviewArtifact: (...args: any[]) => mockSyncProgressFromReviewArtifact(...args)
+}))
+
+import {
+  appendReviewMilestone,
+  buildInitialReviewDocument,
+  finalizeReviewDocument
+} from '../../../backend/tools/review/reviewDocumentSection'
+import { createReopenReviewTool } from '../../../backend/tools/review/reopen_review'
+
+describe('reopen_review tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAllWorkspaces.mockReturnValue([{ name: 'workspace' }])
+    mockResolveUriWithInfo.mockReturnValue({
+      uri: { fsPath: 'D:/workspace/.limcode/review/workspace-review.md' },
+      error: undefined
+    })
+  })
+
+  it('reopens a completed V4 review document and updates reviewSession state', async () => {
+    const initialContent = buildInitialReviewDocument({
+      title: 'Workspace Review',
+      overview: 'End-to-end review',
+      review: 'Initial scope'
+    })
+    const withMilestone = appendReviewMilestone(initialContent, {
+      milestoneTitle: 'Review tools module',
+      summary: 'Checked review tools.',
+      status: 'completed',
+      reviewedModules: ['backend/tools/review']
+    }).content
+    const finalizedContent = finalizeReviewDocument(withMilestone, {
+      conclusion: 'Follow-up work is still required.',
+      overallDecision: 'needs_follow_up'
+    }).content
+
+    mockReadFile.mockResolvedValueOnce(new TextEncoder().encode(finalizedContent))
+
+    const tool = createReopenReviewTool()
+    const setCustomMetadata = jest.fn().mockResolvedValue(undefined)
+    const result = await tool.handler({
+      path: '.limcode/review/workspace-review.md'
+    }, {
+      conversationId: 'conversation-1',
+      conversationStore: {
+        getCustomMetadata: jest.fn().mockResolvedValue({
+          reviewRunId: 'review-1',
+          reviewPath: '.limcode/review/workspace-review.md',
+          status: 'completed',
+          createdAt: '2026-03-17T00:00:00.000Z',
+          finalizedAt: '2026-03-17T01:00:00.000Z'
+        }),
+        setCustomMetadata
+      }
+    } as any)
+
+    expect(result.success).toBe(true)
+    expect((result.data as any).reviewSnapshot.status).toBe('in_progress')
+    expect((result.data as any).reviewSnapshot.finalizedAt).toBeNull()
+    expect((result.data as any).reviewSnapshot.render.locale).toBe('zh-CN')
+    expect((result.data as any).overallDecision).toBeNull()
+    expect((result.data as any).reviewDelta).toMatchObject({ type: 'reopened' })
+    expect((result.data as any).content).toContain('- 状态: 进行中')
+    expect((result.data as any).content).toContain('- 总体结论: 待定')
+
+    expect(setCustomMetadata).toHaveBeenCalledWith(
+      'conversation-1',
+      'reviewSession',
+      expect.objectContaining({
+        reviewPath: '.limcode/review/workspace-review.md',
+        status: 'in_progress',
+        finalizedAt: null
+      })
+    )
+    expect(mockSyncProgressFromReviewArtifact).toHaveBeenCalledWith({
+      reviewPath: '.limcode/review/workspace-review.md',
+      title: 'Workspace Review',
+      eventMessage: '重新打开审查：.limcode/review/workspace-review.md'
+    })
+  })
+
+  it('rejects reopen when another active review session already exists', async () => {
+    const tool = createReopenReviewTool()
+    const result = await tool.handler({
+      path: '.limcode/review/workspace-review.md'
+    }, {
+      conversationId: 'conversation-1',
+      conversationStore: {
+        getCustomMetadata: jest.fn().mockResolvedValue({
+          reviewRunId: 'review-2',
+          reviewPath: '.limcode/review/other-review.md',
+          status: 'in_progress',
+          createdAt: '2026-03-17T00:00:00.000Z',
+          finalizedAt: null
+        }),
+        setCustomMetadata: jest.fn()
+      }
+    } as any)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Another active review session already exists')
+    expect(mockReadFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid review paths', async () => {
+    const tool = createReopenReviewTool()
+    const result = await tool.handler({
+      path: '.limcode/design/not-allowed.md'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('.limcode/review/**.md')
+    expect(mockResolveUriWithInfo).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/tools/update_design.test.ts
+++ b/test/unit/tools/update_design.test.ts
@@ -1,0 +1,94 @@
+const mockCreateDirectory = jest.fn().mockResolvedValue(undefined)
+const mockReadFile = jest.fn()
+const mockWriteFile = jest.fn().mockResolvedValue(undefined)
+const mockGetAllWorkspaces = jest.fn()
+const mockResolveUriWithInfo = jest.fn()
+const mockNormalizeLineEndingsToLF = jest.fn((input: string) => input.replace(/\r\n?/g, '\n'))
+const mockSyncProgressFromDesignArtifact = jest.fn().mockResolvedValue([])
+
+jest.mock('vscode', () => ({
+  workspace: {
+    fs: {
+      createDirectory: mockCreateDirectory,
+      readFile: mockReadFile,
+      writeFile: mockWriteFile
+    }
+  },
+  Uri: {
+    file: (fsPath: string) => ({ fsPath })
+  }
+}))
+
+jest.mock('../../../backend/tools/utils', () => ({
+  getAllWorkspaces: (...args: any[]) => mockGetAllWorkspaces(...args),
+  resolveUriWithInfo: (...args: any[]) => mockResolveUriWithInfo(...args),
+  normalizeLineEndingsToLF: (input: string) => mockNormalizeLineEndingsToLF(input)
+}))
+
+jest.mock('../../../backend/tools/progress/autoSync', () => ({
+  syncProgressFromDesignArtifact: (...args: any[]) => mockSyncProgressFromDesignArtifact(...args)
+}))
+
+import { createUpdateDesignTool } from '../../../backend/tools/design/update_design'
+
+describe('update_design tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAllWorkspaces.mockReturnValue([{ name: 'workspace' }])
+    mockResolveUriWithInfo.mockReturnValue({
+      uri: { fsPath: 'D:/workspace/.limcode/design/api-design.md' },
+      error: undefined
+    })
+    mockReadFile.mockResolvedValue(new TextEncoder().encode('# Existing Design'))
+  })
+
+  it('rewrites an existing design document and returns requiresUserConfirmation', async () => {
+    const tool = createUpdateDesignTool()
+    const result = await tool.handler({
+      path: '.limcode/design/api-design.md',
+      design: '# Revised Design\r\n\r\n- scope',
+      changeSummary: '补充边界说明'
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.requiresUserConfirmation).toBe(true)
+    expect(result.data).toEqual({
+      path: '.limcode/design/api-design.md',
+      content: '# Revised Design\n\n- scope',
+      changeSummary: '补充边界说明'
+    })
+    expect(mockReadFile).toHaveBeenCalledWith({ fsPath: 'D:/workspace/.limcode/design/api-design.md' })
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    expect(mockSyncProgressFromDesignArtifact).toHaveBeenCalledWith({
+      designPath: '.limcode/design/api-design.md',
+      title: undefined
+    })
+  })
+
+  it('rejects update_design when the target design file does not exist', async () => {
+    mockReadFile.mockRejectedValue(new Error('File not found'))
+
+    const tool = createUpdateDesignTool()
+    const result = await tool.handler({
+      path: '.limcode/design/api-design.md',
+      design: '# Revised Design'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('File not found')
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects paths outside .limcode/design', async () => {
+    const tool = createUpdateDesignTool()
+    const result = await tool.handler({
+      path: '.limcode/plans/not-allowed.md',
+      design: '# Invalid'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('.limcode/design/**.md')
+    expect(mockResolveUriWithInfo).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/tools/update_plan.test.ts
+++ b/test/unit/tools/update_plan.test.ts
@@ -4,6 +4,7 @@ const mockWriteFile = jest.fn().mockResolvedValue(undefined)
 const mockGetAllWorkspaces = jest.fn()
 const mockResolveUriWithInfo = jest.fn()
 const mockNormalizeLineEndingsToLF = jest.fn((input: string) => input.replace(/\r\n?/g, '\n'))
+const mockSyncProgressFromPlanArtifact = jest.fn().mockResolvedValue([])
 
 jest.mock('vscode', () => ({
   workspace: {
@@ -22,6 +23,10 @@ jest.mock('../../../backend/tools/utils', () => ({
   getAllWorkspaces: (...args: any[]) => mockGetAllWorkspaces(...args),
   resolveUriWithInfo: (...args: any[]) => mockResolveUriWithInfo(...args),
   normalizeLineEndingsToLF: (input: string) => mockNormalizeLineEndingsToLF(input)
+}))
+
+jest.mock('../../../backend/tools/progress/autoSync', () => ({
+  syncProgressFromPlanArtifact: (...args: any[]) => mockSyncProgressFromPlanArtifact(...args)
 }))
 
 import { createUpdatePlanTool } from '../../../backend/tools/plan/update_plan'
@@ -63,6 +68,15 @@ describe('update_plan tool', () => {
     })
     expect(mockReadFile).toHaveBeenCalledWith({ fsPath: 'D:/workspace/.limcode/plans/api.plan.md' })
     expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    expect(mockSyncProgressFromPlanArtifact).toHaveBeenCalledWith({
+      planPath: '.limcode/plans/api.plan.md',
+      title: undefined,
+      todos: [
+        { id: 'api-1', content: '更新流程', status: 'in_progress' },
+        { id: 'api-2', content: '补充测试', status: 'pending' }
+      ],
+      updateMode: 'revision'
+    })
   })
 
   it('syncs only the TODO section in progress_sync mode and does not require confirmation', async () => {
@@ -105,6 +119,14 @@ describe('update_plan tool', () => {
     expect((result.data as any).content).toContain('<!-- LIMCODE_SOURCE_ARTIFACT_START -->')
     expect((result.data as any).content).toContain('`#api-1`')
     expect((result.data as any).content).not.toContain('`#old-1`')
+    expect(mockSyncProgressFromPlanArtifact).toHaveBeenCalledWith({
+      planPath: '.limcode/plans/api.plan.md',
+      title: undefined,
+      todos: [
+        { id: 'api-1', content: '同步状态', status: 'completed' }
+      ],
+      updateMode: 'progress_sync'
+    })
   })
 
   it('rejects update_plan when the target plan file does not exist', async () => {

--- a/test/unit/tools/update_progress.test.ts
+++ b/test/unit/tools/update_progress.test.ts
@@ -1,0 +1,117 @@
+const mockCreateDirectory = jest.fn().mockResolvedValue(undefined)
+const mockReadFile = jest.fn()
+const mockWriteFile = jest.fn().mockResolvedValue(undefined)
+const mockResolveUriWithInfo = jest.fn()
+const mockNormalizeLineEndingsToLF = jest.fn((input: string) => input.replace(/\r\n?/g, '\n'))
+const mockGetAllWorkspaces = jest.fn()
+
+jest.mock('vscode', () => ({
+  workspace: {
+    fs: {
+      createDirectory: mockCreateDirectory,
+      readFile: mockReadFile,
+      writeFile: mockWriteFile
+    }
+  },
+  Uri: {
+    file: (fsPath: string) => ({ fsPath })
+  }
+}))
+
+jest.mock('../../../backend/tools/utils', () => ({
+  getAllWorkspaces: (...args: any[]) => mockGetAllWorkspaces(...args),
+  resolveUriWithInfo: (...args: any[]) => mockResolveUriWithInfo(...args),
+  normalizeLineEndingsToLF: (input: string) => mockNormalizeLineEndingsToLF(input)
+}))
+
+import { buildProgressDocument } from '../../../backend/tools/progress/documentLayout'
+import { createUpdateProgressTool } from '../../../backend/tools/progress/update_progress'
+
+describe('update_progress tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAllWorkspaces.mockReturnValue([{ name: 'workspace' }])
+    mockResolveUriWithInfo.mockImplementation((targetPath: string) => ({
+      uri: { fsPath: `D:/workspace/${targetPath}` },
+      error: undefined
+    }))
+
+    const existing = buildProgressDocument({
+      projectId: 'workspace',
+      projectName: 'Workspace',
+      createdAt: '2026-04-03T00:00:00.000Z',
+      updatedAt: '2026-04-03T00:00:00.000Z',
+      status: 'active',
+      phase: 'plan',
+      currentFocus: '旧焦点',
+      nextAction: '继续整理方案',
+      activeArtifacts: {
+        plan: '.limcode/plans/project-progress-document-tools-and-summary-card.plan.md'
+      },
+      todos: [
+        { id: 'progress-01', content: '实现后端基础层', status: 'pending' }
+      ],
+      risks: [],
+      milestones: [],
+      log: []
+    }).content
+
+    mockReadFile.mockResolvedValue(new TextEncoder().encode(existing))
+  })
+
+  it('updates summary fields, artifact snapshot, and recent logs', async () => {
+    const tool = createUpdateProgressTool()
+    const result = await tool.handler({
+      phase: 'implementation',
+      currentFocus: '实现后端 Progress 工具',
+      latestConclusion: '后端结构已经开始实现。',
+      nextAction: '继续补齐路径校验与工具注册。',
+      appendLog: [
+        { type: 'updated', message: '切换到实现阶段' }
+      ]
+    })
+
+    expect(result.success).toBe(true)
+    expect((result.data as any).progressSnapshot).toMatchObject({
+      path: '.limcode/progress.md',
+      phase: 'implementation',
+      currentFocus: '实现后端 Progress 工具',
+      latestConclusion: '后端结构已经开始实现。',
+      nextAction: '继续补齐路径校验与工具注册。'
+    })
+    expect((result.data as any).progressDelta).toMatchObject({
+      type: 'updated'
+    })
+
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    const writtenContent = Buffer.from(mockWriteFile.mock.calls[0][1]).toString('utf-8')
+    expect(writtenContent).toContain('实现后端 Progress 工具')
+    expect(writtenContent).toContain('后端结构已经开始实现。')
+    expect(writtenContent).toContain('切换到实现阶段')
+  })
+
+  it('rejects when the target progress file does not exist', async () => {
+    mockReadFile.mockRejectedValue(new Error('File not found'))
+
+    const tool = createUpdateProgressTool()
+    const result = await tool.handler({
+      currentFocus: '更新失败场景'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('File not found')
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid progress path values', async () => {
+    const tool = createUpdateProgressTool()
+    const result = await tool.handler({
+      path: '.limcode/plans/not-allowed.md',
+      currentFocus: '非法路径'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('.limcode/progress.md')
+    expect(mockResolveUriWithInfo).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/tools/validate_progress_document.progress.test.ts
+++ b/test/unit/tools/validate_progress_document.progress.test.ts
@@ -1,0 +1,107 @@
+const mockReadFile = jest.fn()
+const mockResolveUriWithInfo = jest.fn()
+const mockNormalizeLineEndingsToLF = jest.fn((input: string) => input.replace(/\r\n?/g, '\n'))
+const mockGetAllWorkspaces = jest.fn()
+
+jest.mock('vscode', () => ({
+  workspace: {
+    fs: {
+      readFile: mockReadFile,
+      stat: jest.fn(),
+      createDirectory: jest.fn(),
+      writeFile: jest.fn()
+    }
+  },
+  Uri: {
+    file: (fsPath: string) => ({ fsPath }),
+    parse: jest.fn((value: string) => ({ fsPath: value }))
+  },
+  FileType: {
+    Directory: 2
+  }
+}))
+
+jest.mock('../../../backend/tools/utils', () => ({
+  getAllWorkspaces: (...args: any[]) => mockGetAllWorkspaces(...args),
+  resolveUriWithInfo: (...args: any[]) => mockResolveUriWithInfo(...args),
+  normalizeLineEndingsToLF: (input: string) => mockNormalizeLineEndingsToLF(input)
+}))
+
+import { buildProgressDocument } from '../../../backend/tools/progress/documentLayout'
+import { createValidateProgressDocumentTool } from '../../../backend/tools/progress/validate_progress_document'
+
+describe('validate_progress_document tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAllWorkspaces.mockReturnValue([{ name: 'workspace' }])
+    mockResolveUriWithInfo.mockReturnValue({
+      uri: { fsPath: 'D:/workspace/.limcode/progress.md' },
+      error: undefined
+    })
+  })
+
+  it('returns validation summary and progress snapshot for a valid progress document', async () => {
+    const progressDoc = buildProgressDocument({
+      projectId: 'workspace',
+      projectName: 'Workspace',
+      createdAt: '2026-04-03T00:00:00.000Z',
+      updatedAt: '2026-04-03T00:00:00.000Z',
+      status: 'active',
+      phase: 'plan',
+      currentFocus: '整理实现计划',
+      latestConclusion: '准备开始实现。',
+      nextAction: '先补后端，再补前端。',
+      activeArtifacts: {
+        plan: '.limcode/plans/project-progress-document-tools-and-summary-card.plan.md'
+      },
+      todos: [
+        { id: 'progress-01', content: '实现后端基础层', status: 'pending' }
+      ],
+      milestones: [],
+      risks: [],
+      log: []
+    }).content
+
+    mockReadFile.mockResolvedValue(new TextEncoder().encode(progressDoc))
+
+    const tool = createValidateProgressDocumentTool()
+    const result = await tool.handler({
+      path: '.limcode/progress.md'
+    })
+
+    expect(result.success).toBe(true)
+    expect((result.data as any).progressValidation).toMatchObject({
+      isValid: true,
+      issueCount: 0,
+      errorCount: 0,
+      warningCount: 0,
+      formatVersion: 1
+    })
+    expect((result.data as any).progressSnapshot).toMatchObject({
+      path: '.limcode/progress.md',
+      projectName: 'Workspace',
+      status: 'active',
+      phase: 'plan'
+    })
+  })
+
+  it('reports validation failure for an invalid progress document', async () => {
+    mockReadFile.mockResolvedValue(new TextEncoder().encode('# invalid progress doc'))
+
+    const tool = createValidateProgressDocumentTool()
+    const result = await tool.handler({
+      path: '.limcode/progress.md'
+    })
+
+    expect(result.success).toBe(true)
+    expect((result.data as any).progressValidation).toMatchObject({
+      isValid: false,
+      issueCount: 1,
+      errorCount: 1,
+      warningCount: 0
+    })
+    expect((result.data as any).issues).toEqual([
+      expect.objectContaining({ severity: 'error' })
+    ])
+  })
+})

--- a/webview/handlers/FileHandlers.ts
+++ b/webview/handlers/FileHandlers.ts
@@ -1194,6 +1194,7 @@ function buildPlanExecutionPrompt(modified: boolean): string {
     'Do not create another plan unless the user explicitly asks to revise it.',
     'Start implementation immediately.',
     'Use todo_update to track progress as you work.',
+    'Use update_progress and record_progress_milestone to keep .limcode/progress.md current at the project level when progress changes in a meaningful way.',
     "When TODO status changes in a meaningful way, call update_plan with updateMode: 'progress_sync' to sync the latest TODO snapshot back to the plan document.",
     "When calling update_plan with updateMode: 'progress_sync', never pass sourceArtifact. Only send path, todos, updateMode, and optional changeSummary."
   ].join('\n');


### PR DESCRIPTION
# 变更背景

当前仓库已经有会话级 TODO、计划文档和审查文档，但缺少一个项目级的统一进度入口。  
这次改动补齐了 `.limcode/progress.md` 的完整能力，包括：

- 项目级进度文档
- Progress 工具
- design / plan / review 到 progress 的自动联动
- 前端消息卡片与 Response Viewer 展示
- 文档校验工具

# 主要改动

## 1. 新增 Progress 文档能力

新增固定路径的项目进度文档：

- `.limcode/progress.md`

新增后端模块：

- `backend/tools/progress/schema.ts`
- `backend/tools/progress/documentLayout.ts`
- `backend/tools/progress/pathUtils.ts`
- `backend/tools/progress/resultProjection.ts`
- `backend/tools/progress/index.ts`

实现了：

- Progress metadata 结构
- 可见 Markdown 区块渲染
- 文档顺序与基础不变量校验
- 轻量 `progressSnapshot` 投影

## 2. 新增 Progress 工具

新增工具：

- `create_progress`
- `update_progress`
- `record_progress_milestone`
- `validate_progress_document`

工具能力包括：

- 创建项目进度文档
- 更新项目级摘要、TODO 快照、风险和关联文档
- 记录项目级里程碑
- 校验 progress 文档格式和不变量

## 3. 接入模式策略与路径限制

在模式策略中接入了 Progress 工具：

- Design 可用
- Plan 可用
- Review 可用
- Ask 不可用

并增加了严格路径限制：

- 只允许写入 `.limcode/progress.md`
- 支持 multi-root 前缀形式

## 4. 增加 design / plan / review 到 progress 的自动联动

新增自动联动逻辑：

- `create_design` / `update_design` 成功后自动同步 progress
- `create_plan` / `update_plan` 成功后自动同步 progress
- `create_review` / `record_review_milestone` / `finalize_review` / `reopen_review` 成功后自动同步 progress

自动同步内容包括：

- `activeArtifacts.design`
- `activeArtifacts.plan`
- `activeArtifacts.review`
- 计划 TODO 快照
- 项目级日志
- 在合适场景下同步最新结论与下一步

## 5. 修复 `create_progress` 已创建后仍报错的问题

`create_progress` 现在改为幂等行为：

- 如果 progress 文档不存在，则创建
- 如果 progress 文档已存在且有效，则直接返回现有快照，不再报错
- 如果 progress 文档已存在但损坏，则返回明确错误

这解决了“文档已创建成功，但工具仍显示错误”的问题。

## 6. 增加 Progress 卡片与错误可见性

新增前端 Progress 卡片：

- `frontend/src/components/message/ProgressTaskCard.vue`
- `frontend/src/utils/progressCards.ts`

并接入：

- `MessageTaskCards.vue`
- `ResponseViewerDialog.vue`
- `buildResponseViewerData.ts`

现在以下工具结果可以显示 Progress 卡片：

- `create_progress`
- `update_progress`
- `record_progress_milestone`
- `validate_progress_document`

同时补充了错误和 warning 展示：

- Progress 卡片可显示 warning
- Progress 卡片可显示 error
- ToolMessage 在使用 `contentFormatter` 时也能显示工具错误信息

## 7. 补充国际化与前端工具注册

补充了以下内容：

- Progress 工具前端注册
- `validate_progress_document` 前端展示配置
- 中英文、日文文案
- i18n 类型定义

## 8. 补充测试

新增并更新了相关测试，覆盖：

- Progress 工具创建、更新、里程碑记录、校验
- Progress 卡片提取
- Response Viewer 中的 Progress 卡片
- review / plan / design 与 progress 的联动
- 模式策略限制

# 影响范围

## 后端

- `backend/tools/progress/**`
- `backend/tools/design/**`
- `backend/tools/plan/**`
- `backend/tools/review/**`
- `backend/modules/settings/**`
- `webview/handlers/FileHandlers.ts`

## 前端

- `frontend/src/components/message/**`
- `frontend/src/utils/progressCards.ts`
- `frontend/src/utils/tools/progress/**`
- `frontend/src/utils/tools/index.ts`
- `frontend/src/i18n/**`

## 测试

- `test/unit/tools/**`
- `test/unit/settings/**`

# 验证情况

已完成以下验证：

- TypeScript 编译通过
- 前端构建通过
- 全量测试通过

结果：

- 60 个测试套件通过
- 257 个测试通过

# 结果说明

这次改动完成后，项目已经具备完整的 Progress 基础能力：

- 有统一的项目级进度文档
- 有独立的 Progress 工具
- design / plan / review 输出后会自动同步项目进度
- 消息区和 Response Viewer 都可以展示 Progress 卡片
- `create_progress` 的重复创建异常已修复
- Progress 工具的错误信息现在可以直接看到