### PR TITLE
fix: 修复 diff 生命周期、plan 可见性、NoAct 审批门闸与提示系统设置

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -51,3 +51,12 @@ node_modules/**
 !node_modules/strnum/**
 !node_modules/tree-kill/**
 !node_modules/ignore/**
+!node_modules/node-notifier/**
+!node_modules/growly/**
+!node_modules/is-wsl/**
+!node_modules/is-docker/**
+!node_modules/semver/**
+!node_modules/shellwords/**
+!node_modules/uuid/**
+!node_modules/which/**
+!node_modules/isexe/**

--- a/backend/__tests__/tools/diffManager.test.ts
+++ b/backend/__tests__/tools/diffManager.test.ts
@@ -1,0 +1,404 @@
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+
+jest.mock('fs', () => ({
+    readFileSync: jest.fn(),
+    writeFileSync: jest.fn(),
+    existsSync: jest.fn(),
+    unlinkSync: jest.fn()
+}));
+
+jest.mock('../../tools/file/DiffCodeLensProvider', () => ({
+    getDiffCodeLensProvider: () => ({
+        removeSession: jest.fn(),
+        getSession: jest.fn(),
+        getSessionByFilePath: jest.fn()
+    })
+}));
+
+jest.mock('../../core/settingsContext', () => ({
+    getGlobalSettingsManager: () => null
+}));
+
+jest.mock('../../tools/file/apply_diff', () => ({
+    applyDiffToContent: jest.fn()
+}));
+
+jest.mock('../../tools/file/unifiedDiff', () => ({
+    applyUnifiedDiffHunks: jest.fn()
+}));
+
+import { DiffManager, getDiffManager, type PendingDiff } from '../../tools/file/diffManager';
+
+type MockTextDocument = {
+    uri: { fsPath: string; scheme: string; path: string };
+    isDirty: boolean;
+    getText: () => string;
+    setText: (next: string) => void;
+    positionAt: (offset: number) => number;
+    save: jest.Mock<Promise<boolean>, []>;
+};
+
+class MockWorkspaceEdit {
+    public replacements: Array<{ uri: { fsPath: string }; text: string }> = [];
+
+    public replace(uri: { fsPath: string }, _range: unknown, text: string): void {
+        this.replacements.push({ uri, text });
+    }
+}
+
+function resetDiffManagerSingleton(): void {
+    const instance = (DiffManager as any).instance as { dispose?: () => void } | null;
+    if (instance?.dispose) {
+        instance.dispose();
+    }
+    (DiffManager as any).instance = null;
+}
+
+function getManager(): DiffManager {
+    return getDiffManager();
+}
+
+function createDocument(options?: {
+    filePath?: string;
+    initialContent?: string;
+    saveReturns?: boolean;
+}): MockTextDocument {
+    const filePath = options?.filePath ?? 'C:/tmp/file.ts';
+    let text = options?.initialContent ?? 'original';
+    let dirty = false;
+
+    const doc: MockTextDocument = {
+        uri: { fsPath: filePath, scheme: 'file', path: filePath },
+        get isDirty() {
+            return dirty;
+        },
+        set isDirty(value: boolean) {
+            dirty = value;
+        },
+        getText: () => text,
+        setText: (next: string) => {
+            text = next;
+            dirty = true;
+        },
+        positionAt: (offset: number) => offset,
+        save: jest.fn(async () => {
+            if (options?.saveReturns === false) {
+                return false;
+            }
+            dirty = false;
+            return true;
+        })
+    };
+
+    (vscode.workspace as any).textDocuments = [doc];
+    (vscode.workspace.openTextDocument as jest.Mock).mockResolvedValue(doc);
+    return doc;
+}
+
+function createPendingDiff(manager: DiffManager, overrides?: Partial<PendingDiff>): PendingDiff {
+    const diff: PendingDiff = {
+        id: overrides?.id ?? 'diff-1',
+        filePath: overrides?.filePath ?? 'src/file.ts',
+        absolutePath: overrides?.absolutePath ?? 'C:/tmp/file.ts',
+        originalContent: overrides?.originalContent ?? 'original',
+        newContent: overrides?.newContent ?? 'accepted',
+        timestamp: overrides?.timestamp ?? Date.now(),
+        status: overrides?.status ?? 'pending',
+        blocks: overrides?.blocks,
+        rawDiffs: overrides?.rawDiffs,
+        toolId: overrides?.toolId,
+        userEditedContent: overrides?.userEditedContent,
+        diffGuardWarning: overrides?.diffGuardWarning,
+        diffGuardDeletePercent: overrides?.diffGuardDeletePercent
+    };
+
+    ((manager as any).pendingDiffs as Map<string, PendingDiff>).set(diff.id, diff);
+    return diff;
+}
+
+function attachListenerDisposables(manager: DiffManager, id: string) {
+    const saveDisposable = { dispose: jest.fn() };
+    const closeDisposable = { dispose: jest.fn() };
+
+    ((manager as any).saveListeners as Map<string, { dispose: () => void }>).set(id, saveDisposable);
+    ((manager as any).closeListeners as Map<string, { dispose: () => void }>).set(id, closeDisposable);
+
+    return { saveDisposable, closeDisposable };
+}
+
+describe('DiffManager lifecycle closure', () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+        resetDiffManagerSingleton();
+
+        jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        (vscode as any).EventEmitter = class {
+            public event = jest.fn();
+            public fire = jest.fn();
+            public dispose = jest.fn();
+        };
+        (vscode as any).WorkspaceEdit = MockWorkspaceEdit;
+        (vscode as any).Range = jest.fn().mockImplementation((start: unknown, end: unknown) => ({ start, end }));
+        (vscode as any).TabInputTextDiff = class {};
+        (vscode as any).TextEdit = {
+            replace: jest.fn((range: unknown, newText: string) => ({ range, newText }))
+        };
+        (vscode.Uri as any).parse = (value: string) => ({ fsPath: value, scheme: 'file', path: value });
+        (vscode.Uri as any).file = (value: string) => ({ fsPath: value, scheme: 'file', path: value });
+        (vscode as any).TextDocumentSaveReason = { Manual: 1, AfterDelay: 2, FocusOut: 3 };
+
+        (vscode.workspace as any).textDocuments = [];
+        (vscode.workspace as any).registerTextDocumentContentProvider = jest.fn(() => ({ dispose: jest.fn() }));
+        (vscode.workspace as any).openTextDocument = jest.fn();
+        (vscode.workspace as any).applyEdit = jest.fn(async (edit: MockWorkspaceEdit) => {
+            const doc = ((vscode.workspace as any).textDocuments as MockTextDocument[])[0];
+            const replacement = edit.replacements[0];
+            if (doc && replacement && replacement.uri.fsPath === doc.uri.fsPath) {
+                doc.setText(replacement.text);
+            }
+            return true;
+        });
+        (vscode.workspace as any).onDidSaveTextDocument = jest.fn(() => ({ dispose: jest.fn() }));
+        (vscode.workspace as any).onWillSaveTextDocument = jest.fn(() => ({ dispose: jest.fn() }));
+        (vscode.workspace as any).onDidCloseTextDocument = jest.fn(() => ({ dispose: jest.fn() }));
+
+        (vscode.commands.executeCommand as jest.Mock).mockResolvedValue(undefined);
+        (vscode as any).window = {
+            showTextDocument: jest.fn(async () => ({})),
+            setStatusBarMessage: jest.fn(),
+            showErrorMessage: jest.fn(),
+            tabGroups: {
+                all: [],
+                close: jest.fn(async () => undefined)
+            }
+        };
+
+        (fs.readFileSync as jest.Mock).mockReturnValue('original');
+        (fs.writeFileSync as jest.Mock).mockImplementation(() => undefined);
+        (fs.existsSync as jest.Mock).mockReturnValue(false);
+        (fs.unlinkSync as jest.Mock).mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        resetDiffManagerSingleton();
+    });
+
+    it('acceptDiff finalizes accepted state and disposes listeners only after persistence succeeds', async () => {
+        const manager = getManager();
+        createDocument({ initialContent: 'original', saveReturns: true });
+        const diff = createPendingDiff(manager, {
+            originalContent: 'original',
+            newContent: 'accepted'
+        });
+        const listeners = attachListenerDisposables(manager, diff.id);
+
+        let statusChanges = 0;
+        let saveCompleted = 0;
+        manager.addStatusListener(() => {
+            statusChanges += 1;
+        });
+        manager.addSaveCompleteListener(() => {
+            saveCompleted += 1;
+        });
+
+        const accepted = await manager.acceptDiff(diff.id, false, false);
+
+        expect(accepted).toBe(true);
+        expect(diff.status).toBe('accepted');
+        expect(statusChanges).toBe(1);
+        expect(saveCompleted).toBe(1);
+        expect(listeners.saveDisposable.dispose).toHaveBeenCalledTimes(1);
+        expect(listeners.closeDisposable.dispose).toHaveBeenCalledTimes(1);
+        expect((manager as any).saveListeners.has(diff.id)).toBe(false);
+        expect((manager as any).closeListeners.has(diff.id)).toBe(false);
+        expect(manager.isDiffActionInProgress(diff.id)).toBe(false);
+    });
+
+    it('acceptDiff keeps the diff pending and preserves listeners when persistence fails', async () => {
+        const manager = getManager();
+        createDocument({ initialContent: 'original', saveReturns: false });
+        const diff = createPendingDiff(manager, {
+            originalContent: 'original',
+            newContent: 'accepted'
+        });
+        const listeners = attachListenerDisposables(manager, diff.id);
+
+        (fs.writeFileSync as jest.Mock).mockImplementation(() => {
+            throw new Error('disk write failed');
+        });
+
+        let statusChanges = 0;
+        let saveCompleted = 0;
+        manager.addStatusListener(() => {
+            statusChanges += 1;
+        });
+        manager.addSaveCompleteListener(() => {
+            saveCompleted += 1;
+        });
+
+        const accepted = await manager.acceptDiff(diff.id, false, false);
+
+        expect(accepted).toBe(false);
+        expect(diff.status).toBe('pending');
+        expect(statusChanges).toBe(0);
+        expect(saveCompleted).toBe(0);
+        expect(listeners.saveDisposable.dispose).not.toHaveBeenCalled();
+        expect(listeners.closeDisposable.dispose).not.toHaveBeenCalled();
+        expect((manager as any).saveListeners.get(diff.id)).toBe(listeners.saveDisposable);
+        expect((manager as any).closeListeners.get(diff.id)).toBe(listeners.closeDisposable);
+        expect(manager.isDiffActionInProgress(diff.id)).toBe(false);
+        expect((vscode.window as any).showErrorMessage).toHaveBeenCalled();
+    });
+
+    it('rejectDiff finalizes rejected state and disposes listeners on success', async () => {
+        const manager = getManager();
+        const doc = createDocument({ initialContent: 'accepted', saveReturns: true });
+        const diff = createPendingDiff(manager, {
+            originalContent: 'original',
+            newContent: 'accepted'
+        });
+        const listeners = attachListenerDisposables(manager, diff.id);
+
+        let statusChanges = 0;
+        manager.addStatusListener(() => {
+            statusChanges += 1;
+        });
+
+        const rejected = await manager.rejectDiff(diff.id);
+
+        expect(rejected).toBe(true);
+        expect(diff.status).toBe('rejected');
+        expect(doc.getText()).toBe('original');
+        expect(statusChanges).toBe(1);
+        expect(listeners.saveDisposable.dispose).toHaveBeenCalledTimes(1);
+        expect(listeners.closeDisposable.dispose).toHaveBeenCalledTimes(1);
+        expect((manager as any).saveListeners.has(diff.id)).toBe(false);
+        expect((manager as any).closeListeners.has(diff.id)).toBe(false);
+        expect(manager.isDiffActionInProgress(diff.id)).toBe(false);
+    });
+
+    it('createPendingDiff keeps the diff pending when opening the diff view fails', async () => {
+        const manager = getManager();
+        const statusListener = jest.fn();
+        manager.addStatusListener(statusListener);
+
+        jest.spyOn(manager as any, 'showDiffView').mockRejectedValue(new Error('open diff failed'));
+
+        const pendingDiff = await manager.createPendingDiff(
+            'src/file.ts',
+            'C:/tmp/file.ts',
+            'original',
+            'accepted',
+            undefined,
+            undefined,
+            'tool-1'
+        );
+
+        expect(pendingDiff.status).toBe('pending');
+        expect(manager.getDiff(pendingDiff.id)?.status).toBe('pending');
+        expect(statusListener).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalled();
+    });
+
+    it('auto-save failure leaves the diff pending for manual retry', async () => {
+        jest.useFakeTimers();
+
+        const manager = getManager();
+        createDocument({ initialContent: 'original', saveReturns: false });
+        const diff = createPendingDiff(manager, {
+            originalContent: 'original',
+            newContent: 'accepted'
+        });
+        const listeners = attachListenerDisposables(manager, diff.id);
+
+        (fs.writeFileSync as jest.Mock).mockImplementation(() => {
+            throw new Error('auto-save disk write failed');
+        });
+
+        manager.updateSettings({ autoSave: true, autoSaveDelay: 5 });
+        (manager as any).scheduleAutoSave(diff.id);
+
+        await jest.advanceTimersByTimeAsync(10);
+        await Promise.resolve();
+
+        expect(diff.status).toBe('pending');
+        expect((manager as any).autoSaveTimers.has(diff.id)).toBe(false);
+        expect((manager as any).saveListeners.get(diff.id)).toBe(listeners.saveDisposable);
+        expect((manager as any).closeListeners.get(diff.id)).toBe(listeners.closeDisposable);
+        expect(manager.isDiffActionInProgress(diff.id)).toBe(false);
+        expect((vscode.window as any).showErrorMessage).toHaveBeenCalled();
+    });
+
+    it('non-manual save keeps the diff pending and restores the draft in manual mode', async () => {
+        const manager = getManager();
+        const doc = createDocument({ initialContent: 'original', saveReturns: true });
+        const diff = createPendingDiff(manager, {
+            originalContent: 'original',
+            newContent: 'accepted'
+        });
+
+        let willSaveHandler: ((event: any) => void) | undefined;
+        let didSaveHandler: ((savedDoc: any) => Promise<void>) | undefined;
+
+        (vscode.workspace as any).onWillSaveTextDocument = jest.fn((listener: (event: any) => void) => {
+            willSaveHandler = listener;
+            return { dispose: jest.fn() };
+        });
+        (vscode.workspace as any).onDidSaveTextDocument = jest.fn((listener: (savedDoc: any) => Promise<void>) => {
+            didSaveHandler = listener;
+            return { dispose: jest.fn() };
+        });
+
+        (vscode.window as any).showTextDocument = jest.fn(async () => ({
+            edit: async (callback: (editBuilder: { replace: (range: unknown, text: string) => void }) => void) => {
+                callback({
+                    replace: (_range: unknown, text: string) => {
+                        doc.setText(text);
+                    }
+                });
+                return true;
+            }
+        }));
+
+        let statusChanges = 0;
+        manager.addStatusListener(() => {
+            statusChanges += 1;
+        });
+
+        await (manager as any).showDiffView(diff);
+
+        expect(doc.getText()).toBe('accepted');
+        expect(diff.status).toBe('pending');
+        expect(typeof willSaveHandler).toBe('function');
+        expect(typeof didSaveHandler).toBe('function');
+
+        let pendingWillSaveEdits: Promise<Array<{ newText: string }>> | undefined;
+        willSaveHandler?.({
+            document: doc,
+            reason: (vscode as any).TextDocumentSaveReason.FocusOut,
+            waitUntil: (thenable: Promise<Array<{ newText: string }>>) => {
+                pendingWillSaveEdits = Promise.resolve(thenable);
+            }
+        });
+
+        const willSaveEdits = await pendingWillSaveEdits;
+        expect(willSaveEdits).toEqual([
+            expect.objectContaining({ newText: 'original' })
+        ]);
+
+        doc.setText('original');
+        doc.isDirty = false;
+        await didSaveHandler?.(doc);
+
+        expect(diff.status).toBe('pending');
+        expect(statusChanges).toBe(0);
+        expect(doc.getText()).toBe('accepted');
+        expect(doc.isDirty).toBe(true);
+        expect((manager as any).saveListeners.has(diff.id)).toBe(true);
+        expect((manager as any).willSaveListeners.has(diff.id)).toBe(true);
+    });
+});

--- a/backend/i18n/langs/en.ts
+++ b/backend/i18n/langs/en.ts
@@ -572,6 +572,23 @@ Project-level takes priority. Duplicate skill names only load the highest-priori
         }
     },
     
+    notifications: {
+        windowsAgentStop: {
+            currentWindow: 'Current Window',
+            reasonLabels: {
+                error: 'Failure',
+                awaitingUserAction: 'Waiting for User Action',
+                continueRequired: 'Waiting to Continue'
+            },
+            actionLabels: {
+                generatePlan: 'Generate Plan',
+                executePlan: 'Execute Plan',
+                continue: 'Continue',
+                genericConfirmation: 'Confirm'
+            }
+        }
+    },
+    
     workspace: {
         noWorkspaceOpen: 'No workspace open',
         singleWorkspace: 'Workspace: {path}',

--- a/backend/i18n/langs/ja.ts
+++ b/backend/i18n/langs/ja.ts
@@ -572,6 +572,23 @@ description: "このスキルの機能と使用場面の簡単な説明"
         }
     },
     
+    notifications: {
+        windowsAgentStop: {
+            currentWindow: '現在のウィンドウ',
+            reasonLabels: {
+                error: '失敗',
+                awaitingUserAction: 'ユーザー操作待ち',
+                continueRequired: '続行待ち'
+            },
+            actionLabels: {
+                generatePlan: '計画を生成',
+                executePlan: '計画を実行',
+                continue: '続行',
+                genericConfirmation: '確認'
+            }
+        }
+    },
+    
     workspace: {
         noWorkspaceOpen: 'ワークスペースが開いていません',
         singleWorkspace: 'ワークスペース: {path}',

--- a/backend/i18n/langs/zh-CN.ts
+++ b/backend/i18n/langs/zh-CN.ts
@@ -572,6 +572,23 @@ description: "简要描述该技能的功能及使用场景"
         }
     },
     
+    notifications: {
+        windowsAgentStop: {
+            currentWindow: '当前窗口',
+            reasonLabels: {
+                error: '失败',
+                awaitingUserAction: '等待用户操作',
+                continueRequired: '等待继续'
+            },
+            actionLabels: {
+                generatePlan: '生成计划',
+                executePlan: '执行计划',
+                continue: '继续',
+                genericConfirmation: '确认'
+            }
+        }
+    },
+    
     workspace: {
         noWorkspaceOpen: '无工作区打开',
         singleWorkspace: '工作区: {path}',

--- a/backend/i18n/types.ts
+++ b/backend/i18n/types.ts
@@ -519,6 +519,23 @@ export interface BackendLanguageMessages {
         };
 
     };
+    /** 通知相关 */
+    notifications: {
+        windowsAgentStop: {
+            currentWindow: string;
+            reasonLabels: {
+                error: string;
+                awaitingUserAction: string;
+                continueRequired: string;
+            };
+            actionLabels: {
+                generatePlan: string;
+                executePlan: string;
+                continue: string;
+                genericConfirmation: string;
+            };
+        };
+    };
     /** 工作区相关 */
     workspace: {
         noWorkspaceOpen: string;

--- a/backend/modules/api/chat/services/ChatFlowService.ts
+++ b/backend/modules/api/chat/services/ChatFlowService.ts
@@ -9,6 +9,7 @@
  */
 
 import { t } from '../../../../i18n';
+import { Logger } from '../../../../core/logger';
 import type { ConfigManager } from '../../../config/ConfigManager';
 import type { ChannelManager } from '../../../channel/ChannelManager';
 import type { ConversationManager } from '../../../conversation/ConversationManager';
@@ -25,6 +26,7 @@ import type {
   EditAndRetryRequestData,
   ToolConfirmationResponseData,
   DeleteToMessageRequestData,
+  HiddenFunctionResponseData,
   DeleteToMessageSuccessData,
   DeleteToMessageErrorData,
   ChatSuccessData,
@@ -49,6 +51,13 @@ import type { DiffInterruptService } from './DiffInterruptService';
 import type { OrphanedToolCallService } from './OrphanedToolCallService';
 import type { ToolExecutionService, ToolExecutionFullResult, ToolExecutionProgressEvent } from './ToolExecutionService';
 import type { ToolCallParserService } from './ToolCallParserService';
+import {
+  clearPendingApprovalGate,
+  getPendingApprovalGate,
+  getPendingApprovalGateKindForContinuationIntent
+} from '../../../conversation/pendingApprovalGate';
+import { getHiddenContinuationApprovalRequirement } from './approvalGateRules';
+import { resolveAndPersistPostToolStopState } from './postToolStopState';
 
 export type ChatStreamOutput =
   | ChatStreamChunkData
@@ -68,6 +77,7 @@ type TodoItemValue = { id: string; content: string; status: TodoStatusValue };
 const CONVERSATION_PROMPT_MODE_KEY = 'promptModeConfig';
 
 export class ChatFlowService {
+  private readonly log = Logger.get('ChatFlow');
   constructor(
     private configManager: ConfigManager,
     private conversationManager: ConversationManager,
@@ -125,6 +135,115 @@ export class ChatFlowService {
       ...(existing && typeof existing === 'object' ? existing : {}),
       ...(patch || {})
     };
+  }
+
+  private async validateHiddenContinuationApproval(
+    conversationId: string,
+    hiddenFunctionResponse?: HiddenFunctionResponseData
+  ): Promise<ChatErrorData | null> {
+    const requirement = getHiddenContinuationApprovalRequirement(hiddenFunctionResponse);
+    if (!requirement) {
+      return null;
+    }
+
+    const gate = await getPendingApprovalGate(this.conversationManager, conversationId);
+    if (!gate) {
+      this.log.warn('approval_gate.missing', {
+        conversationId,
+        intent: requirement.intent,
+        sourceToolId: hiddenFunctionResponse?.id || null,
+        sourceToolName: hiddenFunctionResponse?.name || null
+      });
+      return {
+        success: false,
+        error: {
+          code: 'APPROVAL_GATE_REQUIRED',
+          message: `Missing pending approval gate for continuation intent: ${requirement.intent}.`
+        }
+      };
+    }
+
+    const approvalId = requirement.approvalId;
+    if (!approvalId) {
+      this.log.warn('approval_gate.approval_id_missing', {
+        conversationId,
+        intent: requirement.intent,
+        gateId: gate.id,
+        sourceToolId: hiddenFunctionResponse?.id || null,
+        sourceToolName: hiddenFunctionResponse?.name || null
+      });
+      return {
+        success: false,
+        error: {
+          code: 'APPROVAL_GATE_REQUIRED',
+          message: `Missing approvalId for continuation intent: ${requirement.intent}.`
+        }
+      };
+    }
+
+    const expectedKind = getPendingApprovalGateKindForContinuationIntent(requirement.intent);
+    const hiddenToolId = typeof hiddenFunctionResponse?.id === 'string' ? hiddenFunctionResponse.id.trim() : '';
+    const hiddenToolName = typeof hiddenFunctionResponse?.name === 'string' ? hiddenFunctionResponse.name.trim() : '';
+
+    if (!hiddenToolId || !hiddenToolName) {
+      return {
+        success: false,
+        error: {
+          code: 'APPROVAL_GATE_MISMATCH',
+          message: 'Hidden continuation payload must include the original tool id and tool name.'
+        }
+      };
+    }
+
+    if (gate.id !== approvalId || gate.kind !== expectedKind || gate.continuationIntent !== requirement.intent || gate.sourceToolCallId !== hiddenToolId || gate.sourceToolName !== hiddenToolName) {
+      this.log.warn('approval_gate.mismatch', {
+        conversationId,
+        intent: requirement.intent,
+        approvalId,
+        gateId: gate.id,
+        gateKind: gate.kind,
+        gateIntent: gate.continuationIntent,
+        hiddenToolId: hiddenToolId || null,
+        hiddenToolName: hiddenToolName || null
+      });
+      return {
+        success: false,
+        error: {
+          code: 'APPROVAL_GATE_MISMATCH',
+          message: `Approval gate mismatch for continuation intent: ${requirement.intent}.`
+        }
+      };
+    }
+
+    await clearPendingApprovalGate(this.conversationManager, conversationId);
+    this.log.info('approval_gate.consumed', {
+      conversationId,
+      intent: requirement.intent,
+      gateId: gate.id,
+      sourceToolId: gate.sourceToolCallId,
+      sourceToolName: gate.sourceToolName
+    });
+    return null;
+  }
+
+  private async clearPendingApprovalGateIfPresent(
+    conversationId: string,
+    reason: string
+  ): Promise<void> {
+    const gate = await getPendingApprovalGate(this.conversationManager, conversationId);
+    if (!gate) {
+      return;
+    }
+
+    await clearPendingApprovalGate(this.conversationManager, conversationId);
+    this.log.info('approval_gate.cleared', {
+      conversationId,
+      reason,
+      gateId: gate.id,
+      gateKind: gate.kind,
+      sourceToolId: gate.sourceToolCallId,
+      sourceToolName: gate.sourceToolName
+    });
   }
 
   private normalizeTodoStatus(value: unknown): TodoStatusValue {
@@ -464,7 +583,17 @@ export class ChatFlowService {
       };
     }
 
+    const approvalValidationError = await this.validateHiddenContinuationApproval(conversationId, hiddenFunctionResponse);
+    if (approvalValidationError) {
+      return approvalValidationError;
+    }
+
     const promptModeSnapshot = await this.resolvePromptModeSnapshot(conversationId, request.promptModeId);
+
+    if (!hiddenFunctionResponse) {
+      await this.clearPendingApprovalGateIfPresent(conversationId, 'visible_user_message');
+    }
+
 
     // 3. 添加输入到历史
     if (hiddenFunctionResponse) {
@@ -535,6 +664,8 @@ export class ChatFlowService {
     }
 
     const promptModeSnapshot = await this.resolvePromptModeSnapshot(conversationId, request.promptModeId);
+
+    await this.clearPendingApprovalGateIfPresent(conversationId, 'retry');
 
     // 3. 工具调用循环（委托给 ToolIterationLoopService，非流式）
     const maxToolIterations = this.getMaxToolIterations();
@@ -620,6 +751,8 @@ export class ChatFlowService {
 
     const promptModeSnapshot = await this.resolvePromptModeSnapshot(conversationId, request.promptModeId);
 
+    await this.clearPendingApprovalGateIfPresent(conversationId, 'edit_and_retry');
+
     // 4. 更新消息内容，并标记为动态提示词插入点
     await this.conversationManager.updateMessage(conversationId, messageIndex, {
       parts: [{ text: newMessage }],
@@ -704,7 +837,21 @@ export class ChatFlowService {
       return;
     }
 
+    const approvalValidationError = await this.validateHiddenContinuationApproval(conversationId, hiddenFunctionResponse);
+    if (approvalValidationError) {
+      yield {
+        conversationId,
+        error: approvalValidationError.error
+      };
+      return;
+    }
+
     const promptModeSnapshot = await this.resolvePromptModeSnapshot(conversationId, request.promptModeId);
+
+    if (!hiddenFunctionResponse) {
+      await this.clearPendingApprovalGateIfPresent(conversationId, 'visible_user_message');
+    }
+
 
     // 3. 中断之前未完成的 diff 等待并关闭编辑器
     this.diffInterruptService.markUserInterrupt();
@@ -819,6 +966,8 @@ export class ChatFlowService {
 
     const promptModeSnapshot = await this.resolvePromptModeSnapshot(conversationId, request.promptModeId);
 
+    await this.clearPendingApprovalGateIfPresent(conversationId, 'retry_stream');
+
     // 3. 中断之前未完成的 diff 等待并关闭编辑器
     this.diffInterruptService.markUserInterrupt();
     await this.diffInterruptService.cancelAllPending();
@@ -839,6 +988,22 @@ export class ChatFlowService {
         toolIteration: true as const,
         toolResults: orphanedFunctionCalls.toolResults,
       } satisfies ChatStreamToolIterationData;
+
+      const orphanedStopState = await resolveAndPersistPostToolStopState(
+        this.conversationManager,
+        conversationId,
+        this.toolCallParserService.extractFunctionCalls(orphanedFunctionCalls.functionCallContent),
+        orphanedFunctionCalls.toolResults,
+        {
+          logger: this.log,
+          logContext: { executionPath: 'retry_stream_orphaned' }
+        }
+      );
+
+      if (orphanedStopState.shouldStop) {
+        this.diffInterruptService.resetUserInterrupt();
+        return;
+      }
     }
 
     // 5. 重置中断标记
@@ -907,6 +1072,8 @@ export class ChatFlowService {
     }
 
     const promptModeSnapshot = await this.resolvePromptModeSnapshot(conversationId, request.promptModeId);
+
+    await this.clearPendingApprovalGateIfPresent(conversationId, 'edit_and_retry');
 
     // 3. 验证消息索引和角色
     const message = await this.conversationManager.getMessage(conversationId, messageIndex);
@@ -1370,6 +1537,28 @@ export class ChatFlowService {
       });
     }
 
+    const postToolStopState = await resolveAndPersistPostToolStopState(
+      this.conversationManager,
+      conversationId,
+      allFunctionCalls,
+      toolResultsThisTurn,
+      {
+        logger: this.log,
+        logContext: { executionPath: 'tool_confirmation' }
+      }
+    );
+
+    if (postToolStopState.shouldStop) {
+      yield {
+        conversationId,
+        content: lastMessage,
+        toolIteration: true as const,
+        toolResults: toolResultsThisTurn,
+        checkpoints: checkpointsThisTurn,
+      } satisfies ChatStreamToolIterationData;
+      return;
+    }
+
     // 如果本轮存在 cancelled，则不再继续推进，也不再等待下一次确认
     const hasCancelledTools = toolResultsThisTurn.some(r => (r.result as any).cancelled);
     if (hasCancelledTools) {
@@ -1453,6 +1642,8 @@ export class ChatFlowService {
     
     // 4. 拒绝所有未响应的工具调用并持久化
     await this.conversationManager.rejectAllPendingToolCalls(conversationId);
+
+    await this.clearPendingApprovalGateIfPresent(conversationId, 'delete_to_message');
 
     try {
       // 5. 删除关联的检查点

--- a/backend/modules/api/chat/services/OrphanedToolCallService.ts
+++ b/backend/modules/api/chat/services/OrphanedToolCallService.ts
@@ -9,7 +9,7 @@
 
 import type { ConversationManager } from '../../../conversation/ConversationManager';
 import type { Content } from '../../../conversation/types';
-import type { FunctionCallInfo } from '../utils';
+import type { FunctionCallInfo, ToolExecutionResult } from '../utils';
 import type { ToolExecutionService } from './ToolExecutionService';
 import type { ResolvedPromptModeSnapshot } from '../../../settings/types';
 import type { ToolCallParserService } from './ToolCallParserService';
@@ -18,7 +18,7 @@ export interface OrphanedToolCallResult {
   /** 原始的函数调用所在的 model 消息 */
   functionCallContent: Content;
   /** 工具执行结果列表 */
-  toolResults: Array<{ id?: string; name: string; result: Record<string, unknown> }>;
+  toolResults: ToolExecutionResult[];
 }
 
 export class OrphanedToolCallService {

--- a/backend/modules/api/chat/services/ToolIterationLoopService.ts
+++ b/backend/modules/api/chat/services/ToolIterationLoopService.ts
@@ -21,7 +21,6 @@ import { t } from '../../../../i18n';
 import { Logger } from '../../../../core/logger';
 import type { CheckpointService } from './CheckpointService';
 import type { ResolvedPromptModeSnapshot } from '../../../settings/types';
-
 import type {
     ChatStreamChunkData,
     ChatStreamCompleteData,
@@ -44,6 +43,7 @@ import type { TokenEstimationService } from './TokenEstimationService';
 import type { ContextTrimService } from './ContextTrimService';
 import type { ToolExecutionService, ToolExecutionFullResult, ToolExecutionProgressEvent } from './ToolExecutionService';
 import type { SummarizeService } from './SummarizeService';
+import { resolveAndPersistPostToolStopState } from './postToolStopState';
 
 const CONVERSATION_PINNED_FILES_KEY = 'inputPinnedFiles';
 const CONVERSATION_SKILLS_KEY = 'inputSkills';
@@ -693,7 +693,18 @@ export class ToolIterationLoopService {
                     isFunctionResponse: true
                 });
 
-                if (firstConfirmTool) {
+                const earlyStopState = await resolveAndPersistPostToolStopState(
+                    this.conversationManager,
+                    conversationId,
+                    functionCalls,
+                    earlyToolResults,
+                    {
+                        logger: this.log,
+                        logContext: { iteration, executionPath: 'stream_early' }
+                    }
+                );
+
+                if (firstConfirmTool && !earlyStopState.shouldStop) {
                     yield {
                         conversationId,
                         pendingToolCalls: [{
@@ -703,8 +714,6 @@ export class ToolIterationLoopService {
                         }],
                         content: finalContent,
                         awaitingConfirmation: true as const,
-                        // 已在流式期间自动完成的前缀工具结果仍需同步给前端，
-                        // 但不能 continue 到下一轮，否则后续待确认工具会变成“无响应的 functionCall”。
                         toolResults: earlyToolResults,
                         checkpoints: []
                     } satisfies ChatStreamToolConfirmationData;
@@ -712,15 +721,10 @@ export class ToolIterationLoopService {
                     return;
                 }
 
-                // 通知前端所有工具已执行完毕（构造与传统路径一致的 toolResults 格式）。
                 // 流式提前执行的工具绕过了 executeFunctionCallsWithProgress 的
                 // start/end 进度事件，需要在这里补发 toolIteration 让前端更新 UI。
-                // 直接从 ToolExecutionFullResult.toolResults 中提取，
-                // 其 result 字段就是工具本身的业务返回值，与传统路径格式一致。
-                // 发送每个工具的完成状态（让前端逐个显示工具结果）
                 for (const tr of earlyToolResults) {
                     const r = tr.result as any;
-                    // 状态判断逻辑与传统路径（executeFunctionCallsWithProgress end 事件）保持一致
                     let status: ChatStreamToolStatusData['tool']['status'] = 'success';
                     if (r?.success === false || r?.error || r?.cancelled || r?.rejected) {
                         status = 'error';
@@ -742,7 +746,10 @@ export class ToolIterationLoopService {
                     checkpoints: [],
                 };
 
-                // 继续下一轮循环让 LLM 处理工具结果
+                if (earlyStopState.shouldStop) {
+                    return;
+                }
+
                 continue;
             }
 
@@ -860,6 +867,31 @@ export class ToolIterationLoopService {
                 });
             }
 
+            if (executionResult) {
+                const postToolStopState = await resolveAndPersistPostToolStopState(
+                    this.conversationManager,
+                    conversationId,
+                    functionCalls,
+                    executionResult.toolResults,
+                    {
+                        logger: this.log,
+                        logContext: { iteration, executionPath: 'stream' }
+                    }
+                );
+
+                if (postToolStopState.shouldStop) {
+                    yield {
+                        conversationId,
+                        content: finalContent,
+                        toolIteration: true as const,
+                        toolResults: executionResult.toolResults,
+                        checkpoints: executionResult.checkpoints
+                    };
+
+                    return;
+                }
+            }
+
             // 13. 如果遇到需要确认的工具，则暂停并等待（仅等待当前这个“队首”工具）
             if (firstConfirmTool) {
                 yield {
@@ -871,7 +903,6 @@ export class ToolIterationLoopService {
                     }],
                     content: finalContent,
                     awaitingConfirmation: true as const,
-                    // 把已自动执行的前缀结果同步给前端（用于刷新工具状态/结果展示）
                     toolResults: executionResult?.toolResults,
                     checkpoints: executionResult?.checkpoints
                 };
@@ -881,19 +912,6 @@ export class ToolIterationLoopService {
 
             // 14. 没有需要确认的工具，说明所有工具均已自动执行完成
             if (executionResult) {
-                const hasCancelled = executionResult.toolResults.some(r => (r.result as any).cancelled);
-                const hasUserConfirmation = executionResult.toolResults.some(r => (r.result as any).requiresUserConfirmation);
-                if (hasCancelled || hasUserConfirmation) {
-                    yield {
-                        conversationId,
-                        content: finalContent,
-                        toolIteration: true as const,
-                        toolResults: executionResult.toolResults,
-                        checkpoints: executionResult.checkpoints
-                    };
-                    return;
-                }
-
                 yield {
                     conversationId,
                     content: finalContent,
@@ -1045,7 +1063,7 @@ export class ToolIterationLoopService {
             const currentHistory = await this.conversationManager.getHistoryRef(conversationId);
             const messageIndex = currentHistory.length - 1;
 
-            const functionResponses = await this.toolExecutionService.executeFunctionCalls(
+            const executionResult = await this.toolExecutionService.executeFunctionCallsWithResults(
                 functionCalls,
                 conversationId,
                 messageIndex,
@@ -1054,12 +1072,34 @@ export class ToolIterationLoopService {
                 promptModeSnapshot
             );
 
+            const functionResponseParts = executionResult.multimodalAttachments
+                ? [...executionResult.multimodalAttachments, ...executionResult.responseParts]
+                : executionResult.responseParts;
+
             // 将函数响应添加到历史（作为 user 消息，标记为函数响应）
             await this.conversationManager.addContent(conversationId, {
                 role: 'user',
-                parts: functionResponses,
+                parts: functionResponseParts,
                 isFunctionResponse: true
             });
+
+            const postToolStopState = await resolveAndPersistPostToolStopState(
+                this.conversationManager,
+                conversationId,
+                functionCalls,
+                executionResult.toolResults,
+                {
+                    logger: this.log,
+                    logContext: { iteration, executionPath: 'non_stream' }
+                }
+            );
+
+            if (postToolStopState.shouldStop) {
+                return {
+                    content: finalContent,
+                    exceededMaxIterations: false
+                };
+            }
             
             // 注：工具响应消息的 token 计数将在下一次循环的 getHistoryWithContextTrimInfo 中
             // 与系统提示词、动态上下文一起并行计算

--- a/backend/modules/api/chat/services/approvalGateRules.ts
+++ b/backend/modules/api/chat/services/approvalGateRules.ts
@@ -1,0 +1,188 @@
+import type { HiddenFunctionResponseData } from '../types';
+import type { FunctionCallInfo } from '../utils';
+import type { PendingApprovalGateContinuationIntent } from '../../../conversation/types';
+import type { PendingApprovalGateSeed } from '../../../conversation/pendingApprovalGate';
+
+const REVIEW_TOOL_NAMES = new Set([
+  'create_review',
+  'record_review_milestone',
+  'finalize_review',
+  'reopen_review',
+  'validate_review_document',
+  'compare_review_documents'
+]);
+
+type LooseRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): LooseRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as LooseRecord
+    : null;
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return normalized || undefined;
+}
+
+function normalizePath(value: unknown): string | undefined {
+  const normalized = asString(value);
+  return normalized ? normalized.replace(/\\/g, '/') : undefined;
+}
+
+function hasMeaningfulValue(value: unknown): boolean {
+  return typeof value === 'string'
+    ? value.trim().length > 0
+    : value !== undefined && value !== null;
+}
+
+function getResultData(result: unknown): LooseRecord | null {
+  const record = asRecord(result);
+  return asRecord(record?.data);
+}
+
+function normalizePlanUpdateMode(result: unknown, args: unknown): 'revision' | 'progress_sync' {
+  const resultRecord = asRecord(result);
+  const data = getResultData(result);
+  const argsRecord = asRecord(args);
+  return data?.updateMode === 'progress_sync'
+    || resultRecord?.updateMode === 'progress_sync'
+    || argsRecord?.updateMode === 'progress_sync'
+    ? 'progress_sync'
+    : 'revision';
+}
+
+function getSourcePath(result: unknown, args: unknown): string | undefined {
+  const resultRecord = asRecord(result);
+  const data = getResultData(result);
+  const argsRecord = asRecord(args);
+  return normalizePath(data?.path)
+    || normalizePath(resultRecord?.path)
+    || normalizePath(argsRecord?.path);
+}
+
+function getReviewStatus(result: unknown): string | undefined {
+  const data = getResultData(result);
+  const reviewSnapshot = asRecord(data?.reviewSnapshot);
+  return asString(reviewSnapshot?.status)
+    || asString(data?.status)
+    || asString(data?.currentStatus);
+}
+
+function hasLegacyPlanGenerationFields(record: LooseRecord): boolean {
+  return hasMeaningfulValue(record.planGenerationPrompt)
+    || hasMeaningfulValue(record.designPath)
+    || hasMeaningfulValue(record.designContent)
+    || hasMeaningfulValue(record.reviewPath)
+    || hasMeaningfulValue(record.reviewContent);
+}
+
+function hasLegacyPlanExecutionFields(record: LooseRecord): boolean {
+  return hasMeaningfulValue(record.planExecutionPrompt)
+    || hasMeaningfulValue(record.planPath)
+    || hasMeaningfulValue(record.planContent);
+}
+
+export function isCoveredContinuationIntent(value: unknown): value is PendingApprovalGateContinuationIntent {
+  return value === 'generate_plan_now' || value === 'implement_now';
+}
+
+export function getCoveredContinuationIntentFromResponse(
+  response: unknown
+): PendingApprovalGateContinuationIntent | null {
+  const record = asRecord(response);
+  if (!record) return null;
+
+  if (record.continuationApproved === true && isCoveredContinuationIntent(record.continuationIntent)) {
+    return record.continuationIntent;
+  }
+
+  if (hasLegacyPlanExecutionFields(record)) {
+    return 'implement_now';
+  }
+
+  if (hasLegacyPlanGenerationFields(record)) {
+    return 'generate_plan_now';
+  }
+
+  return null;
+}
+
+export function getHiddenContinuationApprovalRequirement(
+  hiddenFunctionResponse: HiddenFunctionResponseData | undefined
+): { intent: PendingApprovalGateContinuationIntent; approvalId?: string } | null {
+  if (!hiddenFunctionResponse) return null;
+
+  const intent = getCoveredContinuationIntentFromResponse(hiddenFunctionResponse.response);
+  if (!intent) return null;
+
+  const approvalId = asString(hiddenFunctionResponse.approvalId);
+  return {
+    intent,
+    approvalId
+  };
+}
+
+export function classifyApprovalGateForToolResult(
+  call: Pick<FunctionCallInfo, 'id' | 'name' | 'args'>,
+  result: Record<string, unknown>
+): PendingApprovalGateSeed | null {
+  if (!call.id || !call.name || result.success !== true) {
+    return null;
+  }
+
+  const sourcePath = getSourcePath(result, call.args);
+
+  if (call.name === 'create_design' || call.name === 'update_design') {
+    if (result.requiresUserConfirmation !== true) return null;
+    return {
+      kind: 'generate_plan',
+      continuationIntent: 'generate_plan_now',
+      sourceToolCallId: call.id,
+      sourceToolName: call.name,
+      sourceArtifactType: 'design',
+      sourcePath
+    };
+  }
+
+  if (call.name === 'create_plan') {
+    if (result.requiresUserConfirmation !== true) return null;
+    return {
+      kind: 'execute_plan',
+      continuationIntent: 'implement_now',
+      sourceToolCallId: call.id,
+      sourceToolName: call.name,
+      sourceArtifactType: 'plan',
+      sourcePath
+    };
+  }
+
+  if (call.name === 'update_plan') {
+    if (normalizePlanUpdateMode(result, call.args) === 'progress_sync') {
+      return null;
+    }
+    if (result.requiresUserConfirmation !== true) return null;
+    return {
+      kind: 'execute_plan',
+      continuationIntent: 'implement_now',
+      sourceToolCallId: call.id,
+      sourceToolName: call.name,
+      sourceArtifactType: 'plan',
+      sourcePath
+    };
+  }
+
+  if (REVIEW_TOOL_NAMES.has(call.name) && getReviewStatus(result) === 'completed') {
+    return {
+      kind: 'generate_plan',
+      continuationIntent: 'generate_plan_now',
+      sourceToolCallId: call.id,
+      sourceToolName: call.name,
+      sourceArtifactType: 'review',
+      sourcePath
+    };
+  }
+
+  return null;
+}

--- a/backend/modules/api/chat/services/postToolStopState.ts
+++ b/backend/modules/api/chat/services/postToolStopState.ts
@@ -1,0 +1,123 @@
+import type { FunctionCallInfo, ToolExecutionResult } from '../utils';
+import {
+  replacePendingApprovalGate,
+  type PendingApprovalGateSeed,
+  type PendingApprovalGateStore
+} from '../../../conversation/pendingApprovalGate';
+import { classifyApprovalGateForToolResult } from './approvalGateRules';
+
+export interface PostToolStopLogger {
+  info(message: string, metadata?: Record<string, unknown>): void;
+}
+
+export interface PersistPostToolStopOptions {
+  logger?: PostToolStopLogger;
+  logContext?: Record<string, unknown>;
+}
+
+export type PostToolStopReason = 'approval' | 'cancelled' | null;
+
+export interface PostToolStopState {
+  shouldStop: boolean;
+  reason: PostToolStopReason;
+  gateSeed?: PendingApprovalGateSeed;
+  matchedToolId?: string;
+  matchedToolName?: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function resolvePostToolStopState(
+  functionCalls: Pick<FunctionCallInfo, 'id' | 'name' | 'args'>[],
+  toolResults: ToolExecutionResult[]
+): PostToolStopState {
+  const callById = new Map<string, Pick<FunctionCallInfo, 'id' | 'name' | 'args'>>();
+  for (const call of functionCalls) {
+    callById.set(call.id, call);
+  }
+
+  for (const toolResult of toolResults) {
+    const resultRecord = asRecord(toolResult.result) || {};
+    const call = callById.get(toolResult.id) || {
+      id: toolResult.id,
+      name: toolResult.name,
+      args: {}
+    };
+
+    const gateSeed = classifyApprovalGateForToolResult(call, resultRecord);
+    if (gateSeed) {
+      return {
+        shouldStop: true,
+        reason: 'approval',
+        gateSeed,
+        matchedToolId: call.id,
+        matchedToolName: call.name
+      };
+    }
+
+    if (resultRecord.requiresUserConfirmation === true) {
+      return {
+        shouldStop: true,
+        reason: 'approval',
+        matchedToolId: call.id,
+        matchedToolName: call.name
+      };
+    }
+
+    if (resultRecord.cancelled === true) {
+      return {
+        shouldStop: true,
+        reason: 'cancelled',
+        matchedToolId: call.id,
+        matchedToolName: call.name
+      };
+    }
+  }
+
+  return {
+    shouldStop: false,
+    reason: null
+  };
+}
+
+export async function resolveAndPersistPostToolStopState(
+  store: PendingApprovalGateStore,
+  conversationId: string,
+  functionCalls: Pick<FunctionCallInfo, 'id' | 'name' | 'args'>[],
+  toolResults: ToolExecutionResult[],
+  options: PersistPostToolStopOptions = {}
+): Promise<PostToolStopState> {
+  const stopState = resolvePostToolStopState(functionCalls, toolResults);
+  const logger = options.logger;
+  const logContext = options.logContext ?? {};
+
+  if (stopState.gateSeed) {
+    const gate = await replacePendingApprovalGate(store, conversationId, stopState.gateSeed);
+    logger?.info('approval_gate.armed', {
+      ...logContext,
+      conversationId,
+      gateId: gate.id,
+      gateKind: gate.kind,
+      sourceToolId: gate.sourceToolCallId,
+      sourceToolName: gate.sourceToolName,
+      sourcePath: gate.sourcePath || null
+    });
+    return stopState;
+  }
+
+  if (stopState.shouldStop) {
+    logger?.info('tool.post_stop', {
+      ...logContext,
+      conversationId,
+      reason: stopState.reason,
+      toolId: stopState.matchedToolId || null,
+      toolName: stopState.matchedToolName || null
+    });
+  }
+
+  return stopState;
+}

--- a/backend/modules/api/chat/types.ts
+++ b/backend/modules/api/chat/types.ts
@@ -46,6 +46,9 @@ export interface HiddenFunctionResponseData {
     /** 工具名称 */
     name: string;
 
+    /** 宿主侧审批门闸令牌（可选，仅计划类隐藏 continuation 使用） */
+    approvalId?: string;
+
     /** 函数响应对象 */
     response: Record<string, unknown>;
 }

--- a/backend/modules/channel/StreamAccumulator.ts
+++ b/backend/modules/channel/StreamAccumulator.ts
@@ -269,6 +269,22 @@ export class StreamAccumulator {
         // 注意：不在此处为 functionCall 生成 id。
         // id 的生成推迟到合并逻辑确认无法合并、需要作为新 Part 推入时再执行（见下方 newPart 构建处）。
 
+        // 例外：prompt 模式（json/xml）的增量解析器只会产出“完整工具调用块”，
+        // 不会再走 partialArgs/index 的流式合并路径。
+        // 这里提前补一个稳定 id，保证：
+        // 1. visibleDelta 里的 functionCall 带有 id
+        // 2. 后续写入 this.parts 时沿用同一个 id
+        // 3. 不影响 function_call 模式下的增量合并判断
+        if (
+            this.promptToolParser &&
+            part.functionCall &&
+            !(part.functionCall as any).id &&
+            (part.functionCall as any).partialArgs === undefined &&
+            typeof (part.functionCall as any).index !== 'number'
+        ) {
+            (part.functionCall as any).id = this.createToolCallId();
+        }
+
         if (options?.visibleDelta && part.text !== undefined) {
             options.visibleDelta.push(part.thought ? { text: part.text, thought: true } : { text: part.text });
         } else if (options?.visibleDelta && part.functionCall) {

--- a/backend/modules/conversation/pendingApprovalGate.ts
+++ b/backend/modules/conversation/pendingApprovalGate.ts
@@ -1,0 +1,178 @@
+import type {
+  PendingApprovalGate,
+  PendingApprovalGateContinuationIntent,
+  PendingApprovalGateKind,
+  PendingApprovalGateSourceArtifactType
+} from './types';
+
+export const PENDING_APPROVAL_GATE_KEY = 'pendingApprovalGate';
+
+export interface PendingApprovalGateStore {
+  getCustomMetadata(conversationId: string, key: string): Promise<unknown>;
+  setCustomMetadata(conversationId: string, key: string, value: unknown): Promise<void>;
+}
+
+export interface PendingApprovalGateSeed {
+  kind: PendingApprovalGateKind;
+  continuationIntent: PendingApprovalGateContinuationIntent;
+  sourceToolCallId: string;
+  sourceToolName: string;
+  sourceArtifactType: PendingApprovalGateSourceArtifactType;
+  sourcePath?: string;
+}
+
+export interface PendingApprovalGateExpectation {
+  kind?: PendingApprovalGateKind;
+  continuationIntent?: PendingApprovalGateContinuationIntent;
+  sourceToolCallId?: string;
+  sourceArtifactType?: PendingApprovalGateSourceArtifactType;
+  sourcePath?: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return normalized || undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return undefined;
+}
+
+function normalizePath(value: unknown): string | undefined {
+  const normalized = asString(value);
+  return normalized ? normalized.replace(/\\/g, '/') : undefined;
+}
+
+export function isPendingApprovalGateKind(value: unknown): value is PendingApprovalGateKind {
+  return value === 'generate_plan' || value === 'execute_plan';
+}
+
+export function isPendingApprovalGateContinuationIntent(value: unknown): value is PendingApprovalGateContinuationIntent {
+  return value === 'generate_plan_now' || value === 'implement_now';
+}
+
+export function isPendingApprovalGateSourceArtifactType(value: unknown): value is PendingApprovalGateSourceArtifactType {
+  return value === 'design' || value === 'review' || value === 'plan';
+}
+
+export function normalizePendingApprovalGate(value: unknown): PendingApprovalGate | null {
+  const record = asRecord(value);
+  if (!record) return null;
+
+  const id = asString(record.id);
+  const kind = record.kind;
+  const continuationIntent = record.continuationIntent;
+  const sourceToolCallId = asString(record.sourceToolCallId);
+  const sourceToolName = asString(record.sourceToolName);
+  const sourceArtifactType = record.sourceArtifactType;
+  const createdAt = asNumber(record.createdAt);
+
+  if (!id || !isPendingApprovalGateKind(kind) || !isPendingApprovalGateContinuationIntent(continuationIntent)) {
+    return null;
+  }
+
+  if (!sourceToolCallId || !sourceToolName || !isPendingApprovalGateSourceArtifactType(sourceArtifactType) || createdAt === undefined) {
+    return null;
+  }
+
+  return {
+    id,
+    kind,
+    continuationIntent,
+    sourceToolCallId,
+    sourceToolName,
+    sourceArtifactType,
+    sourcePath: normalizePath(record.sourcePath),
+    createdAt
+  };
+}
+
+function createPendingApprovalGateId(): string {
+  return `approval_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function getPendingApprovalGateKindForContinuationIntent(
+  intent: PendingApprovalGateContinuationIntent
+): PendingApprovalGateKind {
+  return intent === 'implement_now' ? 'execute_plan' : 'generate_plan';
+}
+
+export async function getPendingApprovalGate(
+  store: PendingApprovalGateStore,
+  conversationId: string
+): Promise<PendingApprovalGate | null> {
+  const raw = await store.getCustomMetadata(conversationId, PENDING_APPROVAL_GATE_KEY);
+  return normalizePendingApprovalGate(raw);
+}
+
+export async function replacePendingApprovalGate(
+  store: PendingApprovalGateStore,
+  conversationId: string,
+  seed: PendingApprovalGateSeed
+): Promise<PendingApprovalGate> {
+  const gate: PendingApprovalGate = {
+    id: createPendingApprovalGateId(),
+    kind: seed.kind,
+    continuationIntent: seed.continuationIntent,
+    sourceToolCallId: seed.sourceToolCallId,
+    sourceToolName: seed.sourceToolName,
+    sourceArtifactType: seed.sourceArtifactType,
+    sourcePath: normalizePath(seed.sourcePath),
+    createdAt: Date.now()
+  };
+
+  await store.setCustomMetadata(conversationId, PENDING_APPROVAL_GATE_KEY, gate);
+  return gate;
+}
+
+export async function clearPendingApprovalGate(
+  store: PendingApprovalGateStore,
+  conversationId: string
+): Promise<void> {
+  await store.setCustomMetadata(conversationId, PENDING_APPROVAL_GATE_KEY, null);
+}
+
+export function getPendingApprovalGateMismatchReason(
+  gate: PendingApprovalGate,
+  expected: PendingApprovalGateExpectation
+): string | null {
+  if (expected.kind && gate.kind !== expected.kind) {
+    return `Approval gate kind mismatch. Expected ${expected.kind}, got ${gate.kind}.`;
+  }
+
+  if (expected.continuationIntent && gate.continuationIntent !== expected.continuationIntent) {
+    return `Approval gate intent mismatch. Expected ${expected.continuationIntent}, got ${gate.continuationIntent}.`;
+  }
+
+  if (expected.sourceToolCallId) {
+    const expectedToolId = expected.sourceToolCallId.trim();
+    if (!expectedToolId) {
+      return 'Approval gate validation requires a non-empty toolId.';
+    }
+    if (gate.sourceToolCallId !== expectedToolId) {
+      return `Approval gate tool mismatch. Expected toolId=${expectedToolId}, got ${gate.sourceToolCallId}.`;
+    }
+  }
+
+  if (expected.sourceArtifactType && gate.sourceArtifactType !== expected.sourceArtifactType) {
+    return `Approval gate source artifact mismatch. Expected ${expected.sourceArtifactType}, got ${gate.sourceArtifactType}.`;
+  }
+
+  if (typeof expected.sourcePath === 'string') {
+    const expectedPath = normalizePath(expected.sourcePath);
+    const actualPath = normalizePath(gate.sourcePath);
+    if ((expectedPath || '') !== (actualPath || '')) {
+      return `Approval gate path mismatch. Expected ${expectedPath || '(empty)'}, got ${actualPath || '(empty)'}.`;
+    }
+  }
+
+  return null;
+}

--- a/backend/modules/conversation/types.ts
+++ b/backend/modules/conversation/types.ts
@@ -555,6 +555,29 @@ export interface CheckpointRecord {
     };
 }
 
+export type PendingApprovalGateKind = 'generate_plan' | 'execute_plan';
+export type PendingApprovalGateContinuationIntent = 'generate_plan_now' | 'implement_now';
+export type PendingApprovalGateSourceArtifactType = 'design' | 'review' | 'plan';
+
+export interface PendingApprovalGate {
+    /** 本次审批门闸唯一标识 */
+    id: string;
+    /** 门闸类别 */
+    kind: PendingApprovalGateKind;
+    /** 与现有 continuation 语义对齐的意图 */
+    continuationIntent: PendingApprovalGateContinuationIntent;
+    /** 触发当前门闸的工具调用 ID */
+    sourceToolCallId: string;
+    /** 触发当前门闸的工具名称 */
+    sourceToolName: string;
+    /** 触发当前门闸的源文档类型 */
+    sourceArtifactType: PendingApprovalGateSourceArtifactType;
+    /** 触发当前门闸的源文档路径（如有） */
+    sourcePath?: string;
+    /** 创建时间戳（毫秒） */
+    createdAt: number;
+}
+
 /**
  * 对话元数据
  *

--- a/backend/modules/notifications/WindowsAgentStopNotificationService.ts
+++ b/backend/modules/notifications/WindowsAgentStopNotificationService.ts
@@ -1,0 +1,480 @@
+import * as vscode from 'vscode'
+import { t } from '../../i18n'
+import type { SettingsManager } from '../settings/SettingsManager'
+import { NodeNotifierWindowsToastAdapter } from './WindowsToastAdapter'
+import { renderWindowsAgentStopTemplate } from './templateRenderer'
+import { deriveWindowsAgentStopWindowTitle } from './windowTitle'
+import type {
+  AgentStopNotificationDispatchResult,
+  AgentStopNotificationPayload,
+  AgentStopNotificationReason,
+  PendingAgentActionType,
+  WindowsAgentStopNotificationContentOverride,
+  WindowsNotificationPreviewPayload,
+  WindowsToastAdapter
+} from './types'
+
+const LOG_PREFIX = '[windows-agent-stop-notification][host]'
+const APP_NAME = 'LimCode'
+
+interface ResolvedWindowsAgentStopNotificationContentSettings {
+  titleTemplate: string
+  bodyTemplates: {
+    error: string
+    awaitingUserAction: string
+    continueRequired: string
+  }
+}
+
+interface ResolvedWindowsAgentStopNotificationSettings {
+  enabled: boolean
+  onlyWhenWindowNotFocused: boolean
+  cases: {
+    error: boolean
+    awaitingUserAction: boolean
+    continueRequired: boolean
+  }
+  content: ResolvedWindowsAgentStopNotificationContentSettings
+}
+
+const DEFAULT_WINDOWS_AGENT_STOP_NOTIFICATION_CONTENT: ResolvedWindowsAgentStopNotificationContentSettings = {
+  titleTemplate: '{windowTitle} · LimCode',
+  bodyTemplates: {
+    error: 'LimCode 已停止，请返回处理。',
+    awaitingUserAction: 'LimCode 正在等待：{actionLabel}。',
+    continueRequired: 'LimCode 已暂停，可继续处理。'
+  }
+}
+
+export interface WindowsAgentStopNotificationServiceOptions {
+  settingsManager: Pick<SettingsManager, 'getSettings'>
+  adapter?: WindowsToastAdapter
+  platform?: NodeJS.Platform
+  getWindowState?: () => { focused: boolean }
+  onDidChangeWindowState?: (
+    listener: (state: { focused: boolean }) => void
+  ) => { dispose: () => void }
+  executeCommand?: (command: string) => Promise<unknown> | Thenable<unknown>
+  logger?: Pick<Console, 'warn' | 'error'>
+  dedupeTtlMs?: number
+}
+
+function normalizeText(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
+function normalizeTemplateString(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback
+  const trimmed = value.trim()
+  return trimmed || fallback
+}
+
+function resolveContentSettings(
+  base?: WindowsAgentStopNotificationContentOverride
+): ResolvedWindowsAgentStopNotificationContentSettings {
+  return {
+    titleTemplate: normalizeTemplateString(base?.titleTemplate, DEFAULT_WINDOWS_AGENT_STOP_NOTIFICATION_CONTENT.titleTemplate),
+    bodyTemplates: {
+      error: normalizeTemplateString(base?.bodyTemplates?.error, DEFAULT_WINDOWS_AGENT_STOP_NOTIFICATION_CONTENT.bodyTemplates.error),
+      awaitingUserAction: normalizeTemplateString(base?.bodyTemplates?.awaitingUserAction, DEFAULT_WINDOWS_AGENT_STOP_NOTIFICATION_CONTENT.bodyTemplates.awaitingUserAction),
+      continueRequired: normalizeTemplateString(base?.bodyTemplates?.continueRequired, DEFAULT_WINDOWS_AGENT_STOP_NOTIFICATION_CONTENT.bodyTemplates.continueRequired)
+    }
+  }
+}
+
+function mergeContentSettings(
+  base: ResolvedWindowsAgentStopNotificationContentSettings,
+  override?: WindowsAgentStopNotificationContentOverride
+): ResolvedWindowsAgentStopNotificationContentSettings {
+  return {
+    titleTemplate: normalizeTemplateString(override?.titleTemplate, base.titleTemplate),
+    bodyTemplates: {
+      error: normalizeTemplateString(override?.bodyTemplates?.error, base.bodyTemplates.error),
+      awaitingUserAction: normalizeTemplateString(override?.bodyTemplates?.awaitingUserAction, base.bodyTemplates.awaitingUserAction),
+      continueRequired: normalizeTemplateString(override?.bodyTemplates?.continueRequired, base.bodyTemplates.continueRequired)
+    }
+  }
+}
+
+export class WindowsAgentStopNotificationService {
+  private readonly adapter: WindowsToastAdapter
+  private readonly platform: NodeJS.Platform
+  private readonly getWindowState: () => { focused: boolean }
+  private readonly onDidChangeWindowState: (
+    listener: (state: { focused: boolean }) => void
+  ) => { dispose: () => void }
+  private readonly executeCommand: (command: string) => Promise<unknown> | Thenable<unknown>
+  private readonly logger: Pick<Console, 'warn' | 'error'>
+  private readonly dedupeTtlMs: number
+  private readonly dedupeByKey = new Map<string, number>()
+
+  private windowFocused = false
+  private windowStateDisposable?: { dispose: () => void }
+
+  constructor(options: WindowsAgentStopNotificationServiceOptions) {
+    this.adapter = options.adapter ?? new NodeNotifierWindowsToastAdapter()
+    this.platform = options.platform ?? process.platform
+    this.getWindowState = options.getWindowState ?? (() => vscode.window.state)
+    this.onDidChangeWindowState = options.onDidChangeWindowState ?? vscode.window.onDidChangeWindowState
+    this.executeCommand = options.executeCommand ?? ((command: string) => vscode.commands.executeCommand(command))
+    this.logger = options.logger ?? console
+    this.dedupeTtlMs = options.dedupeTtlMs ?? 5 * 60 * 1000
+    this.settingsManager = options.settingsManager
+
+    this.windowFocused = !!this.getWindowState().focused
+    console.log(LOG_PREFIX, 'service initialized', {
+      platform: this.platform,
+      windowFocused: this.windowFocused
+    })
+
+    this.windowStateDisposable = this.onDidChangeWindowState((state) => {
+      this.windowFocused = !!state.focused
+      console.log(LOG_PREFIX, 'window focus changed', {
+        windowFocused: this.windowFocused
+      })
+    })
+  }
+
+  private readonly settingsManager: Pick<SettingsManager, 'getSettings'>
+
+  private getSettings(): ResolvedWindowsAgentStopNotificationSettings {
+    const raw = this.settingsManager.getSettings().ui?.sound?.windowsAgentStopNotification
+
+    return {
+      enabled: raw?.enabled === true,
+      onlyWhenWindowNotFocused: raw?.onlyWhenWindowNotFocused !== false,
+      cases: {
+        error: raw?.cases?.error !== false,
+        awaitingUserAction: raw?.cases?.awaitingUserAction !== false,
+        continueRequired: raw?.cases?.continueRequired !== false
+      },
+      content: resolveContentSettings(raw?.content)
+    }
+  }
+
+  private cleanupExpiredDedupes(now = Date.now()): void {
+    for (const [key, createdAt] of Array.from(this.dedupeByKey.entries())) {
+      if (now - createdAt > this.dedupeTtlMs) {
+        this.dedupeByKey.delete(key)
+      }
+    }
+  }
+
+  private isReasonEnabled(
+    reason: AgentStopNotificationReason,
+    settings: ResolvedWindowsAgentStopNotificationSettings
+  ): boolean {
+    if (reason === 'error') return settings.cases.error
+    if (reason === 'awaiting_user_action') return settings.cases.awaitingUserAction
+    return settings.cases.continueRequired
+  }
+
+  private isDuplicate(dedupeKey: string): boolean {
+    return this.dedupeByKey.has(dedupeKey)
+  }
+
+  private rememberDedupe(dedupeKey: string, createdAt: number): void {
+    this.dedupeByKey.set(dedupeKey, createdAt)
+  }
+
+  private getReasonLabel(reason: AgentStopNotificationReason): string {
+    switch (reason) {
+      case 'error':
+        return t('notifications.windowsAgentStop.reasonLabels.error')
+      case 'awaiting_user_action':
+        return t('notifications.windowsAgentStop.reasonLabels.awaitingUserAction')
+      case 'continue_required':
+      default:
+        return t('notifications.windowsAgentStop.reasonLabels.continueRequired')
+    }
+  }
+
+  private getActionLabel(actionType?: PendingAgentActionType): string | undefined {
+    switch (actionType) {
+      case 'generate_plan':
+        return t('notifications.windowsAgentStop.actionLabels.generatePlan')
+      case 'execute_plan':
+        return t('notifications.windowsAgentStop.actionLabels.executePlan')
+      case 'continue':
+        return t('notifications.windowsAgentStop.actionLabels.continue')
+      case 'generic_confirmation':
+        return t('notifications.windowsAgentStop.actionLabels.genericConfirmation')
+      default:
+        return undefined
+    }
+  }
+
+  private resolveActionLabel(
+    reason: AgentStopNotificationReason,
+    actionType?: PendingAgentActionType,
+    explicitActionLabel?: string
+  ): string | undefined {
+    const provided = normalizeText(explicitActionLabel)
+    if (provided) {
+      return provided
+    }
+
+    const fromActionType = this.getActionLabel(actionType)
+    if (fromActionType) {
+      return fromActionType
+    }
+
+    if (reason === 'awaiting_user_action') {
+      return t('notifications.windowsAgentStop.actionLabels.genericConfirmation')
+    }
+
+    if (reason === 'continue_required') {
+      return t('notifications.windowsAgentStop.actionLabels.continue')
+    }
+
+    return undefined
+  }
+
+  private getBodyTemplateForReason(
+    reason: AgentStopNotificationReason,
+    content: ResolvedWindowsAgentStopNotificationContentSettings
+  ): string {
+    if (reason === 'error') return content.bodyTemplates.error
+    if (reason === 'awaiting_user_action') return content.bodyTemplates.awaitingUserAction
+    return content.bodyTemplates.continueRequired
+  }
+
+  private buildRenderedNotification(
+    reason: AgentStopNotificationReason,
+    content: ResolvedWindowsAgentStopNotificationContentSettings,
+    options: {
+      actionType?: PendingAgentActionType
+      actionLabel?: string
+    }
+  ): {
+    title: string
+    message: string
+    windowTitle: string
+    reasonLabel: string
+    actionLabel?: string
+  } {
+    const windowTitle = deriveWindowsAgentStopWindowTitle()
+    const reasonLabel = this.getReasonLabel(reason)
+    const actionLabel = this.resolveActionLabel(reason, options.actionType, options.actionLabel)
+    const context = {
+      appName: APP_NAME,
+      windowTitle,
+      actionLabel,
+      reasonLabel
+    }
+
+    const title = normalizeText(renderWindowsAgentStopTemplate(content.titleTemplate, context))
+      || renderWindowsAgentStopTemplate(DEFAULT_WINDOWS_AGENT_STOP_NOTIFICATION_CONTENT.titleTemplate, context)
+      || APP_NAME
+
+    const bodyTemplate = this.getBodyTemplateForReason(reason, content)
+    const defaultBodyTemplate = this.getBodyTemplateForReason(reason, DEFAULT_WINDOWS_AGENT_STOP_NOTIFICATION_CONTENT)
+    const message = normalizeText(renderWindowsAgentStopTemplate(bodyTemplate, context))
+      || renderWindowsAgentStopTemplate(defaultBodyTemplate, context)
+      || title
+
+    return {
+      title,
+      message,
+      windowTitle,
+      reasonLabel,
+      actionLabel
+    }
+  }
+
+  private async handleNotificationClick(): Promise<void> {
+    try {
+      console.log(LOG_PREFIX, 'handling notification click by executing limcode.openChat')
+      await this.executeCommand('limcode.openChat')
+      console.log(LOG_PREFIX, 'limcode.openChat executed successfully')
+    } catch (error) {
+      this.logger.error('[windows-agent-stop-notification] Failed to focus chat view:', error)
+    }
+  }
+
+  private async showToast(title: string, message: string): Promise<AgentStopNotificationDispatchResult> {
+    console.log(LOG_PREFIX, 'showToast invoked', {
+      title,
+      message,
+      windowFocused: this.windowFocused
+    })
+
+    const toastResult = await this.adapter.show({
+      title,
+      message,
+      silent: true,
+      waitForAction: true,
+      onClick: () => this.handleNotificationClick()
+    })
+
+    if (!toastResult.shown) {
+      console.log(LOG_PREFIX, 'toast adapter reported not shown', toastResult)
+
+      if (toastResult.error) {
+        this.logger.warn('[windows-agent-stop-notification] Failed to show toast:', toastResult.error)
+      }
+
+      return {
+        shown: false,
+        skipped: true,
+        reason: toastResult.skippedReason || (toastResult.error ? 'adapter_error' : 'not_shown')
+      }
+    }
+
+    console.log(LOG_PREFIX, 'toast adapter reported success')
+
+    return {
+      shown: true,
+      skipped: false
+    }
+  }
+
+  async notify(payload: AgentStopNotificationPayload): Promise<AgentStopNotificationDispatchResult> {
+    const now = Date.now()
+    this.cleanupExpiredDedupes(now)
+
+    console.log(LOG_PREFIX, 'notify called', {
+      reason: payload.reason,
+      dedupeKey: payload.dedupeKey,
+      conversationId: payload.conversationId,
+      actionType: payload.actionType,
+      windowFocused: this.windowFocused
+    })
+
+    if (this.platform !== 'win32') {
+      console.log(LOG_PREFIX, 'skip notify because platform is not win32', { platform: this.platform })
+      return {
+        shown: false,
+        skipped: true,
+        reason: 'unsupported_platform'
+      }
+    }
+
+    const settings = this.getSettings()
+    console.log(LOG_PREFIX, 'resolved host notification settings', settings)
+
+    if (!settings.enabled) {
+      console.log(LOG_PREFIX, 'skip notify because feature is disabled in settings')
+      return {
+        shown: false,
+        skipped: true,
+        reason: 'disabled'
+      }
+    }
+
+    if (!this.isReasonEnabled(payload.reason, settings)) {
+      console.log(LOG_PREFIX, 'skip notify because reason is disabled in settings', {
+        reason: payload.reason
+      })
+      return {
+        shown: false,
+        skipped: true,
+        reason: 'case_disabled'
+      }
+    }
+
+    if (settings.onlyWhenWindowNotFocused && this.windowFocused) {
+      console.log(LOG_PREFIX, 'skip notify because originating window is focused')
+      return {
+        shown: false,
+        skipped: true,
+        reason: 'window_focused'
+      }
+    }
+
+    const dedupeKey = normalizeText(payload.dedupeKey)
+    if (!dedupeKey) {
+      console.log(LOG_PREFIX, 'skip notify because dedupeKey is missing')
+      return {
+        shown: false,
+        skipped: true,
+        reason: 'missing_dedupe_key'
+      }
+    }
+
+    if (this.isDuplicate(dedupeKey)) {
+      console.log(LOG_PREFIX, 'skip notify because dedupeKey is duplicated', {
+        dedupeKey
+      })
+      return {
+        shown: false,
+        skipped: true,
+        reason: 'duplicate'
+      }
+    }
+
+    const rendered = this.buildRenderedNotification(payload.reason, settings.content, {
+      actionType: payload.actionType,
+      actionLabel: payload.actionLabel
+    })
+    console.log(LOG_PREFIX, 'rendered notification content', {
+      reason: payload.reason,
+      title: rendered.title,
+      message: rendered.message,
+      windowTitle: rendered.windowTitle,
+      reasonLabel: rendered.reasonLabel,
+      actionLabel: rendered.actionLabel
+    })
+
+    const result = await this.showToast(rendered.title, rendered.message)
+    if (!result.shown) {
+      console.log(LOG_PREFIX, 'notify finished without showing toast', result)
+      return result
+    }
+
+    this.rememberDedupe(dedupeKey, now)
+    console.log(LOG_PREFIX, 'remembered dedupeKey after successful toast', {
+      dedupeKey,
+      storedAt: now
+    })
+
+    return result
+  }
+
+  async preview(payload: WindowsNotificationPreviewPayload): Promise<AgentStopNotificationDispatchResult> {
+    console.log(LOG_PREFIX, 'preview called', {
+      reason: payload.reason,
+      actionType: payload.actionType,
+      hasContentOverride: !!payload.content,
+      windowFocused: this.windowFocused
+    })
+
+    if (this.platform !== 'win32') {
+      console.log(LOG_PREFIX, 'skip preview because platform is not win32', { platform: this.platform })
+      return {
+        shown: false,
+        skipped: true,
+        reason: 'unsupported_platform'
+      }
+    }
+
+    const settings = this.getSettings()
+    const content = mergeContentSettings(settings.content, payload.content)
+    const rendered = this.buildRenderedNotification(payload.reason, content, {
+      actionType: payload.actionType,
+      actionLabel: payload.actionLabel
+    })
+
+    console.log(LOG_PREFIX, 'rendered preview content', {
+      reason: payload.reason,
+      title: rendered.title,
+      message: rendered.message,
+      windowTitle: rendered.windowTitle,
+      reasonLabel: rendered.reasonLabel,
+      actionLabel: rendered.actionLabel
+    })
+
+    const result = await this.showToast(rendered.title, rendered.message)
+    console.log(LOG_PREFIX, 'preview finished', result)
+    return result
+  }
+
+  dispose(): void {
+    this.windowStateDisposable?.dispose()
+    this.windowStateDisposable = undefined
+    this.dedupeByKey.clear()
+    console.log(LOG_PREFIX, 'service disposed')
+  }
+}

--- a/backend/modules/notifications/WindowsToastAdapter.ts
+++ b/backend/modules/notifications/WindowsToastAdapter.ts
@@ -1,0 +1,172 @@
+import * as vscode from 'vscode'
+import type { WindowsToastAdapter, WindowsToastRequest, WindowsToastShowResult } from './types'
+
+const LOG_PREFIX = '[windows-agent-stop-notification][toast]'
+
+const DEFAULT_VSCODE_WINDOWS_APP_ID = 'Microsoft.VisualStudioCode'
+
+function resolveVSCodeWindowsToastAppId(): string {
+  const appName = typeof vscode.env.appName === 'string' ? vscode.env.appName.trim() : ''
+  const uriScheme = typeof vscode.env.uriScheme === 'string' ? vscode.env.uriScheme.trim().toLowerCase() : ''
+
+  if (uriScheme === 'vscode-insiders' || /insiders/i.test(appName)) {
+    return 'Microsoft.VisualStudioCode.Insiders'
+  }
+
+  return DEFAULT_VSCODE_WINDOWS_APP_ID
+}
+
+type WindowsToasterLike = {
+  notify: (
+    options: Record<string, unknown>,
+    callback?: (error: Error | null, response?: string, metadata?: unknown) => void
+  ) => void
+  once: (eventName: string, listener: (...args: any[]) => void) => void
+  removeListener: (eventName: string, listener: (...args: any[]) => void) => void
+}
+
+export type WindowsToasterFactory = () => WindowsToasterLike
+
+function defaultCreateWindowsToaster(): WindowsToasterLike {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const notifier = require('node-notifier')
+  const WindowsToaster = notifier?.WindowsToaster || notifier
+  return new WindowsToaster({ withFallback: false })
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message.trim()
+  if (typeof error === 'string' && error.trim()) return error.trim()
+  return 'Unknown Windows toast error'
+}
+
+export class NodeNotifierWindowsToastAdapter implements WindowsToastAdapter {
+  constructor(
+    private readonly createWindowsToaster: WindowsToasterFactory = defaultCreateWindowsToaster,
+    private readonly logger: Pick<Console, 'error'> = console,
+    private readonly cleanupDelayMs = 5 * 60 * 1000,
+    private readonly appId: string = resolveVSCodeWindowsToastAppId()
+  ) {}
+
+  async show(request: WindowsToastRequest): Promise<WindowsToastShowResult> {
+    console.log(LOG_PREFIX, 'show called', {
+      title: request.title,
+      message: request.message,
+      silent: request.silent,
+      waitForAction: request.waitForAction,
+      hasOnClick: typeof request.onClick === 'function',
+      appId: this.appId
+    })
+
+    if (process.platform !== 'win32') {
+      console.log(LOG_PREFIX, 'skip show because platform is not win32', { platform: process.platform })
+      return {
+        shown: false,
+        skippedReason: 'unsupported_platform'
+      }
+    }
+
+    let toaster: WindowsToasterLike
+    try {
+      toaster = this.createWindowsToaster()
+      console.log(LOG_PREFIX, 'created Windows toaster instance')
+    } catch (error) {
+      console.error(LOG_PREFIX, 'failed to create Windows toaster instance', error)
+      return {
+        shown: false,
+        error: toErrorMessage(error)
+      }
+    }
+
+    return await new Promise<WindowsToastShowResult>((resolve) => {
+      let cleaned = false
+      let cleanupTimer: NodeJS.Timeout | null = null
+
+      const cleanup = () => {
+        if (cleaned) return
+        cleaned = true
+
+        if (cleanupTimer) {
+          clearTimeout(cleanupTimer)
+          cleanupTimer = null
+        }
+
+        try {
+          toaster.removeListener('click', handleClick)
+          toaster.removeListener('timeout', handleTimeout)
+          toaster.removeListener('replied', handleReply)
+        } catch {
+          // ignore cleanup failures
+        }
+      }
+
+      const handleClick = () => {
+        console.log(LOG_PREFIX, 'toast click event received')
+        void Promise.resolve(request.onClick?.()).catch((error) => {
+          this.logger.error('[windows-toast] Failed to handle click:', error)
+        }).finally(() => {
+          cleanup()
+        })
+      }
+
+      const handleTimeout = () => {
+        console.log(LOG_PREFIX, 'toast timeout event received')
+        cleanup()
+      }
+
+      const handleReply = () => {
+        console.log(LOG_PREFIX, 'toast replied event received')
+        cleanup()
+      }
+
+      if (request.onClick) {
+        toaster.once('click', handleClick)
+      }
+      toaster.once('timeout', handleTimeout)
+      toaster.once('replied', handleReply)
+      cleanupTimer = setTimeout(cleanup, this.cleanupDelayMs)
+
+      try {
+        console.log(LOG_PREFIX, 'calling toaster.notify')
+        toaster.notify(
+          {
+            title: request.title,
+            message: request.message,
+            sound: request.silent ? false : true,
+            wait: request.waitForAction,
+            appID: this.appId
+          },
+          (error, response, metadata) => {
+            if (error) {
+              console.error(LOG_PREFIX, 'toaster.notify callback returned error', error)
+              cleanup()
+              resolve({
+                shown: false,
+                error: toErrorMessage(error)
+              })
+              return
+            }
+
+            console.log(LOG_PREFIX, 'toaster.notify callback reported success', {
+              response,
+              metadata
+            })
+
+            resolve({ shown: true })
+
+            if (!request.waitForAction && !request.onClick) {
+              cleanup()
+            }
+          }
+        )
+      } catch (error) {
+        console.error(LOG_PREFIX, 'toaster.notify threw synchronously', error)
+        cleanup()
+        resolve({
+          shown: false,
+          error: toErrorMessage(error)
+        })
+      }
+    })
+  }
+}

--- a/backend/modules/notifications/templateRenderer.ts
+++ b/backend/modules/notifications/templateRenderer.ts
@@ -1,0 +1,34 @@
+export interface WindowsAgentStopNotificationTemplateContext {
+  appName: string
+  windowTitle: string
+  actionLabel?: string
+  reasonLabel: string
+}
+
+const ALLOWED_TEMPLATE_VARIABLES = new Set([
+  'appName',
+  'windowTitle',
+  'actionLabel',
+  'reasonLabel'
+] as const)
+
+export function renderWindowsAgentStopTemplate(
+  template: string,
+  context: WindowsAgentStopNotificationTemplateContext
+): string {
+  if (!template) {
+    return ''
+  }
+
+  return template.replace(/\{([^{}]+)\}/g, (_match, rawName: string) => {
+    const name = String(rawName || '').trim()
+    if (!ALLOWED_TEMPLATE_VARIABLES.has(name as 'appName' | 'windowTitle' | 'actionLabel' | 'reasonLabel')) {
+      return ''
+    }
+
+    if (name === 'appName') return context.appName
+    if (name === 'windowTitle') return context.windowTitle
+    if (name === 'actionLabel') return context.actionLabel ?? ''
+    return context.reasonLabel
+  }).trim()
+}

--- a/backend/modules/notifications/types.ts
+++ b/backend/modules/notifications/types.ts
@@ -1,0 +1,60 @@
+export type AgentStopNotificationReason = 'error' | 'awaiting_user_action' | 'continue_required'
+
+export type PendingAgentActionType = 'generate_plan' | 'execute_plan' | 'continue' | 'generic_confirmation'
+
+export interface WindowsAgentStopNotificationContentOverride {
+  titleTemplate?: string
+  bodyTemplates?: {
+    error?: string
+    awaitingUserAction?: string
+    continueRequired?: string
+  }
+}
+
+export interface AgentStopNotificationPayload {
+  reason: AgentStopNotificationReason
+  dedupeKey: string
+  createdAt: number
+  title?: string
+  message?: string
+  conversationId?: string
+  conversationTitle?: string
+  actionType?: PendingAgentActionType
+  actionLabel?: string
+  toolName?: string
+  toolId?: string
+  path?: string
+  errorCode?: string
+  errorMessage?: string
+}
+
+export interface WindowsNotificationPreviewPayload {
+  reason: AgentStopNotificationReason
+  actionType?: PendingAgentActionType
+  actionLabel?: string
+  content?: WindowsAgentStopNotificationContentOverride
+}
+
+export interface WindowsToastRequest {
+  title: string
+  message: string
+  silent: boolean
+  waitForAction: boolean
+  onClick?: () => void | Promise<void>
+}
+
+export interface WindowsToastShowResult {
+  shown: boolean
+  skippedReason?: string
+  error?: string
+}
+
+export interface WindowsToastAdapter {
+  show(request: WindowsToastRequest): Promise<WindowsToastShowResult>
+}
+
+export interface AgentStopNotificationDispatchResult {
+  shown: boolean
+  skipped: boolean
+  reason?: string
+}

--- a/backend/modules/notifications/windowTitle.ts
+++ b/backend/modules/notifications/windowTitle.ts
@@ -1,0 +1,62 @@
+import * as path from 'path'
+import * as vscode from 'vscode'
+import { t } from '../../i18n'
+
+interface WorkspaceLike {
+  workspaceFile?: { fsPath: string } | null
+  workspaceFolders?: Array<{
+    name?: string
+    uri: { fsPath: string }
+  }>
+}
+
+interface WindowLike {
+  activeTextEditor?: {
+    document?: {
+      uri?: {
+        fsPath?: string
+      }
+    }
+  } | null
+}
+
+export interface DeriveWindowsAgentStopWindowTitleOptions {
+  workspace?: WorkspaceLike
+  window?: WindowLike
+  basename?: (value: string) => string
+}
+
+function basenameOrUndefined(value: string | undefined, basename: (value: string) => string): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  const name = basename(value).trim()
+  return name || undefined
+}
+
+export function deriveWindowsAgentStopWindowTitle(
+  options: DeriveWindowsAgentStopWindowTitleOptions = {}
+): string {
+  const workspace = options.workspace ?? vscode.workspace
+  const window = options.window ?? vscode.window
+  const basename = options.basename ?? path.basename
+
+  const workspaceFileName = basenameOrUndefined(workspace.workspaceFile?.fsPath, basename)
+  if (workspaceFileName) {
+    return workspaceFileName
+  }
+
+  const workspaceFolders = workspace.workspaceFolders ?? []
+  if (workspaceFolders.length === 1) {
+    const folderName = workspaceFolders[0]?.name?.trim()
+    return folderName || basenameOrUndefined(workspaceFolders[0]?.uri?.fsPath, basename) || t('notifications.windowsAgentStop.currentWindow')
+  }
+
+  const activeEditorFileName = basenameOrUndefined(window.activeTextEditor?.document?.uri?.fsPath, basename)
+  if (activeEditorFileName) {
+    return activeEditorFileName
+  }
+
+  return t('notifications.windowsAgentStop.currentWindow')
+}

--- a/backend/modules/settings/types.ts
+++ b/backend/modules/settings/types.ts
@@ -1245,6 +1245,42 @@ export interface StorageStats {
 /**
  * UI 声音提醒设置
  */
+export interface WindowsAgentStopNotificationContentSettings {
+    /** 通知标题模板 */
+    titleTemplate?: string;
+
+    /** 通知正文模板 */
+    bodyTemplates?: {
+        /** 错误停止 */
+        error?: string;
+        /** 等待用户动作 */
+        awaitingUserAction?: string;
+        /** 等待继续 */
+        continueRequired?: string;
+    };
+}
+
+export interface WindowsAgentStopNotificationSettings {
+    /** 总开关（默认关闭） */
+    enabled?: boolean;
+
+    /** 仅在当前窗口未聚焦时发送通知 */
+    onlyWhenWindowNotFocused?: boolean;
+
+    /** 停止场景开关 */
+    cases?: {
+        /** 错误停止 */
+        error?: boolean;
+        /** 等待用户操作 */
+        awaitingUserAction?: boolean;
+        /** 等待继续 */
+        continueRequired?: boolean;
+    };
+
+    /** 通知内容模板 */
+    content?: WindowsAgentStopNotificationContentSettings;
+}
+
 export interface UISoundSettings {
     /** 总开关（默认关闭，避免打扰） */
     enabled?: boolean;
@@ -1278,6 +1314,11 @@ export interface UISoundSettings {
 
     /** 提示音风格 */
     theme?: 'beep' | 'soft';
+
+    /**
+     * Windows 专用 Agent 停止系统通知设置
+     */
+    windowsAgentStopNotification?: WindowsAgentStopNotificationSettings;
 }
 
 /**
@@ -2432,7 +2473,24 @@ export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
                 taskComplete: true,
                 taskError: true
             },
-            theme: 'beep'
+            theme: 'beep',
+            windowsAgentStopNotification: {
+                enabled: false,
+                onlyWhenWindowNotFocused: true,
+                cases: {
+                    error: true,
+                    awaitingUserAction: true,
+                    continueRequired: true
+                },
+                content: {
+                    titleTemplate: '{windowTitle} · LimCode',
+                    bodyTemplates: {
+                        error: 'LimCode 已停止，请返回处理。',
+                        awaitingUserAction: 'LimCode 正在等待：{actionLabel}。',
+                        continueRequired: 'LimCode 已暂停，可继续处理。'
+                    }
+                }
+            }
         }
     },
     lastUpdated: Date.now()

--- a/backend/tools/file/diffManager.ts
+++ b/backend/tools/file/diffManager.ts
@@ -279,9 +279,21 @@ export class DiffManager {
     
     /** 文档保存事件监听器 */
     private saveListeners: Map<string, vscode.Disposable> = new Map();
+
+    /** 文档即将保存事件监听器 */
+    private willSaveListeners: Map<string, vscode.Disposable> = new Map();
     
     /** 文档关闭事件监听器 */
     private closeListeners: Map<string, vscode.Disposable> = new Map();
+
+    /** 被非手动保存打断后，需要在保存完成后恢复的草稿内容 */
+    private suppressedNonManualSaveDrafts: Map<string, string> = new Map();
+
+    /** 正在执行接受动作的 diff */
+    private acceptingDiffIds: Set<string> = new Set();
+
+    /** 正在执行拒绝动作的 diff */
+    private rejectingDiffIds: Set<string> = new Set();
     
     private constructor() {
         this.contentProvider = new OriginalContentProvider();
@@ -399,6 +411,81 @@ export class DiffManager {
         for (const listener of this.saveCompleteListeners) {
             listener(diff);
         }
+    }
+
+    /**
+     * 某个 diff 是否正处于内部接受/拒绝动作处理中
+     */
+    public isDiffActionInProgress(id: string): boolean {
+        return this.acceptingDiffIds.has(id) || this.rejectingDiffIds.has(id);
+    }
+
+    /**
+     * 释放 diff 相关监听器
+     */
+    private disposeDiffListeners(id: string): void {
+        const saveListener = this.saveListeners.get(id);
+        if (saveListener) {
+            saveListener.dispose();
+            this.saveListeners.delete(id);
+        }
+
+        const willSaveListener = this.willSaveListeners.get(id);
+        if (willSaveListener) {
+            willSaveListener.dispose();
+            this.willSaveListeners.delete(id);
+        }
+
+        const closeListener = this.closeListeners.get(id);
+        if (closeListener) {
+            closeListener.dispose();
+            this.closeListeners.delete(id);
+        }
+
+        this.suppressedNonManualSaveDrafts.delete(id);
+    }
+
+    private async restorePendingDraftAfterNonManualSave(diff: PendingDiff, draftContent: string): Promise<void> {
+        const fileUri = vscode.Uri.file(diff.absolutePath);
+        const doc = vscode.workspace.textDocuments.find(d => d.uri.fsPath === diff.absolutePath)
+            || await vscode.workspace.openTextDocument(fileUri);
+
+        const currentContent = doc.getText();
+        if (currentContent === draftContent) {
+            return;
+        }
+
+        const edit = new vscode.WorkspaceEdit();
+        const fullRange = new vscode.Range(
+            doc.positionAt(0),
+            doc.positionAt(currentContent.length)
+        );
+        edit.replace(fileUri, fullRange, draftContent);
+        const applied = await vscode.workspace.applyEdit(edit);
+        if (!applied) {
+            throw new Error(`Failed to restore pending diff draft for ${diff.filePath}`);
+        }
+    }
+
+    private finalizeAcceptedDiff(diff: PendingDiff): void {
+        if (diff.status !== 'pending') {
+            return;
+        }
+        this.disposeDiffListeners(diff.id);
+        diff.status = 'accepted';
+        this.cleanup(diff.id);
+        this.notifyStatusChange();
+        this.notifySaveComplete(diff);
+    }
+
+    private finalizeRejectedDiff(diff: PendingDiff): void {
+        if (diff.status !== 'pending') {
+            return;
+        }
+        this.disposeDiffListeners(diff.id);
+        diff.status = 'rejected';
+        this.cleanup(diff.id);
+        this.notifyStatusChange();
     }
     
     /**
@@ -540,7 +627,14 @@ export class DiffManager {
             await this.directApplyAndSave(pendingDiff);
         } else {
             // 显示 diff 视图
-            await this.showDiffView(pendingDiff);
+            try {
+                await this.showDiffView(pendingDiff);
+            } catch (error) {
+                console.warn(
+                    `[DiffManager] Failed to open diff view for ${filePath}; keeping pending diff available for manual apply/reject.`,
+                    error
+                );
+            }
         }
         
         // 如果开启自动保存且 diff 仍处于 pending 状态，设置定时器
@@ -860,54 +954,115 @@ export class DiffManager {
             return;
         }
         
-        // 5. 监听文档保存事件
+        // 5. 监听文档即将保存事件
+        const willSaveListener = vscode.workspace.onWillSaveTextDocument((event) => {
+            if (event.document.uri.fsPath !== diff.absolutePath || diff.status !== 'pending') {
+                return;
+            }
+
+            if (this.isDiffActionInProgress(diff.id)) {
+                return;
+            }
+
+            const currentSettings = this.getSettings();
+            if (currentSettings.autoSave || event.reason === vscode.TextDocumentSaveReason.Manual) {
+                return;
+            }
+
+            const currentDraftContent = event.document.getText();
+            this.suppressedNonManualSaveDrafts.set(diff.id, currentDraftContent);
+
+            const fullRange = new vscode.Range(
+                event.document.positionAt(0),
+                event.document.positionAt(currentDraftContent.length)
+            );
+
+            event.waitUntil(Promise.resolve([
+                vscode.TextEdit.replace(fullRange, diff.originalContent)
+            ]));
+        });
+
+        // 6. 监听文档保存事件
         const saveListener = vscode.workspace.onDidSaveTextDocument(async (savedDoc) => {
-            if (savedDoc.uri.fsPath === diff.absolutePath) {
-                // 检查用户是否修改了内容（保存时的最终内容）
-                const savedContent = savedDoc.getText();
+            if (savedDoc.uri.fsPath !== diff.absolutePath || diff.status !== 'pending') {
+                return;
+            }
 
-                // 以“系统建议将保存的内容”为基准（考虑 CodeLens 拒绝块等）
-                const baseSuggestedContent = this.computeFinalSuggestedContent(diff.id, diff);
+            if (this.isDiffActionInProgress(diff.id)) {
+                return;
+            }
 
-                if (savedContent !== baseSuggestedContent && savedContent !== diff.originalContent) {
-                    // 仅保留摘要，不在工具响应里发送完整文件内容
-                    diff.userEditedContent = computeUserEditedNewLinesSummary(baseSuggestedContent, savedContent);
+            const suppressedDraft = this.suppressedNonManualSaveDrafts.get(diff.id);
+            if (suppressedDraft !== undefined) {
+                this.suppressedNonManualSaveDrafts.delete(diff.id);
+                try {
+                    await this.restorePendingDraftAfterNonManualSave(diff, suppressedDraft);
+                } catch (error) {
+                    console.warn(
+                        `[DiffManager] Failed to restore pending diff draft after non-manual save for ${diff.filePath}:`,
+                        error
+                    );
                 }
+                return;
+            }
 
-                diff.status = 'accepted';
-                saveListener.dispose();
-                this.cleanup(diff.id);
-                this.notifyStatusChange();
-                this.notifySaveComplete(diff);
+            // 检查用户是否修改了内容（保存时的最终内容）
+            const savedContent = savedDoc.getText();
 
-                // 非自动保存模式下，用户手动保存后自动关闭 diff 标签页
+            if (savedContent === diff.originalContent) {
+                this.finalizeRejectedDiff(diff);
+
                 const currentSettings = this.getSettings();
                 if (!currentSettings.autoSave) {
                     await this.closeDiffTab(diff.absolutePath);
                 }
+                return;
+            }
+
+            // 以“系统建议将保存的内容”为基准（考虑 CodeLens 拒绝块等）
+            const baseSuggestedContent = this.computeFinalSuggestedContent(diff.id, diff);
+
+            if (savedContent !== baseSuggestedContent && savedContent !== diff.originalContent) {
+                // 仅保留摘要，不在工具响应里发送完整文件内容
+                diff.userEditedContent = computeUserEditedNewLinesSummary(baseSuggestedContent, savedContent);
+            }
+
+            this.finalizeAcceptedDiff(diff);
+
+            // 非自动保存模式下，用户手动保存后自动关闭 diff 标签页
+            const currentSettings = this.getSettings();
+            if (!currentSettings.autoSave) {
+                await this.closeDiffTab(diff.absolutePath);
             }
         });
         
-        // 6. 监听文档关闭事件
+        // 7. 监听文档关闭事件
         const closeListener = vscode.workspace.onDidCloseTextDocument((closedDoc) => {
-            if (closedDoc.uri.fsPath === diff.absolutePath && diff.status === 'pending') {
-                try {
-                    const currentContent = fs.readFileSync(diff.absolutePath, 'utf8');
-                    if (currentContent !== diff.newContent) {
-                        diff.status = 'rejected';
-                        this.cleanup(diff.id);
-                        this.notifyStatusChange();
-                    }
-                } catch (e) {
-                    // 忽略错误
+            if (closedDoc.uri.fsPath !== diff.absolutePath || diff.status !== 'pending') {
+                return;
+            }
+
+            if (this.isDiffActionInProgress(diff.id)) {
+                return;
+            }
+
+            try {
+                const currentContent = fs.readFileSync(diff.absolutePath, 'utf8');
+                if (currentContent !== diff.newContent) {
+                    this.finalizeRejectedDiff(diff);
                 }
-                closeListener.dispose();
-                saveListener.dispose();
+            } catch (e) {
+                // 忽略错误
             }
         });
 
         // 若在注册监听器期间被取消/拒绝，立即释放监听器并恢复内容，避免残留订阅造成后续错乱
         if (!isPending()) {
+            try {
+                willSaveListener.dispose();
+            } catch {
+                // ignore
+            }
             try {
                 saveListener.dispose();
             } catch {
@@ -927,6 +1082,7 @@ export class DiffManager {
             return;
         }
         
+        this.willSaveListeners.set(diff.id, willSaveListener);
         this.saveListeners.set(diff.id, saveListener);
         this.closeListeners.set(diff.id, closeListener);
     }
@@ -943,7 +1099,10 @@ export class DiffManager {
         const currentSettings = this.getSettings();
         const timer = setTimeout(async () => {
             // 自动保存：强制使用 AI 建议的内容（避免覆盖用户可能正在进行的手动修改）
-            await this.acceptDiff(id, true, true);
+            const accepted = await this.acceptDiff(id, true, true);
+            if (!accepted) {
+                console.warn(`[DiffManager] Auto-save failed for diff ${id}; keeping it pending for manual retry.`);
+            }
             this.autoSaveTimers.delete(id);
         }, currentSettings.autoSaveDelay);
         
@@ -958,23 +1117,13 @@ export class DiffManager {
      */
     public async acceptDiff(id: string, closeTab: boolean = false, isAutoSave: boolean = false): Promise<boolean> {
         const diff = this.pendingDiffs.get(id);
-        if (!diff || diff.status !== 'pending') {
+        if (!diff || diff.status !== 'pending' || this.isDiffActionInProgress(id)) {
             return false;
         }
+
+        this.acceptingDiffIds.add(id);
         
         try {
-            // 移除监听器（避免重复处理）
-            const saveListener = this.saveListeners.get(id);
-            if (saveListener) {
-                saveListener.dispose();
-                this.saveListeners.delete(id);
-            }
-            const closeListener = this.closeListeners.get(id);
-            if (closeListener) {
-                closeListener.dispose();
-                this.closeListeners.delete(id);
-            }
-
             const finalContent = this.computeFinalSuggestedContent(id, diff);
             
             const uri = vscode.Uri.file(diff.absolutePath);
@@ -1000,7 +1149,10 @@ export class DiffManager {
                         doc.positionAt(currentContent.length)
                     );
                     edit.replace(uri, fullRange, finalContent);
-                    await vscode.workspace.applyEdit(edit);
+                    const applied = await vscode.workspace.applyEdit(edit);
+                    if (!applied) {
+                        throw new Error(`Failed to stage accepted diff content for ${diff.filePath}`);
+                    }
                 }
                 contentToSave = finalContent;
             } else {
@@ -1062,22 +1214,28 @@ export class DiffManager {
                 }
             }
             
-            diff.status = 'accepted';
-            this.cleanup(id);
-
-            this.notifyStatusChange();
-            this.notifySaveComplete(diff);
+            this.finalizeAcceptedDiff(diff);
             
-            vscode.window.setStatusBarMessage(`$(check) ${t('tools.file.diffManager.savedShort', { filePath: diff.filePath })}`, 3000);
+            try {
+                vscode.window.setStatusBarMessage(`$(check) ${t('tools.file.diffManager.savedShort', { filePath: diff.filePath })}`, 3000);
+            } catch (error) {
+                console.warn(`[DiffManager] Failed to show accepted status for ${diff.filePath}:`, error);
+            }
             
             if (closeTab) {
-                await this.closeDiffTab(diff.absolutePath);
+                try {
+                    await this.closeDiffTab(diff.absolutePath);
+                } catch (error) {
+                    console.warn(`[DiffManager] Failed to close diff tab for ${diff.filePath}:`, error);
+                }
             }
             
             return true;
         } catch (error) {
             vscode.window.showErrorMessage(t('tools.file.diffManager.saveFailed', { error: error instanceof Error ? error.message : String(error) }));
             return false;
+        } finally {
+            this.acceptingDiffIds.delete(id);
         }
     }
     
@@ -1103,9 +1261,11 @@ export class DiffManager {
      */
     public async rejectDiff(id: string): Promise<boolean> {
         const diff = this.pendingDiffs.get(id);
-        if (!diff || diff.status !== 'pending') {
+        if (!diff || diff.status !== 'pending' || this.isDiffActionInProgress(id)) {
             return false;
         }
+
+        this.rejectingDiffIds.add(id);
         
         try {
             // 1. 恢复文件内容
@@ -1119,7 +1279,10 @@ export class DiffManager {
                     doc.positionAt(doc.getText().length)
                 );
                 edit.replace(uri, fullRange, diff.originalContent);
-                await vscode.workspace.applyEdit(edit);
+                const applied = await vscode.workspace.applyEdit(edit);
+                if (!applied) {
+                    throw new Error(`Failed to restore original content for ${diff.filePath}`);
+                }
                 
                 // 如果文件曾经被保存过（脏了），这里我们不强制保存，因为用户拒绝了 AI 的修改。
                 // 但如果文件在 AI 修改前就是干净的，AI 修改让它变脏了，我们现在恢复了原始内容，它应该变回干净（或者通过 undo）。
@@ -1128,30 +1291,20 @@ export class DiffManager {
                 fs.writeFileSync(diff.absolutePath, diff.originalContent, 'utf8');
             }
 
-            // 2. 关闭 diff 标签页
-            await this.closeDiffTab(diff.absolutePath);
+            this.finalizeRejectedDiff(diff);
 
-            // 3. 移除监听器
-            const saveListener = this.saveListeners.get(id);
-            if (saveListener) {
-                saveListener.dispose();
-                this.saveListeners.delete(id);
+            try {
+                await this.closeDiffTab(diff.absolutePath);
+            } catch (error) {
+                console.warn(`[DiffManager] Failed to close rejected diff tab for ${diff.filePath}:`, error);
             }
-            const closeListener = this.closeListeners.get(id);
-            if (closeListener) {
-                closeListener.dispose();
-                this.closeListeners.delete(id);
-            }
-
-            diff.status = 'rejected';
-            this.cleanup(id);
-
-            this.notifyStatusChange();
             
             return true;
         } catch (error) {
             console.error('Failed to reject diff:', error);
             return false;
+        } finally {
+            this.rejectingDiffIds.delete(id);
         }
     }
     
@@ -1379,11 +1532,18 @@ export class DiffManager {
             listener.dispose();
         }
         this.saveListeners.clear();
+
+        for (const listener of this.willSaveListeners.values()) {
+            listener.dispose();
+        }
+        this.willSaveListeners.clear();
         
         for (const listener of this.closeListeners.values()) {
             listener.dispose();
         }
         this.closeListeners.clear();
+
+        this.suppressedNonManualSaveDrafts.clear();
         
         if (this.providerDisposable) {
             this.providerDisposable.dispose();

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -21,6 +21,7 @@ import { sendToExtension, onMessageFromExtension } from './utils/vscode'
 import type { Attachment, Message, StreamChunk } from './types'
 import { configureSoundSettings } from './services/soundCues'
 import { handleSoundEvent, registerGlobalAudioUnlockHooks, registerVisibilityChangeHooks } from './services/soundEventController'
+import { createAgentStopNotificationController, type AgentStopNotificationController } from './services/agentStopNotificationController'
 
 // i18n
 const { t } = useI18n()
@@ -66,6 +67,7 @@ const lastRetryAttempt = ref(-1)
 let disposeMessageListener: (() => void) | null = null
 let disposeAudioUnlockHooks: (() => void) | null = null
 let disposeVisibilityHooks: (() => void) | null = null
+let agentStopNotificationController: AgentStopNotificationController | null = null
 
 /**
  * 从 toolStatus chunk 中检测特定工具完成并播放音效：
@@ -214,9 +216,11 @@ async function handleSend(content: string, messageAttachments: Attachment[]) {
 
 // 处理取消请求
 async function handleCancel() {
+  agentStopNotificationController?.markUserCancelled()
   try {
     await chatStore.cancelStream()
   } catch (err) {
+    agentStopNotificationController?.clearUserCancelled()
     console.error('取消失败:', err)
   }
 }
@@ -391,6 +395,11 @@ onMounted(async () => {
   
   // 先加载语言设置，确保 UI 语言正确
   await loadLanguageSettings()
+
+  agentStopNotificationController = createAgentStopNotificationController({
+    chatStore,
+    sendToExtension
+  })
   
   // 立即注册命令监听器，确保在初始化期间也能响应用户操作
   disposeMessageListener = onMessageFromExtension((message: any) => {
@@ -465,6 +474,9 @@ onBeforeUnmount(() => {
 
   disposeVisibilityHooks?.()
   disposeVisibilityHooks = null
+
+  agentStopNotificationController?.dispose()
+  agentStopNotificationController = null
 })
 </script>
 

--- a/frontend/src/components/common/MarkdownRenderer.vue
+++ b/frontend/src/components/common/MarkdownRenderer.vue
@@ -36,9 +36,12 @@ import footnote from 'markdown-it-footnote'
 import deflist from 'markdown-it-deflist'
 import taskLists from 'markdown-it-task-lists'
 
+type RenderProfile = 'default' | 'artifactSafe'
+
 const props = withDefaults(defineProps<{
   content: string
   latexOnly?: boolean  // 仅渲染 LaTeX，不渲染 Markdown（用于用户消息）
+  renderProfile?: RenderProfile
   /**
    * 是否处于流式更新中
    *
@@ -47,6 +50,7 @@ const props = withDefaults(defineProps<{
   isStreaming?: boolean
 }>(), {
   latexOnly: false,
+  renderProfile: 'default',
   isStreaming: false
 })
 
@@ -510,9 +514,9 @@ function markdownItWorkspaceFileLinks(md: MarkdownIt) {
 /**
  * 创建并配置 markdown-it 实例
  */
-function createMarkdownIt() {
+function createMarkdownIt(options: { allowHtml: boolean }) {
   const md = new MarkdownIt({
-    html: true,           // 允许 HTML 标签
+    html: options.allowHtml,
     xhtmlOut: false,
     breaks: true,         // 换行转 <br>
     linkify: true,        // 自动检测链接
@@ -674,7 +678,12 @@ function createMarkdownIt() {
 }
 
 // 创建 markdown-it 实例
-const md = createMarkdownIt()
+const defaultMd = createMarkdownIt({ allowHtml: true })
+const artifactSafeMd = createMarkdownIt({ allowHtml: false })
+
+function getMarkdownItInstance(renderProfile: RenderProfile): MarkdownIt {
+  return renderProfile === 'artifactSafe' ? artifactSafeMd : defaultMd
+}
 
 /**
  * 仅渲染 LaTeX（保留原始文本格式）
@@ -896,17 +905,19 @@ function markdownItKatex(md: MarkdownIt) {
 /**
  * 渲染 Markdown 和 LaTeX
  */
-function renderContent(content: string, latexOnly: boolean): string {
+function renderContent(content: string, latexOnly: boolean, renderProfile: RenderProfile): string {
   if (!content) return ''
   
   // 仅 LaTeX 模式（用户消息）
   if (latexOnly) {
     return renderLatexOnly(content)
   }
+
+  const markdownIt = getMarkdownItInstance(renderProfile)
   
   // 完整 Markdown 模式：LaTeX 由 markdown-it 插件解析（$...$ / $$...$$）
   // 每次渲染传入独立 env，保证 code block 的序号从 1 开始
-  let html = md.render(content, {})
+  let html = markdownIt.render(content, {})
   
   // 保留多个连续空格（在段落内容中）
   html = html.replace(/(<(?:p|li|td|th|dd|dt)[^>]*>)([\s\S]*?)(<\/(?:p|li|td|th|dd|dt)>)/g,
@@ -936,9 +947,11 @@ const STREAM_RENDER_DEBOUNCE_MS = 120
 let renderTimer: number | null = null
 /** 上一次实际渲染时使用的内容快照，用于跳过无变化的重渲染 */
 let lastRenderedSource = ''
+let lastRenderedProfile: RenderProfile = 'default'
 let lastRenderedLatexOnly = false
 /** 后处理（图片/Mermaid/链接校验）是否已对当前内容完成 */
 let postProcessedSource = ''
+let postProcessedProfile: RenderProfile = 'default'
 
 function clearRenderTimer() {
   if (renderTimer !== null) {
@@ -955,22 +968,28 @@ function scheduleRender() {
   if (!props.isStreaming && renderedContent.value === '') {
     const contentChanged = !(
       props.content === lastRenderedSource &&
-      props.latexOnly === lastRenderedLatexOnly
+      props.latexOnly === lastRenderedLatexOnly &&
+      props.renderProfile === lastRenderedProfile
     )
     if (contentChanged) {
       lastRenderedSource = props.content
       lastRenderedLatexOnly = props.latexOnly
-      renderedContent.value = renderContent(props.content, props.latexOnly)
+      lastRenderedProfile = props.renderProfile
+      renderedContent.value = renderContent(props.content, props.latexOnly, props.renderProfile)
     }
     // 后处理（图片/Mermaid/链接校验、代码块换行状态）仍异步执行
     renderTimer = window.setTimeout(async () => {
       await nextTick()
       applyCodeBlockWrapStates()
-      if (!props.isStreaming && postProcessedSource !== props.content) {
+      if (!props.isStreaming && (
+        postProcessedSource !== props.content ||
+        postProcessedProfile !== props.renderProfile
+      )) {
         await prevalidateFilePaths(props.content)
         await loadWorkspaceImages()
         await renderMermaid()
         postProcessedSource = props.content
+        postProcessedProfile = props.renderProfile
       }
     }, 0)
     return
@@ -981,26 +1000,30 @@ function scheduleRender() {
     const contentChanged = !(
       props.content === lastRenderedSource &&
       props.latexOnly === lastRenderedLatexOnly &&
+      props.renderProfile === lastRenderedProfile &&
       renderedContent.value !== ''
     )
 
     // 需要后处理（图片/Mermaid）且尚未完成
-    const needsPostProcess = !props.isStreaming && postProcessedSource !== props.content
+    const needsPostProcess = !props.isStreaming && (
+      postProcessedSource !== props.content ||
+      postProcessedProfile !== props.renderProfile
+    )
 
     if (contentChanged || needsPostProcess) {
       // 非流式阶段：渲染前预校验文件路径，写入缓存供 markdown-it 插件查询
       // 这样不存在的路径从一开始就不会生成 <a> 标签，无闪烁
-      if (!props.isStreaming) {
+      if (!props.isStreaming && contentChanged) {
         await prevalidateFilePaths(props.content)
       }
 
       lastRenderedSource = props.content
       lastRenderedLatexOnly = props.latexOnly
-      renderedContent.value = renderContent(props.content, props.latexOnly)
+      lastRenderedProfile = props.renderProfile
+      renderedContent.value = renderContent(props.content, props.latexOnly, props.renderProfile)
 
       // Mermaid / workspace images 需要基于最新 DOM 执行
       await nextTick()
-
       // 回填代码块换行状态（流式阶段也需要保持）
       applyCodeBlockWrapStates()
     }
@@ -1014,6 +1037,7 @@ function scheduleRender() {
     await renderMermaid()
 
     postProcessedSource = props.content
+    postProcessedProfile = props.renderProfile
   }, delay)
 }
 
@@ -1315,7 +1339,7 @@ onMounted(() => {
 })
 
 watch(
-  () => [props.content, props.latexOnly, props.isStreaming] as const,
+  () => [props.content, props.latexOnly, props.renderProfile, props.isStreaming] as const,
   () => {
     scheduleRender()
   },

--- a/frontend/src/components/common/TaskCard.vue
+++ b/frontend/src/components/common/TaskCard.vue
@@ -92,7 +92,7 @@ const statusClass = computed(() => {
     <div v-if="hasPreview" class="preview">
       <CustomScrollbar :horizontal="true" :max-height="160">
         <div class="preview-inner">
-          <MarkdownRenderer v-if="previewIsMarkdown" :content="preview!" />
+          <MarkdownRenderer v-if="previewIsMarkdown" :content="preview!" render-profile="artifactSafe" />
           <pre v-else class="preview-text">{{ preview }}</pre>
         </div>
       </CustomScrollbar>

--- a/frontend/src/components/message/MessageList.vue
+++ b/frontend/src/components/message/MessageList.vue
@@ -58,7 +58,7 @@ const todoBarItems = computed<BuildTodoItem[]>(() => {
 })
 
 // 每个对话独立记忆 TODO 展开状态；key = conversationId, value = 用户最后设定的展开/折叠
-// undefined 表示该对话从未手动设置过（首次出现 TODO 时自动展开）
+// undefined 表示该对话从未手动设置过（首次出现 TODO 时默认折叠）
 const todoExpandedMap = new Map<string, boolean>()
 const isTodoExpanded = ref(false)
 
@@ -344,7 +344,7 @@ watch(
   () => chatStore.activeBuild?.id,
   (id, prev) => {
     if (id && id !== prev) {
-      isBuildExpanded.value = true
+      isBuildExpanded.value = false
     }
   }
 )
@@ -389,8 +389,8 @@ function restoreTodoExpandedState() {
   if (convId && todoExpandedMap.has(convId)) {
     isTodoExpanded.value = todoExpandedMap.get(convId)!
   } else {
-    isTodoExpanded.value = true
-    if (convId) todoExpandedMap.set(convId, true)
+    isTodoExpanded.value = false
+    if (convId) todoExpandedMap.set(convId, false)
   }
 }
 
@@ -1371,9 +1371,12 @@ function formatCheckpointTime(timestamp: number): string {
 }
 
 .build-body {
+  max-height: min(40vh, 320px);
   padding: 8px 10px 10px;
   background: var(--vscode-editor-background);
   border-top: 1px solid var(--vscode-panel-border);
+  overflow: auto;
+  overscroll-behavior: contain;
 }
 
 .build-empty {
@@ -1389,6 +1392,7 @@ function formatCheckpointTime(timestamp: number): string {
 .build-todos {
   display: flex;
   flex-direction: column;
+  min-height: 0;
   gap: 6px;
 }
 

--- a/frontend/src/components/message/MessageTaskCards.vue
+++ b/frontend/src/components/message/MessageTaskCards.vue
@@ -1081,7 +1081,7 @@ const hasAny = computed(() => taskCards.value.length > 0)
       <div class="task-content">
         <CustomScrollbar :max-height="isCardExpanded(c.key) ? 500 : 200">
           <div class="task-preview">
-            <MarkdownRenderer :content="getCardPreviewContent(c)" />
+            <MarkdownRenderer :content="getCardPreviewContent(c)" render-profile="artifactSafe" />
           </div>
         </CustomScrollbar>
       </div>

--- a/frontend/src/components/message/MessageTaskCards.vue
+++ b/frontend/src/components/message/MessageTaskCards.vue
@@ -480,6 +480,7 @@ async function executePlan(card: TaskCardItem) {
         sourceArtifactType?: 'design' | 'review'
         sourcePath?: string
         error?: string
+        approvalId?: string
         todos?: Array<{
           id: string
           content: string
@@ -488,6 +489,7 @@ async function executePlan(card: TaskCardItem) {
       }>('plan.confirmExecution', {
         path: card.path,
         originalContent: card.content,
+        toolId: card.toolId,
         conversationId: chatStore.currentConversationId
       })
 
@@ -499,6 +501,13 @@ async function executePlan(card: TaskCardItem) {
       }
 
       const prompt = String(confirmResult?.prompt || '')
+      const approvalId = typeof confirmResult?.approvalId === 'string'
+        ? confirmResult.approvalId.trim()
+        : ''
+      if (!approvalId) {
+        await showNotification(t('components.message.tool.planCard.executePlanFailed'), 'warning')
+        return
+      }
       const latestPlanContent = confirmResult?.planContent || card.content
       const todosFromPlan = Array.isArray(confirmResult?.todos) ? confirmResult.todos : []
 
@@ -530,6 +539,7 @@ async function executePlan(card: TaskCardItem) {
         modelOverride: selectedModelId.value || undefined,
         hidden: {
           functionResponse: {
+            approvalId,
             id: card.toolId,
             name: card.toolName,
             response: {
@@ -565,15 +575,30 @@ async function generatePlan(card: TaskCardItem) {
       const confirmResult = await sendToExtension<{
         success: boolean
         prompt: string
+        approvalId?: string
         designContent: string
         designPath: string
+        error?: string
       }>('design.confirmPlanGeneration', {
         path: card.path,
         originalContent: card.content,
+        toolId: card.toolId,
         conversationId: chatStore.currentConversationId
       })
 
+      if (!confirmResult?.success) {
+        await showNotification(String(confirmResult?.error || t('components.message.tool.designCard.generatePlanFailed')), 'warning')
+        return
+      }
+
       const prompt = String(confirmResult?.prompt || '')
+      const approvalId = typeof confirmResult?.approvalId === 'string'
+        ? confirmResult.approvalId.trim()
+        : ''
+      if (!approvalId) {
+        await showNotification(t('components.message.tool.designCard.generatePlanFailed'), 'warning')
+        return
+      }
       const latestDesignContent = confirmResult?.designContent || card.content
       const latestDesignPath = String(confirmResult?.designPath || card.path || '')
 
@@ -592,6 +617,7 @@ async function generatePlan(card: TaskCardItem) {
         modelOverride: selectedModelId.value || undefined,
         hidden: {
           functionResponse: {
+            approvalId,
             id: card.toolId,
             name: card.toolName,
             response: {
@@ -626,15 +652,30 @@ async function generatePlanFromReview(card: TaskCardItem) {
       const confirmResult = await sendToExtension<{
         success: boolean
         prompt: string
+        approvalId?: string
         reviewContent: string
         reviewPath: string
+        error?: string
       }>('review.confirmPlanGeneration', {
         path: card.path,
         originalContent: card.content,
+        toolId: card.toolId,
         conversationId: chatStore.currentConversationId
       })
 
+      if (!confirmResult?.success) {
+        await showNotification(String(confirmResult?.error || t('components.message.tool.reviewCard.generatePlanFailed')), 'warning')
+        return
+      }
+
       const prompt = String(confirmResult?.prompt || '')
+      const approvalId = typeof confirmResult?.approvalId === 'string'
+        ? confirmResult.approvalId.trim()
+        : ''
+      if (!approvalId) {
+        await showNotification(t('components.message.tool.reviewCard.generatePlanFailed'), 'warning')
+        return
+      }
       const latestReviewContent = confirmResult?.reviewContent || card.content
       const latestReviewPath = String(confirmResult?.reviewPath || card.path || '')
 
@@ -650,6 +691,7 @@ async function generatePlanFromReview(card: TaskCardItem) {
         modelOverride: selectedModelId.value || undefined,
         hidden: {
           functionResponse: {
+            approvalId,
             id: card.toolId,
             name: card.toolName,
             response: {

--- a/frontend/src/components/message/ProgressTaskCard.vue
+++ b/frontend/src/components/message/ProgressTaskCard.vue
@@ -388,21 +388,21 @@ onBeforeUnmount(() => {
         <div v-if="card.latestConclusion" class="progress-block">
           <div class="progress-label">{{ t('components.message.tool.progressCard.latestConclusion') }}</div>
           <div class="progress-rich-content">
-            <MarkdownRenderer :content="card.latestConclusion" />
+            <MarkdownRenderer :content="card.latestConclusion" render-profile="artifactSafe" />
           </div>
         </div>
 
         <div v-if="card.currentBlocker" class="progress-block">
           <div class="progress-label">{{ t('components.message.tool.progressCard.currentBlocker') }}</div>
           <div class="progress-rich-content">
-            <MarkdownRenderer :content="card.currentBlocker" />
+            <MarkdownRenderer :content="card.currentBlocker" render-profile="artifactSafe" />
           </div>
         </div>
 
         <div v-if="card.nextAction" class="progress-block">
           <div class="progress-label">{{ t('components.message.tool.progressCard.nextAction') }}</div>
           <div class="progress-rich-content">
-            <MarkdownRenderer :content="card.nextAction" />
+            <MarkdownRenderer :content="card.nextAction" render-profile="artifactSafe" />
           </div>
         </div>
 
@@ -431,7 +431,7 @@ onBeforeUnmount(() => {
         <div v-if="showRawContent" class="progress-block">
           <div class="progress-label">{{ t('components.message.tool.progressCard.rawResult') }}</div>
           <div class="progress-raw-result">
-            <MarkdownRenderer :content="props.content" />
+            <MarkdownRenderer :content="props.content" render-profile="artifactSafe" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/message/ReviewTaskCard.vue
+++ b/frontend/src/components/message/ReviewTaskCard.vue
@@ -666,13 +666,13 @@ onBeforeUnmount(() => {
                 <div v-if="item.description" class="review-finding-rich">
                   <div class="review-inline-label">{{ t('components.message.tool.reviewCard.changeDescription') }}</div>
                   <div class="review-rich-content compact">
-                    <MarkdownRenderer :content="item.description" />
+                    <MarkdownRenderer :content="item.description" render-profile="artifactSafe" />
                   </div>
                 </div>
                 <div v-if="item.recommendation" class="review-finding-rich">
                   <div class="review-inline-label">{{ t('components.message.tool.reviewCard.changeRecommendation') }}</div>
                   <div class="review-rich-content compact">
-                    <MarkdownRenderer :content="item.recommendation" />
+                    <MarkdownRenderer :content="item.recommendation" render-profile="artifactSafe" />
                   </div>
                 </div>
                 <div v-if="item.relatedMilestoneIds && item.relatedMilestoneIds.length > 0" class="review-detail-row">
@@ -709,13 +709,13 @@ onBeforeUnmount(() => {
                 <div v-if="item.description" class="review-finding-rich">
                   <div class="review-inline-label">{{ t('components.message.tool.reviewCard.changeDescription') }}</div>
                   <div class="review-rich-content compact">
-                    <MarkdownRenderer :content="item.description" />
+                    <MarkdownRenderer :content="item.description" render-profile="artifactSafe" />
                   </div>
                 </div>
                 <div v-if="item.recommendation" class="review-finding-rich">
                   <div class="review-inline-label">{{ t('components.message.tool.reviewCard.changeRecommendation') }}</div>
                   <div class="review-rich-content compact">
-                    <MarkdownRenderer :content="item.recommendation" />
+                    <MarkdownRenderer :content="item.recommendation" render-profile="artifactSafe" />
                   </div>
                 </div>
                 <div v-if="item.relatedMilestoneIds && item.relatedMilestoneIds.length > 0" class="review-detail-row">
@@ -752,13 +752,13 @@ onBeforeUnmount(() => {
                 <div v-if="item.description" class="review-finding-rich">
                   <div class="review-inline-label">{{ t('components.message.tool.reviewCard.changeDescription') }}</div>
                   <div class="review-rich-content compact">
-                    <MarkdownRenderer :content="item.description" />
+                    <MarkdownRenderer :content="item.description" render-profile="artifactSafe" />
                   </div>
                 </div>
                 <div v-if="item.recommendation" class="review-finding-rich">
                   <div class="review-inline-label">{{ t('components.message.tool.reviewCard.changeRecommendation') }}</div>
                   <div class="review-rich-content compact">
-                    <MarkdownRenderer :content="item.recommendation" />
+                    <MarkdownRenderer :content="item.recommendation" render-profile="artifactSafe" />
                   </div>
                 </div>
                 <div v-if="item.relatedMilestoneIds && item.relatedMilestoneIds.length > 0" class="review-detail-row">
@@ -779,14 +779,14 @@ onBeforeUnmount(() => {
         <div v-if="card.latestConclusion" class="review-block">
           <div class="review-label">{{ t('components.message.tool.reviewCard.latestConclusion') }}</div>
           <div class="review-rich-content">
-            <MarkdownRenderer :content="card.latestConclusion" />
+            <MarkdownRenderer :content="card.latestConclusion" render-profile="artifactSafe" />
           </div>
         </div>
 
         <div v-if="card.recommendedNextAction" class="review-block">
           <div class="review-label">{{ t('components.message.tool.reviewCard.recommendedNextAction') }}</div>
           <div class="review-rich-content">
-            <MarkdownRenderer :content="card.recommendedNextAction" />
+            <MarkdownRenderer :content="card.recommendedNextAction" render-profile="artifactSafe" />
           </div>
         </div>
 
@@ -818,7 +818,7 @@ onBeforeUnmount(() => {
           <div class="review-raw-result">
             <CustomScrollbar :max-height="400">
               <div class="review-raw-result-inner">
-                <MarkdownRenderer v-if="rawContentIsMarkdown" :content="rawContent" />
+                <MarkdownRenderer v-if="rawContentIsMarkdown" :content="rawContent" render-profile="artifactSafe" />
                 <pre v-else class="review-raw-text">{{ rawContent }}</pre>
               </div>
             </CustomScrollbar>

--- a/frontend/src/components/message/ToolMessage.vue
+++ b/frontend/src/components/message/ToolMessage.vue
@@ -15,7 +15,7 @@ import type { ToolUsage, Message } from '../../types'
 import { getToolConfig } from '../../utils/toolRegistry'
 import { ensureMcpToolRegistered } from '../../utils/tools'
 import { useChatStore } from '../../stores'
-import { sendToExtension, onExtensionCommand } from '../../utils/vscode'
+import { sendToExtension, onExtensionCommand, showNotification } from '../../utils/vscode'
 import { useI18n } from '../../i18n'
 import { generateId } from '../../utils/format'
 import { isPerfEnabled } from '../../utils/perf'
@@ -43,12 +43,18 @@ function debugToolOnce(key: string, data: Record<string, unknown>) {
 // 支持 apply_diff, write_file, search_in_files(替换模式) 共用 diff 确认流程
 
 // 支持 diff 确认的工具名称列表
-const DIFF_SUPPORTED_TOOLS = ['apply_diff', 'write_file', 'search_in_files']
+const DIFF_SUPPORTED_TOOLS = ['apply_diff', 'write_file', 'search_in_files', 'insert_code', 'delete_code']
 
 type ApplyDiffAutoSaveConfig = { autoSave: boolean; autoSaveDelay: number }
 
-// 每个工具的自动确认配置
-const applyDiffConfigs = ref<Map<string, ApplyDiffAutoSaveConfig>>(new Map())
+type PendingDiffSession = {
+  id: string
+  toolId?: string
+  filePath: string
+  diffGuardWarning?: string
+  diffGuardDeletePercent?: number
+}
+
 const applyDiffTimeLeft = ref<Map<string, number>>(new Map())
 const applyDiffProgress = ref<Map<string, number>>(new Map())
 const applyDiffTimers = new Map<string, ReturnType<typeof setInterval>>()
@@ -56,8 +62,8 @@ const applyDiffTimers = new Map<string, ReturnType<typeof setInterval>>()
 // apply_diff 的全局配置（应用到所有支持 diff 的工具）
 const globalApplyDiffConfig = ref<ApplyDiffAutoSaveConfig>({ autoSave: false, autoSaveDelay: 3000 })
 
-// 工具 ID 到 Pending Diff ID 的映射
-const toolIdToPendingId = ref<Map<string, string>>(new Map())
+// 工具 ID 到 Pending Diff 列表的映射
+const toolIdToPendingDiffs = ref<Map<string, PendingDiffSession[]>>(new Map())
 
 // 工具 ID 到 diff 警戒值警告的映射
 const diffGuardWarnings = ref<Map<string, { warning: string; deletePercent: number }>>(new Map())
@@ -73,6 +79,96 @@ const seenDiffToolIds = ref<Set<string>>(new Set())
 const pendingDiffOrphanedAt = ref<Map<string, number>>(new Map())
 const DIFF_ORPHAN_GRACE_MS = 800
 
+const processingDiffSessionIds = ref<Set<string>>(new Set())
+const diffActionErrors = ref<Map<string, string>>(new Map())
+
+function addProcessingDiffSessionId(sessionId: string) {
+  if (!sessionId || processingDiffSessionIds.value.has(sessionId)) return
+  const next = new Set(processingDiffSessionIds.value)
+  next.add(sessionId)
+  processingDiffSessionIds.value = next
+}
+
+function removeProcessingDiffSessionId(sessionId: string) {
+  if (!sessionId || !processingDiffSessionIds.value.has(sessionId)) return
+  const next = new Set(processingDiffSessionIds.value)
+  next.delete(sessionId)
+  processingDiffSessionIds.value = next
+}
+
+function clearDiffActionError(sessionId: string) {
+  if (!sessionId || !diffActionErrors.value.has(sessionId)) return
+  const next = new Map(diffActionErrors.value)
+  next.delete(sessionId)
+  diffActionErrors.value = next
+}
+
+function setDiffActionError(sessionId: string, message: string) {
+  const next = new Map(diffActionErrors.value)
+  next.set(sessionId, message)
+  diffActionErrors.value = next
+}
+
+function getDiffActionError(sessionId: string): string | undefined {
+  return diffActionErrors.value.get(sessionId)
+}
+
+function getAllPendingDiffSessions(): PendingDiffSession[] {
+  return Array.from(toolIdToPendingDiffs.value.values()).flatMap((sessions) => sessions)
+}
+
+function getPendingDiffSessions(toolOrId: ToolUsage | string): PendingDiffSession[] {
+  const toolId = typeof toolOrId === 'string' ? toolOrId : toolOrId.id
+  return toolIdToPendingDiffs.value.get(toolId) ?? []
+}
+
+function hasPendingDiffSession(sessionId: string): boolean {
+  return getAllPendingDiffSessions().some((session) => session.id === sessionId)
+}
+
+function extractPendingDiffIdsFromResultData(data: any): string[] {
+  const pendingDiffIds = new Set<string>()
+
+  if (typeof data?.pendingDiffId === 'string' && data.pendingDiffId) {
+    pendingDiffIds.add(data.pendingDiffId)
+  }
+
+  if (Array.isArray(data?.results)) {
+    for (const item of data.results) {
+      if (typeof item?.pendingDiffId === 'string' && item.pendingDiffId) {
+        pendingDiffIds.add(item.pendingDiffId)
+      }
+    }
+  }
+
+  if (Array.isArray(data?.replacements)) {
+    for (const item of data.replacements) {
+      if (typeof item?.pendingDiffId === 'string' && item.pendingDiffId) {
+        pendingDiffIds.add(item.pendingDiffId)
+      }
+    }
+  }
+
+  return Array.from(pendingDiffIds)
+}
+
+function getActionErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && typeof error.message === 'string' && error.message.trim()) {
+    return error.message
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return error
+  }
+
+  const maybeMessage = (error as any)?.message
+  if (typeof maybeMessage === 'string' && maybeMessage.trim()) {
+    return maybeMessage
+  }
+
+  return fallback
+}
+
 // 检查是否是支持 diff 的工具且处于 pending 状态
 function isDiffToolPending(tool: ToolUsage) {
   // 检查工具是否支持 diff 确认
@@ -86,35 +182,12 @@ function isDiffToolPending(tool: ToolUsage) {
   }
   
   // 情况 1: 检查工具是否在后端活跃的 Pending Diff 列表中
-  if (toolIdToPendingId.value.has(tool.id)) return true
+  if (getPendingDiffSessions(tool).length > 0) return true
   
   // 情况 2: 结果中已有状态 (已返回)，且后端报告它是活跃的
   const resultData = tool.result?.data as any
   if (resultData) {
-    // apply_diff: pendingDiffId 直接在 data 上
-    if (resultData.pendingDiffId) {
-      if (Array.from(toolIdToPendingId.value.values()).includes(resultData.pendingDiffId)) {
-        return true
-      }
-    }
-    
-    // write_file: pendingDiffId 在 data.results 数组的每个元素上
-    if (Array.isArray(resultData.results)) {
-      for (const r of resultData.results) {
-        if (r.pendingDiffId && Array.from(toolIdToPendingId.value.values()).includes(r.pendingDiffId)) {
-          return true
-        }
-      }
-    }
-    
-    // search_in_files: pendingDiffId 在 data.replacements 数组的每个元素上
-    if (Array.isArray(resultData.replacements)) {
-      for (const r of resultData.replacements) {
-        if (r.pendingDiffId && Array.from(toolIdToPendingId.value.values()).includes(r.pendingDiffId)) {
-          return true
-        }
-      }
-    }
+    return extractPendingDiffIdsFromResultData(resultData).some((pendingDiffId) => hasPendingDiffSession(pendingDiffId))
   }
   
   return false
@@ -128,8 +201,8 @@ function normalizeApplyDiffConfig(raw: any): ApplyDiffAutoSaveConfig {
 }
 
 function clearAllDiffTimers() {
-  for (const toolId of Array.from(applyDiffTimers.keys())) {
-    stopDiffTimer(toolId)
+  for (const sessionId of Array.from(applyDiffTimers.keys())) {
+    stopDiffTimer(sessionId)
   }
   applyDiffTimeLeft.value = new Map()
   applyDiffProgress.value = new Map()
@@ -139,108 +212,107 @@ function applyGlobalApplyDiffConfig(config: ApplyDiffAutoSaveConfig, opts?: { re
   const restartTimers = opts?.restartTimers ?? false
   globalApplyDiffConfig.value = config
 
-  // 更新当前工具的配置缓存（用于 UI 渲染）
-  for (const tool of enhancedTools.value) {
-    if (isDiffToolPending(tool)) {
-      applyDiffConfigs.value.set(tool.id, config)
-    } else {
-      applyDiffConfigs.value.delete(tool.id)
-    }
-  }
-
   if (!restartTimers) return
 
   // 配置变更时，重置所有倒计时并按新配置重新开始
   clearAllDiffTimers()
 
   if (config.autoSave) {
-    for (const tool of enhancedTools.value) {
-      if (isDiffToolPending(tool) && !applyDiffTimers.has(tool.id)) {
-        applyDiffConfigs.value.set(tool.id, config)
-        startDiffTimer(tool.id, config.autoSaveDelay)
+    for (const session of getAllPendingDiffSessions()) {
+      if (!applyDiffTimers.has(session.id) && !processingDiffSessionIds.value.has(session.id) && !diffActionErrors.value.has(session.id)) {
+        startDiffTimer(session.id, config.autoSaveDelay)
       }
     }
   }
 }
 
 // 启动自动确认计时器
-function startDiffTimer(toolId: string, delay: number) {
-  if (applyDiffTimers.has(toolId)) return
+function startDiffTimer(sessionId: string, delay: number) {
+  if (applyDiffTimers.has(sessionId)) return
+  if (processingDiffSessionIds.value.has(sessionId)) return
+  if (diffActionErrors.value.has(sessionId)) return
+  if (delay <= 0) return
+
   
-  applyDiffTimeLeft.value.set(toolId, delay)
-  applyDiffProgress.value.set(toolId, 100)
+  applyDiffTimeLeft.value.set(sessionId, delay)
+  applyDiffProgress.value.set(sessionId, 100)
   const startTime = Date.now()
   
   const timer = setInterval(() => {
     const elapsed = Date.now() - startTime
     const remaining = Math.max(0, delay - elapsed)
-    applyDiffTimeLeft.value.set(toolId, remaining)
-    applyDiffProgress.value.set(toolId, (remaining / delay) * 100)
+    applyDiffTimeLeft.value.set(sessionId, remaining)
+    applyDiffProgress.value.set(sessionId, (remaining / delay) * 100)
     
     if (remaining <= 0) {
-      stopDiffTimer(toolId)
-      confirmDiff(toolId)
+      stopDiffTimer(sessionId)
+      confirmDiff(sessionId)
     }
   }, 50)
   
-  applyDiffTimers.set(toolId, timer)
+  applyDiffTimers.set(sessionId, timer)
 }
 
-function stopDiffTimer(toolId: string) {
-  const timer = applyDiffTimers.get(toolId)
+function stopDiffTimer(sessionId: string) {
+  const timer = applyDiffTimers.get(sessionId)
   if (timer) {
     clearInterval(timer)
-    applyDiffTimers.delete(toolId)
+    applyDiffTimers.delete(sessionId)
   }
+  applyDiffTimeLeft.value.delete(sessionId)
+  applyDiffProgress.value.delete(sessionId)
 }
 
 // 确认执行 diff
-async function confirmDiff(toolId: string) {
-  stopDiffTimer(toolId)
-  const tool = enhancedTools.value.find(t => t.id === toolId)
-  let sessionId = (tool?.result as any)?.data?.pendingDiffId
-  
-  // 如果结果中还没有，从映射中找
-  if (!sessionId) {
-    sessionId = toolIdToPendingId.value.get(toolId)
+async function confirmDiff(sessionId: string) {
+  if (processingDiffSessionIds.value.has(sessionId)) return
+
+  stopDiffTimer(sessionId)
+  clearDiffActionError(sessionId)
+
+  if (!hasPendingDiffSession(sessionId)) {
+    const message = 'Pending diff not found. Please retry after status sync.'
+    setDiffActionError(sessionId, message)
+    await showNotification(message, 'error')
+    return
   }
-  
-  if (!sessionId) return
+
+  addProcessingDiffSessionId(sessionId)
   
   try {
     await sendToExtension('diff.accept', { sessionId })
   } catch (err) {
+    removeProcessingDiffSessionId(sessionId)
+    const message = getActionErrorMessage(err, 'Failed to accept diff. Please retry.')
+    setDiffActionError(sessionId, message)
+    await showNotification(message, 'error')
     console.error('Failed to accept diff:', err)
   }
 }
 
 // 拒绝执行 diff
-async function rejectDiff(toolId: string) {
-  stopDiffTimer(toolId)
-  const tool = enhancedTools.value.find(t => t.id === toolId)
-  let sessionId = (tool?.result as any)?.data?.pendingDiffId
-  
-  // 如果结果中还没有，从映射中找
-  if (!sessionId) {
-    sessionId = toolIdToPendingId.value.get(toolId)
+async function rejectDiff(sessionId: string) {
+  if (processingDiffSessionIds.value.has(sessionId)) return
+
+  stopDiffTimer(sessionId)
+  clearDiffActionError(sessionId)
+
+  if (!hasPendingDiffSession(sessionId)) {
+    const message = 'Pending diff not found. Please retry after status sync.'
+    setDiffActionError(sessionId, message)
+    await showNotification(message, 'error')
+    return
   }
-  
-  if (!sessionId) return
+
+  addProcessingDiffSessionId(sessionId)
   
   try {
-    const result = await sendToExtension<{ success: boolean }>('diff.reject', { 
-      sessionId,
-      toolId,
-      conversationId: chatStore.currentConversationId
-    })
-    
-    // 拒绝成功后直接更新前端工具状态，而不是重新加载历史
-    if (result?.success && tool) {
-      tool.status = 'error'
-      // 从映射中移除
-      toolIdToPendingId.value.delete(toolId)
-    }
+    await sendToExtension('diff.reject', { sessionId })
   } catch (err) {
+    removeProcessingDiffSessionId(sessionId)
+    const message = getActionErrorMessage(err, 'Failed to reject diff. Please retry.')
+    setDiffActionError(sessionId, message)
+    await showNotification(message, 'error')
     console.error('Failed to reject diff:', err)
   }
 }
@@ -267,12 +339,13 @@ onMounted(async () => {
   // 监听 enhancedTools 的变化，为新出现的 pending 工具启动计时器
   watchEffect(() => {
     const cfg = globalApplyDiffConfig.value
-    for (const tool of enhancedTools.value) {
-      if (isDiffToolPending(tool) && !applyDiffTimers.has(tool.id)) {
-        applyDiffConfigs.value.set(tool.id, cfg)
-        if (cfg.autoSave) {
-          startDiffTimer(tool.id, cfg.autoSaveDelay)
-        }
+    if (!cfg.autoSave) {
+      return
+    }
+
+    for (const session of getAllPendingDiffSessions()) {
+      if (!applyDiffTimers.has(session.id) && !processingDiffSessionIds.value.has(session.id) && !diffActionErrors.value.has(session.id)) {
+        startDiffTimer(session.id, cfg.autoSaveDelay)
       }
     }
   })
@@ -280,22 +353,34 @@ onMounted(async () => {
   // 监听状态变化同步
   const unregister = onExtensionCommand('diff.statusChanged', (data: any) => {
     // 更新工具 ID 映射
-    const newMapping = new Map<string, string>()
+    const newMapping = new Map<string, PendingDiffSession[]>()
     for (const d of data.pendingDiffs) {
       if (d.toolId) {
-        newMapping.set(d.toolId, d.id)
+        const existing = newMapping.get(d.toolId) || []
+        existing.push({
+          id: d.id,
+          toolId: d.toolId,
+          filePath: d.filePath,
+          diffGuardWarning: d.diffGuardWarning,
+          diffGuardDeletePercent: d.diffGuardDeletePercent
+        })
+        newMapping.set(d.toolId, existing)
       }
     }
-    toolIdToPendingId.value = newMapping
+    toolIdToPendingDiffs.value = newMapping
 
     // 更新 diff 警戒值警告映射
     const newWarnings = new Map<string, { warning: string; deletePercent: number }>()
     for (const d of data.pendingDiffs) {
       if (d.toolId && d.diffGuardWarning) {
-        newWarnings.set(d.toolId, {
+        const nextWarning = {
           warning: d.diffGuardWarning,
           deletePercent: d.diffGuardDeletePercent ?? 0
-        })
+        }
+        const currentWarning = newWarnings.get(d.toolId)
+        if (!currentWarning || nextWarning.deletePercent >= currentWarning.deletePercent) {
+          newWarnings.set(d.toolId, nextWarning)
+        }
       }
     }
 
@@ -318,22 +403,36 @@ onMounted(async () => {
     }
     seenDiffToolIds.value = nextSeen
 
-    // 检查是否有新的 pending 工具需要启动计时器
-    const cfg = globalApplyDiffConfig.value
-    if (cfg.autoSave) {
-      for (const tool of enhancedTools.value) {
-        if (isDiffToolPending(tool) && !applyDiffTimers.has(tool.id)) {
-          applyDiffConfigs.value.set(tool.id, cfg)
-          startDiffTimer(tool.id, cfg.autoSaveDelay)
-        }
+    const activeSessionIds = new Set<string>(data.pendingDiffs.map((d: any) => d.id))
+
+    const nextProcessingDiffs = new Set(processingDiffSessionIds.value)
+    let processingChanged = false
+    for (const sessionId of Array.from(nextProcessingDiffs)) {
+      if (!activeSessionIds.has(sessionId)) {
+        nextProcessingDiffs.delete(sessionId)
+        processingChanged = true
       }
+    }
+    if (processingChanged) {
+      processingDiffSessionIds.value = nextProcessingDiffs
+    }
+
+    const nextDiffErrors = new Map(diffActionErrors.value)
+    let errorsChanged = false
+    for (const sessionId of Array.from(nextDiffErrors.keys())) {
+      if (!activeSessionIds.has(sessionId)) {
+        nextDiffErrors.delete(sessionId)
+        errorsChanged = true
+      }
+    }
+    if (errorsChanged) {
+      diffActionErrors.value = nextDiffErrors
     }
 
     // 清理已完成工具的计时器
-    for (const toolId of applyDiffTimers.keys()) {
-      const isStillPending = data.pendingDiffs.some((d: any) => d.toolId === toolId)
-      if (!isStillPending) {
-        stopDiffTimer(toolId)
+    for (const sessionId of Array.from(applyDiffTimers.keys())) {
+      if (!activeSessionIds.has(sessionId)) {
+        stopDiffTimer(sessionId)
       }
     }
   })
@@ -384,6 +483,16 @@ const enhancedTools = computed<ToolUsage[]>(() => {
   })
 
   return props.tools.map((tool) => {
+    const isDiffTool = DIFF_SUPPORTED_TOOLS.includes(tool.name)
+    let isDiffApplicable = true
+    if (tool.name === 'search_in_files') {
+      const args = tool.args as Record<string, unknown>
+      const mode = args?.mode as string
+      isDiffApplicable = mode === 'replace'
+    }
+
+    const activePendingDiff = isDiffTool && isDiffApplicable && isDiffToolPending(tool)
+
     // 获取响应结果
     let response: Record<string, unknown> | null | undefined = tool.result
     if (!response && tool.id) {
@@ -397,6 +506,18 @@ const enhancedTools = computed<ToolUsage[]>(() => {
       let success = (response as any).success !== false && !error
       
       const data = (response as any).data
+
+      if (activePendingDiff) {
+        const isAnyDiffProcessing = getPendingDiffSessions(tool).some((pendingDiff) => processingDiffSessionIds.value.has(pendingDiff.id))
+
+        return {
+          ...tool,
+          result: response || undefined,
+          error: undefined,
+          status: isAnyDiffProcessing ? ('executing' as const) : ('awaiting_apply' as const),
+          awaitingConfirmation: false
+        }
+      }
 
       // 根据工具响应确定最终状态
       let status: ToolUsage['status'] = success ? 'success' : 'error'
@@ -435,19 +556,11 @@ const enhancedTools = computed<ToolUsage[]>(() => {
     // 重要：diff 工具在后端被 cancel/reject 后，可能不会立刻返回 functionResponse（例如流被中断）。
     // 此时如果我们已经“见过”这个 diff 工具进入 pendingDiffs 列表，但现在列表里没有它，
     // 则说明 diff 已结束（多半是被取消），需要将 UI 状态从 running/pending 纠正为 error。
-    const isDiffTool = DIFF_SUPPORTED_TOOLS.includes(tool.name)
-    let isDiffApplicable = true
-    if (tool.name === 'search_in_files') {
-      const args = tool.args as Record<string, unknown>
-      const mode = args?.mode as string
-      isDiffApplicable = mode === 'replace'
-    }
-
     if (
       isDiffTool &&
       isDiffApplicable &&
       seenDiffToolIds.value.has(tool.id) &&
-      !toolIdToPendingId.value.has(tool.id) &&
+      getPendingDiffSessions(tool.id).length === 0 &&
       (effectiveStatus === 'executing' || effectiveStatus === 'awaiting_apply')
     ) {
       const now = Date.now()
@@ -478,7 +591,12 @@ const enhancedTools = computed<ToolUsage[]>(() => {
     }
 
     // diff 工具：如果 diff 处于 pending（等待应用/审阅），将状态映射为 awaiting_apply
-    if (isDiffToolPending(tool)) {
+    if (activePendingDiff) {
+      const isAnyDiffProcessing = getPendingDiffSessions(tool).some((pendingDiff) => processingDiffSessionIds.value.has(pendingDiff.id))
+      if (isAnyDiffProcessing) {
+        return { ...tool, status: 'executing' as const, awaitingConfirmation: false }
+      }
+
       return { ...tool, status: 'awaiting_apply' as const, awaitingConfirmation: false }
     }
 
@@ -525,6 +643,44 @@ watchEffect(() => {
 
   if (changed) {
     processingToolIds.value = current
+  }
+})
+
+watchEffect(() => {
+  if (processingDiffSessionIds.value.size === 0) return
+
+  const activeSessionIds = new Set(getAllPendingDiffSessions().map((session) => session.id))
+  const current = new Set(processingDiffSessionIds.value)
+  let changed = false
+
+  for (const sessionId of current) {
+    if (!activeSessionIds.has(sessionId)) {
+      current.delete(sessionId)
+      changed = true
+    }
+  }
+
+  if (changed) {
+    processingDiffSessionIds.value = current
+  }
+})
+
+watchEffect(() => {
+  if (diffActionErrors.value.size === 0) return
+
+  const activeSessionIds = new Set(getAllPendingDiffSessions().map((session) => session.id))
+  const next = new Map(diffActionErrors.value)
+  let changed = false
+
+  for (const sessionId of Array.from(next.keys())) {
+    if (!activeSessionIds.has(sessionId)) {
+      next.delete(sessionId)
+      changed = true
+    }
+  }
+
+  if (changed) {
+    diffActionErrors.value = next
   }
 })
 
@@ -853,7 +1009,17 @@ function renderToolContent(tool: ToolUsage) {
       status: tool.status,
       toolId: tool.id,
       toolName: tool.name,
-      messageBackendIndex: props.messageBackendIndex
+      messageBackendIndex: props.messageBackendIndex,
+      pendingDiffs: getPendingDiffSessions(tool),
+      diffActionController: {
+        autoSaveEnabled: globalApplyDiffConfig.value.autoSave,
+        getTimeLeft: (sessionId: string) => applyDiffTimeLeft.value.get(sessionId) || 0,
+        getProgress: (sessionId: string) => applyDiffProgress.value.get(sessionId) || 0,
+        isProcessing: (sessionId: string) => processingDiffSessionIds.value.has(sessionId),
+        getError: (sessionId: string) => getDiffActionError(sessionId),
+        confirm: (sessionId: string) => confirmDiff(sessionId),
+        reject: (sessionId: string) => rejectDiff(sessionId)
+      }
     })
   }
   
@@ -1015,23 +1181,45 @@ function renderToolContent(tool: ToolUsage) {
         </span>
       </div>
 
-      <!-- Diff 工具确认操作栏 (位于外层，不随展开面板隐藏) -->
-      <div v-if="isDiffToolPending(tool)" class="diff-action-footer">
-        <div class="footer-top" v-if="applyDiffConfigs.get(tool.id)?.autoSave">
-          <div class="timer-container">
-            <div class="timer-bar" :style="{ width: (applyDiffProgress.get(tool.id) || 0) + '%' }"></div>
+      <!-- Diff 工具确认操作栏（按独立 pending diff 渲染，不随展开面板隐藏） -->
+      <div v-if="getPendingDiffSessions(tool).length > 0" class="diff-action-list">
+        <div v-for="pendingDiff in getPendingDiffSessions(tool)" :key="pendingDiff.id" class="diff-action-footer">
+          <div class="diff-action-file">
+            <span class="codicon codicon-file-code"></span>
+            <span class="diff-action-file-path">{{ pendingDiff.filePath }}</span>
           </div>
-          <span class="timer-text">{{ ((applyDiffTimeLeft.get(tool.id) || 0) / 1000).toFixed(1) }}s</span>
-        </div>
-        <div class="footer-buttons">
-          <button class="confirm-btn-primary" @click.stop="confirmDiff(tool.id)">
-            <span class="codicon codicon-check"></span>
-            {{ t('components.message.tool.saveAll') }}
-          </button>
-          <button class="reject-btn-secondary" @click.stop="rejectDiff(tool.id)">
-            <span class="codicon codicon-close"></span>
-            {{ t('components.message.tool.rejectAll') }}
-          </button>
+          <div class="footer-top" v-if="globalApplyDiffConfig.autoSave">
+            <div class="timer-container">
+              <div class="timer-bar" :style="{ width: (applyDiffProgress.get(pendingDiff.id) || 0) + '%' }"></div>
+            </div>
+            <span class="timer-text">{{ ((applyDiffTimeLeft.get(pendingDiff.id) || 0) / 1000).toFixed(1) }}s</span>
+          </div>
+          <div class="footer-buttons">
+            <button
+              class="confirm-btn-primary"
+              :disabled="processingDiffSessionIds.has(pendingDiff.id)"
+              @click.stop="confirmDiff(pendingDiff.id)"
+            >
+              <span class="codicon codicon-check"></span>
+              {{ t('common.save') }}
+            </button>
+            <button
+              class="reject-btn-secondary"
+              :disabled="processingDiffSessionIds.has(pendingDiff.id)"
+              @click.stop="rejectDiff(pendingDiff.id)"
+            >
+              <span class="codicon codicon-close"></span>
+              {{ t('components.message.tool.reject') }}
+            </button>
+          </div>
+          <div v-if="processingDiffSessionIds.has(pendingDiff.id)" class="diff-action-state">
+            <span class="codicon codicon-loading codicon-modifier-spin"></span>
+            <span>{{ t('tools.executing') }}</span>
+          </div>
+          <div v-else-if="getDiffActionError(pendingDiff.id)" class="diff-action-error">
+            <span class="codicon codicon-error"></span>
+            <span>{{ getDiffActionError(pendingDiff.id) }}</span>
+          </div>
         </div>
       </div>
     </div>
@@ -1407,13 +1595,38 @@ function renderToolContent(tool: ToolUsage) {
 }
 
 /* Diff 工具操作栏样式 */
+.diff-action-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .diff-action-footer {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 4px;
+  padding: 6px 8px;
   background: var(--vscode-editor-inactiveSelectionBackground);
-  border-top: 1px solid var(--vscode-panel-border);
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 2px;
+}
+
+.diff-action-file {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.diff-action-file .codicon {
+  color: var(--vscode-charts-blue);
+}
+
+.diff-action-file-path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .footer-top {
@@ -1466,6 +1679,31 @@ function renderToolContent(tool: ToolUsage) {
   border-radius: 2px;
   border: none;
   transition: opacity 0.12s ease;
+}
+
+.footer-buttons button:disabled {
+  opacity: 0.65;
+  cursor: default;
+}
+
+.diff-action-state {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.diff-action-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: 2px;
+  background: var(--vscode-inputValidation-errorBackground);
+  border: 1px solid var(--vscode-inputValidation-errorBorder);
+  color: var(--vscode-inputValidation-errorForeground);
+  font-size: 11px;
 }
 
 .confirm-btn-primary {

--- a/frontend/src/components/settings/SettingsPanel.vue
+++ b/frontend/src/components/settings/SettingsPanel.vue
@@ -49,7 +49,7 @@ const tabs = computed<TabItem[]>(() => [
   { id: 'context', label: t('components.settings.tabs.context'), icon: 'codicon-symbol-namespace' },
   { id: 'prompt', label: t('components.settings.tabs.prompt'), icon: 'codicon-note' },
   { id: 'tokenCount', label: t('components.settings.tabs.tokenCount'), icon: 'codicon-symbol-numeric' },
-  { id: 'sound', label: t('components.settings.tabs.sound'), icon: 'codicon-bell' },
+  { id: 'sound', label: t('components.settings.tabs.sound'), icon: 'codicon-notifications' },
   { id: 'appearance', label: t('components.settings.tabs.appearance'), icon: 'codicon-paintcan' },
   { id: 'general', label: t('components.settings.tabs.general'), icon: 'codicon-settings-gear' },
 ])
@@ -436,7 +436,7 @@ onMounted(() => {
             <SubAgentsSettings />
           </div>
 
-          <!-- 声音提醒 -->
+          <!-- 提示系统 -->
           <div v-if="settingsStore.activeTab === 'sound'" class="settings-section">
             <h4>{{ t('components.settings.settingsPanel.sections.sound.title') }}</h4>
             <p class="settings-description">{{ t('components.settings.settingsPanel.sections.sound.description') }}</p>

--- a/frontend/src/components/settings/SoundSettings.vue
+++ b/frontend/src/components/settings/SoundSettings.vue
@@ -497,266 +497,293 @@ onBeforeUnmount(() => {
     </div>
 
     <template v-else>
-      <div class="form-group">
-        <label class="group-label">
-          <i class="codicon codicon-bell"></i>
-          {{ t('components.settings.soundSettings.enabled.title') }}
-        </label>
-        <p class="field-description">{{ t('components.settings.soundSettings.enabled.description') }}</p>
-
-        <CustomCheckbox v-model="enabled" :label="t('components.settings.soundSettings.enabled.label')" />
+      <div class="panel-overview">
+        <div class="section-title">{{ t('components.settings.soundSettings.overview.title') }}</div>
+        <p class="section-description">{{ t('components.settings.soundSettings.overview.description') }}</p>
       </div>
 
-      <div class="form-group">
-        <label class="group-label">
-          <i class="codicon codicon-unmute"></i>
-          {{ t('components.settings.soundSettings.volume.title') }}
-        </label>
-        <p class="field-description">{{ t('components.settings.soundSettings.volume.description') }}</p>
-
-        <div class="slider-row">
-          <input
-            v-model.number="volume"
-            class="range"
-            type="range"
-            min="0"
-            max="100"
-            step="1"
-          />
-          <div class="range-value">{{ volumeText }}</div>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="group-label">
-          <i class="codicon codicon-clock"></i>
-          {{ t('components.settings.soundSettings.cooldown.title') }}
-        </label>
-        <p class="field-description">{{ t('components.settings.soundSettings.cooldown.description') }}</p>
-
-        <div class="slider-row">
-          <input
-            v-model.number="cooldownMs"
-            class="range"
-            type="range"
-            min="0"
-            max="5000"
-            step="100"
-          />
-          <div class="range-value">{{ cooldownMs }}ms</div>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="group-label">
-          <i class="codicon codicon-symbol-event"></i>
-          {{ t('components.settings.soundSettings.cues.title') }}
-        </label>
-        <p class="field-description">{{ t('components.settings.soundSettings.cues.description') }}</p>
-
-        <div class="cues-grid">
-          <CustomCheckbox v-model="cueWarning" :label="t('components.settings.soundSettings.cues.warning')" />
-          <CustomCheckbox v-model="cueError" :label="t('components.settings.soundSettings.cues.error')" />
-          <CustomCheckbox v-model="cueTaskComplete" :label="t('components.settings.soundSettings.cues.taskComplete')" />
-          <CustomCheckbox v-model="cueTaskError" :label="t('components.settings.soundSettings.cues.taskError')" />
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="group-label">
-          <i class="codicon codicon-bell-dot"></i>
-          {{ t('components.settings.soundSettings.windowsAgentStopNotification.title') }}
-        </label>
-        <p class="field-description">{{ t('components.settings.soundSettings.windowsAgentStopNotification.description') }}</p>
-        <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.rawTextHint') }}</p>
-        <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.bestEffortClickHint') }}</p>
-
-        <CustomCheckbox
-          v-model="windowsAgentStopNotificationEnabled"
-          :label="t('components.settings.soundSettings.windowsAgentStopNotification.enabled')"
-        />
-        <CustomCheckbox
-          v-model="windowsAgentStopNotificationOnlyWhenWindowNotFocused"
-          :label="t('components.settings.soundSettings.windowsAgentStopNotification.onlyWhenWindowNotFocused')"
-        />
-
-        <div class="cues-grid">
-          <CustomCheckbox v-model="windowsAgentStopNotificationCaseError" :label="t('components.settings.soundSettings.windowsAgentStopNotification.cases.error')" />
-          <CustomCheckbox v-model="windowsAgentStopNotificationCaseAwaitingUserAction" :label="t('components.settings.soundSettings.windowsAgentStopNotification.cases.awaitingUserAction')" />
-          <CustomCheckbox v-model="windowsAgentStopNotificationCaseContinueRequired" :label="t('components.settings.soundSettings.windowsAgentStopNotification.cases.continueRequired')" />
+      <section class="settings-area">
+        <div class="section-header">
+          <div class="section-title">{{ t('components.settings.soundSettings.sections.sound.title') }}</div>
+          <p class="section-description">{{ t('components.settings.soundSettings.sections.sound.description') }}</p>
         </div>
 
-        <div class="template-field">
-          <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.title') }}</label>
-          <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.description') }}</p>
-        </div>
+        <div class="section-body">
+          <div class="form-group">
+            <label class="group-label">
+              <i class="codicon codicon-bell"></i>
+              {{ t('components.settings.soundSettings.enabled.title') }}
+            </label>
+            <p class="field-description">{{ t('components.settings.soundSettings.enabled.description') }}</p>
 
-        <div class="template-grid">
-          <div class="template-field">
-            <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.titleTemplate') }}</label>
-            <input v-model="windowsAgentStopNotificationTitleTemplate" class="template-input" type="text">
+            <CustomCheckbox v-model="enabled" :label="t('components.settings.soundSettings.enabled.label')" />
           </div>
-          <div class="template-field">
-            <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.errorBodyTemplate') }}</label>
-            <textarea v-model="windowsAgentStopNotificationErrorBodyTemplate" class="template-textarea" rows="2"></textarea>
-          </div>
-          <div class="template-field">
-            <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.awaitingUserActionBodyTemplate') }}</label>
-            <textarea v-model="windowsAgentStopNotificationAwaitingUserActionBodyTemplate" class="template-textarea" rows="2"></textarea>
-          </div>
-          <div class="template-field">
-            <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.continueRequiredBodyTemplate') }}</label>
-            <textarea v-model="windowsAgentStopNotificationContinueRequiredBodyTemplate" class="template-textarea" rows="2"></textarea>
-          </div>
-          <div class="template-field">
-            <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.variables') }}</label>
-            <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.variablesHint') }}</p>
-            <div class="variable-list">
-              <code v-for="variable in windowsAgentStopTemplateVariables" :key="variable" class="variable-chip">{{ variable }}</code>
+
+          <div class="form-group">
+            <label class="group-label">
+              <i class="codicon codicon-unmute"></i>
+              {{ t('components.settings.soundSettings.volume.title') }}
+            </label>
+            <p class="field-description">{{ t('components.settings.soundSettings.volume.description') }}</p>
+
+            <div class="slider-row">
+              <input
+                v-model.number="volume"
+                class="range"
+                type="range"
+                min="0"
+                max="100"
+                step="1"
+              />
+              <div class="range-value">{{ volumeText }}</div>
             </div>
           </div>
-          <div class="template-field">
-            <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.title') }}</label>
-            <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.description') }}</p>
+
+          <div class="form-group">
+            <label class="group-label">
+              <i class="codicon codicon-clock"></i>
+              {{ t('components.settings.soundSettings.cooldown.title') }}
+            </label>
+            <p class="field-description">{{ t('components.settings.soundSettings.cooldown.description') }}</p>
+
+            <div class="slider-row">
+              <input
+                v-model.number="cooldownMs"
+                class="range"
+                type="range"
+                min="0"
+                max="5000"
+                step="100"
+              />
+              <div class="range-value">{{ cooldownMs }}ms</div>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label class="group-label">
+              <i class="codicon codicon-symbol-event"></i>
+              {{ t('components.settings.soundSettings.cues.title') }}
+            </label>
+            <p class="field-description">{{ t('components.settings.soundSettings.cues.description') }}</p>
+
+            <div class="cues-grid">
+              <CustomCheckbox v-model="cueWarning" :label="t('components.settings.soundSettings.cues.warning')" />
+              <CustomCheckbox v-model="cueError" :label="t('components.settings.soundSettings.cues.error')" />
+              <CustomCheckbox v-model="cueTaskComplete" :label="t('components.settings.soundSettings.cues.taskComplete')" />
+              <CustomCheckbox v-model="cueTaskError" :label="t('components.settings.soundSettings.cues.taskError')" />
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label class="group-label">
+              <i class="codicon codicon-file-media"></i>
+              {{ t('components.settings.soundSettings.assets.title') }}
+            </label>
+            <p class="field-description">
+              {{
+                t('components.settings.soundSettings.assets.description', {
+                  size: formatFileSize(MAX_ASSET_BYTES)
+                })
+              }}
+            </p>
+
+            <input
+              ref="assetFileInputRef"
+              type="file"
+              accept="audio/*"
+              style="display: none"
+              @change="handleAssetFileChange"
+            />
+
+            <div class="assets-list">
+              <div class="asset-row">
+                <div class="asset-row-left">
+                  <div class="asset-row-title">{{ t('components.settings.soundSettings.cues.warning') }}</div>
+                  <div class="asset-row-value">
+                    {{ assetWarning?.name || builtinAssets.warning?.name || t('components.settings.soundSettings.assets.none') }}
+                  </div>
+                </div>
+                <div class="asset-row-actions">
+                  <button class="action-btn" @click="triggerSelectAsset('warning')">
+                    <i class="codicon codicon-folder-opened"></i>
+                    {{ t('components.settings.soundSettings.assets.choose') }}
+                  </button>
+                  <button v-if="assetWarning" class="action-btn" @click="clearAsset('warning')">
+                    <i class="codicon codicon-trash"></i>
+                    {{ t('components.settings.soundSettings.assets.clear') }}
+                  </button>
+                </div>
+              </div>
+
+              <div class="asset-row">
+                <div class="asset-row-left">
+                  <div class="asset-row-title">{{ t('components.settings.soundSettings.cues.error') }}</div>
+                  <div class="asset-row-value">
+                    {{ assetError?.name || builtinAssets.error?.name || t('components.settings.soundSettings.assets.none') }}
+                  </div>
+                </div>
+                <div class="asset-row-actions">
+                  <button class="action-btn" @click="triggerSelectAsset('error')">
+                    <i class="codicon codicon-folder-opened"></i>
+                    {{ t('components.settings.soundSettings.assets.choose') }}
+                  </button>
+                  <button v-if="assetError" class="action-btn" @click="clearAsset('error')">
+                    <i class="codicon codicon-trash"></i>
+                    {{ t('components.settings.soundSettings.assets.clear') }}
+                  </button>
+                </div>
+              </div>
+
+              <div class="asset-row">
+                <div class="asset-row-left">
+                  <div class="asset-row-title">{{ t('components.settings.soundSettings.cues.taskComplete') }}</div>
+                  <div class="asset-row-value">
+                    {{ assetTaskComplete?.name || builtinAssets.taskComplete?.name || t('components.settings.soundSettings.assets.none') }}
+                  </div>
+                </div>
+                <div class="asset-row-actions">
+                  <button class="action-btn" @click="triggerSelectAsset('taskComplete')">
+                    <i class="codicon codicon-folder-opened"></i>
+                    {{ t('components.settings.soundSettings.assets.choose') }}
+                  </button>
+                  <button v-if="assetTaskComplete" class="action-btn" @click="clearAsset('taskComplete')">
+                    <i class="codicon codicon-trash"></i>
+                    {{ t('components.settings.soundSettings.assets.clear') }}
+                  </button>
+                </div>
+              </div>
+
+              <div class="asset-row">
+                <div class="asset-row-left">
+                  <div class="asset-row-title">{{ t('components.settings.soundSettings.cues.taskError') }}</div>
+                  <div class="asset-row-value">
+                    {{ assetTaskError?.name || builtinAssets.taskError?.name || builtinAssets.error?.name || t('components.settings.soundSettings.assets.none') }}
+                  </div>
+                </div>
+                <div class="asset-row-actions">
+                  <button class="action-btn" @click="triggerSelectAsset('taskError')">
+                    <i class="codicon codicon-folder-opened"></i>
+                    {{ t('components.settings.soundSettings.assets.choose') }}
+                  </button>
+                  <button v-if="assetTaskError" class="action-btn" @click="clearAsset('taskError')">
+                    <i class="codicon codicon-trash"></i>
+                    {{ t('components.settings.soundSettings.assets.clear') }}
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <span v-if="assetMessage" class="test-message" :class="assetMessageType">
+              {{ assetMessage }}
+            </span>
+          </div>
+
+          <div class="form-group">
+            <label class="group-label">
+              <i class="codicon codicon-play"></i>
+              {{ t('components.settings.soundSettings.test.title') }}
+            </label>
+            <p class="field-description">{{ t('components.settings.soundSettings.test.description') }}</p>
+
             <div class="test-buttons">
-              <button class="action-btn" @click="triggerWindowsNotificationPreview('error')">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.error') }}</button>
-              <button class="action-btn" @click="triggerWindowsNotificationPreview('awaiting_user_action')">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.awaitingUserAction') }}</button>
-              <button class="action-btn" @click="triggerWindowsNotificationPreview('continue_required')">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.continueRequired') }}</button>
+              <button class="action-btn" @click="testCue('warning')">
+                {{ t('components.settings.soundSettings.test.warning') }}
+              </button>
+              <button class="action-btn" @click="testCue('error')">
+                {{ t('components.settings.soundSettings.test.error') }}
+              </button>
+              <button class="action-btn" @click="testCue('taskComplete')">
+                {{ t('components.settings.soundSettings.test.taskComplete') }}
+              </button>
+              <button class="action-btn" @click="testCue('taskError')">
+                {{ t('components.settings.soundSettings.test.taskError') }}
+              </button>
+            </div>
+
+            <span v-if="testMessage" class="test-message" :class="testMessageType">
+              {{ testMessage }}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <section class="settings-area">
+        <div class="section-header">
+          <div class="section-title">{{ t('components.settings.soundSettings.sections.windowsNotification.title') }}</div>
+          <p class="section-description">{{ t('components.settings.soundSettings.sections.windowsNotification.description') }}</p>
+        </div>
+
+        <div class="section-body">
+          <div class="form-group">
+            <label class="group-label">
+              <i class="codicon codicon-bell-dot"></i>
+              {{ t('components.settings.soundSettings.windowsAgentStopNotification.optionsTitle') }}
+            </label>
+            <p class="field-description">{{ t('components.settings.soundSettings.windowsAgentStopNotification.description') }}</p>
+            <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.rawTextHint') }}</p>
+            <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.bestEffortClickHint') }}</p>
+
+            <CustomCheckbox
+              v-model="windowsAgentStopNotificationEnabled"
+              :label="t('components.settings.soundSettings.windowsAgentStopNotification.enabled')"
+            />
+            <CustomCheckbox
+              v-model="windowsAgentStopNotificationOnlyWhenWindowNotFocused"
+              :label="t('components.settings.soundSettings.windowsAgentStopNotification.onlyWhenWindowNotFocused')"
+            />
+
+            <div class="template-field">
+              <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.casesTitle') }}</label>
+            </div>
+
+            <div class="cues-grid">
+              <CustomCheckbox v-model="windowsAgentStopNotificationCaseError" :label="t('components.settings.soundSettings.windowsAgentStopNotification.cases.error')" />
+              <CustomCheckbox v-model="windowsAgentStopNotificationCaseAwaitingUserAction" :label="t('components.settings.soundSettings.windowsAgentStopNotification.cases.awaitingUserAction')" />
+              <CustomCheckbox v-model="windowsAgentStopNotificationCaseContinueRequired" :label="t('components.settings.soundSettings.windowsAgentStopNotification.cases.continueRequired')" />
+            </div>
+
+            <div class="template-field">
+              <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.title') }}</label>
+              <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.description') }}</p>
+            </div>
+
+            <div class="template-grid">
+              <div class="template-field">
+                <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.titleTemplate') }}</label>
+                <input v-model="windowsAgentStopNotificationTitleTemplate" class="template-input" type="text">
+              </div>
+              <div class="template-field">
+                <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.errorBodyTemplate') }}</label>
+                <textarea v-model="windowsAgentStopNotificationErrorBodyTemplate" class="template-textarea" rows="2"></textarea>
+              </div>
+              <div class="template-field">
+                <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.awaitingUserActionBodyTemplate') }}</label>
+                <textarea v-model="windowsAgentStopNotificationAwaitingUserActionBodyTemplate" class="template-textarea" rows="2"></textarea>
+              </div>
+              <div class="template-field">
+                <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.continueRequiredBodyTemplate') }}</label>
+                <textarea v-model="windowsAgentStopNotificationContinueRequiredBodyTemplate" class="template-textarea" rows="2"></textarea>
+              </div>
+              <div class="template-field">
+                <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.variables') }}</label>
+                <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.variablesHint') }}</p>
+                <div class="variable-list">
+                  <code v-for="variable in windowsAgentStopTemplateVariables" :key="variable" class="variable-chip">{{ variable }}</code>
+                </div>
+              </div>
+              <div class="template-field">
+                <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.title') }}</label>
+                <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.description') }}</p>
+                <div class="test-buttons">
+                  <button class="action-btn" @click="triggerWindowsNotificationPreview('error')">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.error') }}</button>
+                  <button class="action-btn" @click="triggerWindowsNotificationPreview('awaiting_user_action')">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.awaitingUserAction') }}</button>
+                  <button class="action-btn" @click="triggerWindowsNotificationPreview('continue_required')">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.continueRequired') }}</button>
+                </div>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-
-      <div class="form-group">
-        <label class="group-label">
-          <i class="codicon codicon-file-media"></i>
-          {{ t('components.settings.soundSettings.assets.title') }}
-        </label>
-        <p class="field-description">
-          {{
-            t('components.settings.soundSettings.assets.description', {
-              size: formatFileSize(MAX_ASSET_BYTES)
-            })
-          }}
-        </p>
-
-        <input
-          ref="assetFileInputRef"
-          type="file"
-          accept="audio/*"
-          style="display: none"
-          @change="handleAssetFileChange"
-        />
-
-        <div class="assets-list">
-          <div class="asset-row">
-            <div class="asset-row-left">
-              <div class="asset-row-title">{{ t('components.settings.soundSettings.cues.warning') }}</div>
-              <div class="asset-row-value">
-                {{ assetWarning?.name || builtinAssets.warning?.name || t('components.settings.soundSettings.assets.none') }}
-              </div>
-            </div>
-            <div class="asset-row-actions">
-              <button class="action-btn" @click="triggerSelectAsset('warning')">
-                <i class="codicon codicon-folder-opened"></i>
-                {{ t('components.settings.soundSettings.assets.choose') }}
-              </button>
-              <button v-if="assetWarning" class="action-btn" @click="clearAsset('warning')">
-                <i class="codicon codicon-trash"></i>
-                {{ t('components.settings.soundSettings.assets.clear') }}
-              </button>
-            </div>
-          </div>
-
-          <div class="asset-row">
-            <div class="asset-row-left">
-              <div class="asset-row-title">{{ t('components.settings.soundSettings.cues.error') }}</div>
-              <div class="asset-row-value">
-                {{ assetError?.name || builtinAssets.error?.name || t('components.settings.soundSettings.assets.none') }}
-              </div>
-            </div>
-            <div class="asset-row-actions">
-              <button class="action-btn" @click="triggerSelectAsset('error')">
-                <i class="codicon codicon-folder-opened"></i>
-                {{ t('components.settings.soundSettings.assets.choose') }}
-              </button>
-              <button v-if="assetError" class="action-btn" @click="clearAsset('error')">
-                <i class="codicon codicon-trash"></i>
-                {{ t('components.settings.soundSettings.assets.clear') }}
-              </button>
-            </div>
-          </div>
-
-          <div class="asset-row">
-            <div class="asset-row-left">
-              <div class="asset-row-title">{{ t('components.settings.soundSettings.cues.taskComplete') }}</div>
-              <div class="asset-row-value">
-                {{ assetTaskComplete?.name || builtinAssets.taskComplete?.name || t('components.settings.soundSettings.assets.none') }}
-              </div>
-            </div>
-            <div class="asset-row-actions">
-              <button class="action-btn" @click="triggerSelectAsset('taskComplete')">
-                <i class="codicon codicon-folder-opened"></i>
-                {{ t('components.settings.soundSettings.assets.choose') }}
-              </button>
-              <button v-if="assetTaskComplete" class="action-btn" @click="clearAsset('taskComplete')">
-                <i class="codicon codicon-trash"></i>
-                {{ t('components.settings.soundSettings.assets.clear') }}
-              </button>
-            </div>
-          </div>
-
-          <div class="asset-row">
-            <div class="asset-row-left">
-              <div class="asset-row-title">{{ t('components.settings.soundSettings.cues.taskError') }}</div>
-              <div class="asset-row-value">
-                {{ assetTaskError?.name || builtinAssets.taskError?.name || builtinAssets.error?.name || t('components.settings.soundSettings.assets.none') }}
-              </div>
-            </div>
-            <div class="asset-row-actions">
-              <button class="action-btn" @click="triggerSelectAsset('taskError')">
-                <i class="codicon codicon-folder-opened"></i>
-                {{ t('components.settings.soundSettings.assets.choose') }}
-              </button>
-              <button v-if="assetTaskError" class="action-btn" @click="clearAsset('taskError')">
-                <i class="codicon codicon-trash"></i>
-                {{ t('components.settings.soundSettings.assets.clear') }}
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <span v-if="assetMessage" class="test-message" :class="assetMessageType">
-          {{ assetMessage }}
-        </span>
-      </div>
-
-      <div class="form-group">
-        <label class="group-label">
-          <i class="codicon codicon-play"></i>
-          {{ t('components.settings.soundSettings.test.title') }}
-        </label>
-        <p class="field-description">{{ t('components.settings.soundSettings.test.description') }}</p>
-
-        <div class="test-buttons">
-          <button class="action-btn" @click="testCue('warning')">
-            {{ t('components.settings.soundSettings.test.warning') }}
-          </button>
-          <button class="action-btn" @click="testCue('error')">
-            {{ t('components.settings.soundSettings.test.error') }}
-          </button>
-          <button class="action-btn" @click="testCue('taskComplete')">
-            {{ t('components.settings.soundSettings.test.taskComplete') }}
-          </button>
-          <button class="action-btn" @click="testCue('taskError')">
-            {{ t('components.settings.soundSettings.test.taskError') }}
-          </button>
-        </div>
-
-        <span v-if="testMessage" class="test-message" :class="testMessageType">
-          {{ testMessage }}
-        </span>
-      </div>
+      </section>
 
       <div class="actions">
         <button class="action-btn primary" @click="saveConfig" :disabled="isSaving">
@@ -781,7 +808,38 @@ onBeforeUnmount(() => {
 .sound-settings {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 20px;
+}
+
+.panel-overview,
+.settings-area {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 8px;
+  background: var(--vscode-sideBar-background);
+}
+
+.section-header,
+.section-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--vscode-foreground);
+}
+
+.section-description {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--vscode-descriptionForeground);
 }
 
 .loading {

--- a/frontend/src/components/settings/SoundSettings.vue
+++ b/frontend/src/components/settings/SoundSettings.vue
@@ -43,6 +43,21 @@ const cueWarning = ref(DEFAULT_UI_SOUND_SETTINGS.cues.warning)
 const cueError = ref(DEFAULT_UI_SOUND_SETTINGS.cues.error)
 const cueTaskComplete = ref(DEFAULT_UI_SOUND_SETTINGS.cues.taskComplete)
 const cueTaskError = ref(DEFAULT_UI_SOUND_SETTINGS.cues.taskError)
+const windowsAgentStopNotificationEnabled = ref(DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.enabled)
+const windowsAgentStopNotificationOnlyWhenWindowNotFocused = ref(
+  DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.onlyWhenWindowNotFocused
+)
+const windowsAgentStopNotificationCaseError = ref(DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.cases.error)
+const windowsAgentStopNotificationCaseAwaitingUserAction = ref(DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.cases.awaitingUserAction)
+const windowsAgentStopNotificationCaseContinueRequired = ref(DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.cases.continueRequired)
+const windowsAgentStopNotificationTitleTemplate = ref(DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.content.titleTemplate)
+const windowsAgentStopNotificationErrorBodyTemplate = ref(DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.content.bodyTemplates.error)
+const windowsAgentStopNotificationAwaitingUserActionBodyTemplate = ref(DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.content.bodyTemplates.awaitingUserAction)
+const windowsAgentStopNotificationContinueRequiredBodyTemplate = ref(DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.content.bodyTemplates.continueRequired)
+
+type WindowsAgentStopPreviewReason = 'error' | 'awaiting_user_action' | 'continue_required'
+
+const windowsAgentStopTemplateVariables = ['{appName}', '{windowTitle}', '{actionLabel}', '{reasonLabel}']
 
 const assetWarning = ref<UISoundAsset | null>(null)
 const assetError = ref<UISoundAsset | null>(null)
@@ -95,6 +110,17 @@ function cancelActiveTests() {
 
 const volumeText = computed(() => `${volume.value}%`)
 
+function buildWindowsAgentStopNotificationContentDraft() {
+  return {
+    titleTemplate: windowsAgentStopNotificationTitleTemplate.value,
+    bodyTemplates: {
+      error: windowsAgentStopNotificationErrorBodyTemplate.value,
+      awaitingUserAction: windowsAgentStopNotificationAwaitingUserActionBodyTemplate.value,
+      continueRequired: windowsAgentStopNotificationContinueRequiredBodyTemplate.value
+    }
+  }
+}
+
 function buildCurrentSettings(): UISoundSettings {
   const assets: NonNullable<UISoundSettings['assets']> = {}
 
@@ -126,6 +152,16 @@ function buildCurrentSettings(): UISoundSettings {
       taskError: cueTaskError.value
     },
     assets: Object.keys(assets).length > 0 ? assets : undefined,
+    windowsAgentStopNotification: {
+      enabled: windowsAgentStopNotificationEnabled.value,
+      onlyWhenWindowNotFocused: windowsAgentStopNotificationOnlyWhenWindowNotFocused.value,
+      cases: {
+        error: windowsAgentStopNotificationCaseError.value,
+        awaitingUserAction: windowsAgentStopNotificationCaseAwaitingUserAction.value,
+        continueRequired: windowsAgentStopNotificationCaseContinueRequired.value
+      },
+      content: buildWindowsAgentStopNotificationContentDraft()
+    },
     theme: theme.value
   }
 }
@@ -248,6 +284,15 @@ async function loadConfig() {
     }
 
     theme.value = normalized.theme
+    windowsAgentStopNotificationEnabled.value = normalized.windowsAgentStopNotification.enabled
+    windowsAgentStopNotificationOnlyWhenWindowNotFocused.value = normalized.windowsAgentStopNotification.onlyWhenWindowNotFocused
+    windowsAgentStopNotificationCaseError.value = normalized.windowsAgentStopNotification.cases.error
+    windowsAgentStopNotificationCaseAwaitingUserAction.value = normalized.windowsAgentStopNotification.cases.awaitingUserAction
+    windowsAgentStopNotificationCaseContinueRequired.value = normalized.windowsAgentStopNotification.cases.continueRequired
+    windowsAgentStopNotificationTitleTemplate.value = normalized.windowsAgentStopNotification.content.titleTemplate
+    windowsAgentStopNotificationErrorBodyTemplate.value = normalized.windowsAgentStopNotification.content.bodyTemplates.error
+    windowsAgentStopNotificationAwaitingUserActionBodyTemplate.value = normalized.windowsAgentStopNotification.content.bodyTemplates.awaitingUserAction
+    windowsAgentStopNotificationContinueRequiredBodyTemplate.value = normalized.windowsAgentStopNotification.content.bodyTemplates.continueRequired
 
     // 同步到运行时（即使用户不点击保存，也保证显示与运行时一致）
     configureSoundSettings(normalized)
@@ -315,6 +360,15 @@ async function resetToDefault() {
   cueError.value = DEFAULT_UI_SOUND_SETTINGS.cues.error
   cueTaskComplete.value = DEFAULT_UI_SOUND_SETTINGS.cues.taskComplete
   cueTaskError.value = DEFAULT_UI_SOUND_SETTINGS.cues.taskError
+  windowsAgentStopNotificationEnabled.value = DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.enabled
+  windowsAgentStopNotificationOnlyWhenWindowNotFocused.value = DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.onlyWhenWindowNotFocused
+  windowsAgentStopNotificationCaseError.value = DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.cases.error
+  windowsAgentStopNotificationCaseAwaitingUserAction.value = DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.cases.awaitingUserAction
+  windowsAgentStopNotificationCaseContinueRequired.value = DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.cases.continueRequired
+  windowsAgentStopNotificationTitleTemplate.value = DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.content.titleTemplate
+  windowsAgentStopNotificationErrorBodyTemplate.value = DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.content.bodyTemplates.error
+  windowsAgentStopNotificationAwaitingUserActionBodyTemplate.value = DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.content.bodyTemplates.awaitingUserAction
+  windowsAgentStopNotificationContinueRequiredBodyTemplate.value = DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.content.bodyTemplates.continueRequired
 
   assetWarning.value = null
   assetError.value = null
@@ -326,8 +380,46 @@ async function resetToDefault() {
   await saveConfig()
 }
 
+function getTestCueLabel(cue: SoundCue): string {
+  switch (cue) {
+    case 'warning':
+      return t('components.settings.soundSettings.test.warning')
+    case 'error':
+      return t('components.settings.soundSettings.test.error')
+    case 'taskComplete':
+      return t('components.settings.soundSettings.test.taskComplete')
+    case 'taskError':
+      return t('components.settings.soundSettings.test.taskError')
+  }
+}
+
+async function triggerWindowsNotificationPreview(reason: WindowsAgentStopPreviewReason): Promise<void> {
+  try {
+    const payload = {
+      reason,
+      actionType: reason === 'awaiting_user_action'
+        ? 'execute_plan'
+        : reason === 'continue_required'
+          ? 'continue'
+          : undefined,
+      content: buildWindowsAgentStopNotificationContentDraft()
+    }
+
+    console.log('[sound-settings][preview]', 'sending Windows notification preview', {
+      reason,
+      payload
+    })
+
+    const result = await sendToExtension('notifications.preview', payload)
+    console.log('[sound-settings][preview]', 'Windows notification preview finished', { reason, result })
+  } catch (error) {
+    console.error('Failed to trigger Windows notification preview:', error)
+  }
+}
+
 async function testCue(cue: SoundCue) {
   testMessage.value = ''
+  console.log('[sound-settings][testCue]', 'start test cue', { cue })
 
   // 试听应使用当前表单音量，但不应把“未保存”的 enabled/cues 等设置带到运行时。
   // 因此这里临时覆盖运行时音量，播放后再恢复。
@@ -467,6 +559,71 @@ onBeforeUnmount(() => {
           <CustomCheckbox v-model="cueError" :label="t('components.settings.soundSettings.cues.error')" />
           <CustomCheckbox v-model="cueTaskComplete" :label="t('components.settings.soundSettings.cues.taskComplete')" />
           <CustomCheckbox v-model="cueTaskError" :label="t('components.settings.soundSettings.cues.taskError')" />
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label class="group-label">
+          <i class="codicon codicon-bell-dot"></i>
+          {{ t('components.settings.soundSettings.windowsAgentStopNotification.title') }}
+        </label>
+        <p class="field-description">{{ t('components.settings.soundSettings.windowsAgentStopNotification.description') }}</p>
+        <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.rawTextHint') }}</p>
+        <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.bestEffortClickHint') }}</p>
+
+        <CustomCheckbox
+          v-model="windowsAgentStopNotificationEnabled"
+          :label="t('components.settings.soundSettings.windowsAgentStopNotification.enabled')"
+        />
+        <CustomCheckbox
+          v-model="windowsAgentStopNotificationOnlyWhenWindowNotFocused"
+          :label="t('components.settings.soundSettings.windowsAgentStopNotification.onlyWhenWindowNotFocused')"
+        />
+
+        <div class="cues-grid">
+          <CustomCheckbox v-model="windowsAgentStopNotificationCaseError" :label="t('components.settings.soundSettings.windowsAgentStopNotification.cases.error')" />
+          <CustomCheckbox v-model="windowsAgentStopNotificationCaseAwaitingUserAction" :label="t('components.settings.soundSettings.windowsAgentStopNotification.cases.awaitingUserAction')" />
+          <CustomCheckbox v-model="windowsAgentStopNotificationCaseContinueRequired" :label="t('components.settings.soundSettings.windowsAgentStopNotification.cases.continueRequired')" />
+        </div>
+
+        <div class="template-field">
+          <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.title') }}</label>
+          <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.description') }}</p>
+        </div>
+
+        <div class="template-grid">
+          <div class="template-field">
+            <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.titleTemplate') }}</label>
+            <input v-model="windowsAgentStopNotificationTitleTemplate" class="template-input" type="text">
+          </div>
+          <div class="template-field">
+            <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.errorBodyTemplate') }}</label>
+            <textarea v-model="windowsAgentStopNotificationErrorBodyTemplate" class="template-textarea" rows="2"></textarea>
+          </div>
+          <div class="template-field">
+            <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.awaitingUserActionBodyTemplate') }}</label>
+            <textarea v-model="windowsAgentStopNotificationAwaitingUserActionBodyTemplate" class="template-textarea" rows="2"></textarea>
+          </div>
+          <div class="template-field">
+            <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.continueRequiredBodyTemplate') }}</label>
+            <textarea v-model="windowsAgentStopNotificationContinueRequiredBodyTemplate" class="template-textarea" rows="2"></textarea>
+          </div>
+          <div class="template-field">
+            <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.variables') }}</label>
+            <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.templates.variablesHint') }}</p>
+            <div class="variable-list">
+              <code v-for="variable in windowsAgentStopTemplateVariables" :key="variable" class="variable-chip">{{ variable }}</code>
+            </div>
+          </div>
+          <div class="template-field">
+            <label class="template-label">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.title') }}</label>
+            <p class="inline-hint">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.description') }}</p>
+            <div class="test-buttons">
+              <button class="action-btn" @click="triggerWindowsNotificationPreview('error')">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.error') }}</button>
+              <button class="action-btn" @click="triggerWindowsNotificationPreview('awaiting_user_action')">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.awaitingUserAction') }}</button>
+              <button class="action-btn" @click="triggerWindowsNotificationPreview('continue_required')">{{ t('components.settings.soundSettings.windowsAgentStopNotification.preview.continueRequired') }}</button>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -738,6 +895,59 @@ onBeforeUnmount(() => {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.inline-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.template-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.template-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.template-label {
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.template-input,
+.template-textarea {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--vscode-input-foreground);
+  background: var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-border, transparent);
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+.template-textarea {
+  resize: vertical;
+  min-height: 56px;
+}
+
+.variable-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.variable-chip {
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
 }
 
 .actions {

--- a/frontend/src/components/tools/file/write_file.vue
+++ b/frontend/src/components/tools/file/write_file.vue
@@ -717,7 +717,7 @@ onBeforeUnmount(() => {
         <div class="plan-content">
           <CustomScrollbar :max-height="isPlanExpanded(file.path) ? 500 : 200">
             <div class="plan-preview">
-              <MarkdownRenderer :content="isPlanExpanded(file.path) ? file.content : extractPreviewText(file.content, { maxLines: 12, maxChars: 1600 })" />
+              <MarkdownRenderer :content="isPlanExpanded(file.path) ? file.content : extractPreviewText(file.content, { maxLines: 12, maxChars: 1600 })" render-profile="artifactSafe" />
             </div>
           </CustomScrollbar>
         </div>

--- a/frontend/src/i18n/langs/en.ts
+++ b/frontend/src/i18n/langs/en.ts
@@ -787,7 +787,7 @@ const en: LanguageMessages = {
                 context: 'Context',
                 prompt: 'Prompt',
                 tokenCount: 'Token Count',
-                sound: 'Sound',
+                sound: 'Notification System',
                 appearance: 'Appearance',
                 general: 'General'
             },
@@ -1741,8 +1741,8 @@ const en: LanguageMessages = {
                         description: 'Configure specialized sub-agents that AI can invoke'
                     },
                     sound: {
-                        title: 'Sound',
-                        description: 'Play sound cues for warnings, errors, and task completion'
+                        title: 'Notification System',
+                        description: 'Configure sound cues and Windows Agent stop notifications'
                     },
                     appearance: {
                         title: 'Appearance',
@@ -1981,9 +1981,17 @@ const en: LanguageMessages = {
                 saveFailed: 'Save failed'
             },
             soundSettings: {
+                overview: {
+                    title: 'About This Page',
+                    description: 'This page manages Webview sound cues and Windows Agent stop notifications together. The settings below are grouped by function for easier adjustment.'
+                },
+                sections: {
+                    sound: { title: 'Sound Cues', description: 'Configure Webview sound cues, including enable state, volume, events, imported audio files, and test playback.' },
+                    windowsNotification: { title: 'Windows Agent Stop Notifications', description: 'Configure Windows notifications shown when the Agent stops, including templates and preview.' }
+                },
                 enabled: {
                     title: 'Enable Sound Notifications',
-                    description: 'Play sound cues on certain events (disabled by default)',
+                    description: 'Play sound cues on certain events. This switch affects only sound cues and does not control Windows system notifications.',
                     label: 'Enable'
                 },
                 volume: {
@@ -2022,12 +2030,14 @@ const en: LanguageMessages = {
                     taskError: 'Test: Task Failed'
                 },
                 windowsAgentStopNotification: {
-                    title: 'Windows System Notifications',
+                    title: 'Windows Agent Stop Notifications',
                     description: 'Only available on Windows. These notifications are used only when the Agent stops. This phase shows a recognizable window title and renders the notification text from templates.',
+                    optionsTitle: 'Notification Rules',
                     enabled: 'Enable Windows system notifications',
                     onlyWhenWindowNotFocused: 'Notify only when the current window is not focused',
                     rawTextHint: 'Notification title and body are generated from templates and do not directly display raw Agent text.',
                     bestEffortClickHint: 'Click handling remains best effort and is not a guarantee of precise window recovery in this phase.',
+                    casesTitle: 'Notify For',
                     cases: {
                         error: 'Notify on failures',
                         awaitingUserAction: 'Notify when user action is required',

--- a/frontend/src/i18n/langs/en.ts
+++ b/frontend/src/i18n/langs/en.ts
@@ -2015,11 +2015,41 @@ const en: LanguageMessages = {
                 },
                 test: {
                     title: 'Test Playback',
-                    description: 'Unlock browser audio policy and preview cues',
+                    description: 'Unlock browser audio policy and preview sound cues',
                     warning: 'Test: Warning',
                     error: 'Test: Error',
                     taskComplete: 'Test: Task Completed',
                     taskError: 'Test: Task Failed'
+                },
+                windowsAgentStopNotification: {
+                    title: 'Windows System Notifications',
+                    description: 'Only available on Windows. These notifications are used only when the Agent stops. This phase shows a recognizable window title and renders the notification text from templates.',
+                    enabled: 'Enable Windows system notifications',
+                    onlyWhenWindowNotFocused: 'Notify only when the current window is not focused',
+                    rawTextHint: 'Notification title and body are generated from templates and do not directly display raw Agent text.',
+                    bestEffortClickHint: 'Click handling remains best effort and is not a guarantee of precise window recovery in this phase.',
+                    cases: {
+                        error: 'Notify on failures',
+                        awaitingUserAction: 'Notify when user action is required',
+                        continueRequired: 'Notify when continuation is required'
+                    },
+                    templates: {
+                        title: 'Notification Templates',
+                        description: 'Templates only support extension-controlled variables for rendering the title and body.',
+                        titleTemplate: 'Title Template',
+                        errorBodyTemplate: 'Failure Body Template',
+                        awaitingUserActionBodyTemplate: 'Awaiting User Action Body Template',
+                        continueRequiredBodyTemplate: 'Continue Required Body Template',
+                        variables: 'Available Variables',
+                        variablesHint: 'Available variables: {appName}, {windowTitle}, {actionLabel}, {reasonLabel}'
+                    },
+                    preview: {
+                        title: 'Notification Preview',
+                        description: 'Preview uses the template currently being edited and the current window title, then renders the final notification on the host side.',
+                        error: 'Preview Failure Notification',
+                        awaitingUserAction: 'Preview Awaiting User Action Notification',
+                        continueRequired: 'Preview Continue Required Notification'
+                    }
                 },
                 testBlocked: 'Audio may be blocked by browser policy. Click a test button once to unlock.',
                 testPlayed: 'Played',
@@ -2741,6 +2771,23 @@ const en: LanguageMessages = {
             summarizing: 'Auto summarizing...',
             manualSummarizing: 'Summarizing context...',
             cancelTooltip: 'Cancel summarize request'
+        },
+        agentStopNotification: {
+            errorTitle: 'LimCode Agent stopped',
+            errorMessage: 'The current conversation failed. Click the notification to return to the originating window.',
+            errorMessageWithConversation: 'Conversation "{title}" failed. Click the notification to return to the originating window.',
+            awaitingUserActionTitle: 'LimCode is waiting for your action',
+            awaitingUserActionMessage: 'The current conversation needs you to click "{action}". Click the notification to return to the originating window.',
+            awaitingUserActionMessageWithConversation: 'Conversation "{title}" needs you to click "{action}". Click the notification to return to the originating window.',
+            continueRequiredTitle: 'LimCode is waiting to continue',
+            continueRequiredMessage: 'The current conversation needs to continue. Click the notification to return to the originating window.',
+            continueRequiredMessageWithConversation: 'Conversation "{title}" needs to continue. Click the notification to return to the originating window.',
+            actions: {
+                generatePlan: 'Generate Plan',
+                executePlan: 'Execute Plan',
+                continue: 'Continue',
+                genericConfirmation: 'Return to LimCode and continue'
+            }
         }
     },
 

--- a/frontend/src/i18n/langs/ja.ts
+++ b/frontend/src/i18n/langs/ja.ts
@@ -787,7 +787,7 @@ const ja: LanguageMessages = {
                 context: 'コンテキスト',
                 prompt: 'プロンプト',
                 tokenCount: 'トークンカウント',
-                sound: 'サウンド通知',
+                sound: '通知システム',
                 appearance: '外観',
                 general: '一般'
             },
@@ -1741,8 +1741,8 @@ const ja: LanguageMessages = {
                         description: 'AI が呼び出せる専門サブエージェントを設定'
                     },
                     sound: {
-                        title: 'サウンド通知',
-                        description: '警告、エラー、タスク完了時に通知音を再生'
+                        title: '通知システム',
+                        description: 'サウンド通知と Windows Agent 停止通知をまとめて設定'
                     },
                     appearance: {
                         title: '外観',
@@ -1981,9 +1981,17 @@ const ja: LanguageMessages = {
                 saveFailed: '保存に失敗しました'
             },
             soundSettings: {
+                overview: {
+                    title: 'このページについて',
+                    description: 'このページでは、Webview のサウンド通知と Windows Agent 停止システム通知をまとめて管理します。下の設定は機能ごとに分けてあります。'
+                },
+                sections: {
+                    sound: { title: 'サウンド通知', description: 'Webview 内で再生する通知音を設定します。' },
+                    windowsNotification: { title: 'Windows Agent 停止システム通知', description: 'Agent 停止時に表示する Windows 通知、テンプレート、プレビューを設定します。' }
+                },
                 enabled: {
                     title: 'サウンド通知を有効化',
-                    description: '特定のイベント発生時に通知音を再生します（既定は無効）',
+                    description: '特定のイベントで通知音を再生します。このスイッチはサウンド通知だけに影響し、Windows システム通知は制御しません。',
                     label: '有効化'
                 },
                 volume: {
@@ -2022,12 +2030,14 @@ const ja: LanguageMessages = {
                     taskError: '試聴：タスク失敗'
                 },
                 windowsAgentStopNotification: {
-                    title: 'Windows システム通知',
+                    title: 'Windows Agent 停止システム通知',
                     description: 'Windows でのみ有効です。通知は Agent が停止した場面だけで使われます。現段階では識別しやすいウィンドウ名を表示し、テンプレートから通知文面を生成します。',
+                    optionsTitle: '通知ルール',
                     enabled: 'Windows システム通知を有効にする',
                     onlyWhenWindowNotFocused: '現在のウィンドウが前面にないときだけ通知する',
                     rawTextHint: '通知タイトルと本文はテンプレートから生成され、Agent の生テキストをそのまま表示しません。',
                     bestEffortClickHint: '通知クリックの処理は引き続き best effort であり、この段階では厳密なウィンドウ復帰を保証しません。',
+                    casesTitle: '通知する場面',
                     cases: {
                         error: '失敗時に通知する',
                         awaitingUserAction: 'ユーザー操作が必要なときに通知する',

--- a/frontend/src/i18n/langs/ja.ts
+++ b/frontend/src/i18n/langs/ja.ts
@@ -2021,6 +2021,36 @@ const ja: LanguageMessages = {
                     taskComplete: '試聴：タスク完了',
                     taskError: '試聴：タスク失敗'
                 },
+                windowsAgentStopNotification: {
+                    title: 'Windows システム通知',
+                    description: 'Windows でのみ有効です。通知は Agent が停止した場面だけで使われます。現段階では識別しやすいウィンドウ名を表示し、テンプレートから通知文面を生成します。',
+                    enabled: 'Windows システム通知を有効にする',
+                    onlyWhenWindowNotFocused: '現在のウィンドウが前面にないときだけ通知する',
+                    rawTextHint: '通知タイトルと本文はテンプレートから生成され、Agent の生テキストをそのまま表示しません。',
+                    bestEffortClickHint: '通知クリックの処理は引き続き best effort であり、この段階では厳密なウィンドウ復帰を保証しません。',
+                    cases: {
+                        error: '失敗時に通知する',
+                        awaitingUserAction: 'ユーザー操作が必要なときに通知する',
+                        continueRequired: '続行が必要なときに通知する'
+                    },
+                    templates: {
+                        title: '通知テンプレート',
+                        description: 'テンプレートでは、拡張機能が管理する変数だけを使ってタイトルと本文を生成します。',
+                        titleTemplate: 'タイトルテンプレート',
+                        errorBodyTemplate: '失敗本文テンプレート',
+                        awaitingUserActionBodyTemplate: 'ユーザー操作待ち本文テンプレート',
+                        continueRequiredBodyTemplate: '続行待ち本文テンプレート',
+                        variables: '使用できる変数',
+                        variablesHint: '使用できる変数: {appName}、{windowTitle}、{actionLabel}、{reasonLabel}'
+                    },
+                    preview: {
+                        title: '通知プレビュー',
+                        description: 'プレビューは、現在編集中のテンプレートと現在のウィンドウ名を使い、ホスト側で最終通知を描画します。',
+                        error: '失敗通知をプレビュー',
+                        awaitingUserAction: 'ユーザー操作待ち通知をプレビュー',
+                        continueRequired: '続行待ち通知をプレビュー'
+                    }
+                },
                 testBlocked: '音声がブラウザのポリシーでブロックされている可能性があります。テストボタンを一度クリックして解除してください。',
                 testPlayed: '再生しました',
                 testFailed: '再生に失敗しました（ブラウザのポリシーでブロックされている可能性があります）',
@@ -2741,6 +2771,23 @@ const ja: LanguageMessages = {
             summarizing: '自動要約中...',
             manualSummarizing: '要約中...',
             cancelTooltip: '要約をキャンセル'
+        },
+        agentStopNotification: {
+            errorTitle: 'LimCode Agent が停止しました',
+            errorMessage: '現在の会話は失敗しました。通知をクリックすると元のウィンドウに戻れます。',
+            errorMessageWithConversation: '会話「{title}」は失敗しました。通知をクリックすると元のウィンドウに戻れます。',
+            awaitingUserActionTitle: 'LimCode は操作を待っています',
+            awaitingUserActionMessage: '現在の会話では「{action}」が必要です。通知をクリックすると元のウィンドウに戻れます。',
+            awaitingUserActionMessageWithConversation: '会話「{title}」では「{action}」が必要です。通知をクリックすると元のウィンドウに戻れます。',
+            continueRequiredTitle: 'LimCode は続行を待っています',
+            continueRequiredMessage: '現在の会話は続行が必要です。通知をクリックすると元のウィンドウに戻れます。',
+            continueRequiredMessageWithConversation: '会話「{title}」は続行が必要です。通知をクリックすると元のウィンドウに戻れます。',
+            actions: {
+                generatePlan: 'プランを生成',
+                executePlan: 'プランを実行',
+                continue: '続行',
+                genericConfirmation: 'LimCode に戻って続行'
+            }
         }
     },
 

--- a/frontend/src/i18n/langs/zh-CN.ts
+++ b/frontend/src/i18n/langs/zh-CN.ts
@@ -787,7 +787,7 @@ const zhCN: LanguageMessages = {
                 context: '上下文',
                 prompt: '提示词',
                 tokenCount: 'Token 计数',
-                sound: '声音提醒',
+                sound: '提示系统',
                 appearance: '外观',
                 general: '通用'
             },
@@ -1741,8 +1741,8 @@ const zhCN: LanguageMessages = {
                         description: '配置可由 AI 调用的专业子代理'
                     },
                     sound: {
-                        title: '声音提醒',
-                        description: '配置警告、错误与任务完成时的提示音'
+                        title: '提示系统',
+                        description: '统一配置声音提示与 Windows Agent 停止系统通知'
                     },
                     appearance: {
                         title: '外观设置',
@@ -1981,9 +1981,17 @@ const zhCN: LanguageMessages = {
                 saveFailed: '保存失败'
             },
             soundSettings: {
+                overview: {
+                    title: '本页说明',
+                    description: '本页同时管理 Webview 声音提示和 Windows Agent 停止系统通知。下方内容按功能分区，便于分别调整。'
+                },
+                sections: {
+                    sound: { title: '声音提示', description: '配置 Webview 内的提示音，包括启用、音量、事件、音效文件与测试播放。' },
+                    windowsNotification: { title: 'Windows Agent 停止系统通知', description: '配置 Agent 停止后的 Windows 系统通知、模板与预览。' }
+                },
                 enabled: {
                     title: '启用声音提醒',
-                    description: '在特定事件发生时播放提示音（默认关闭）',
+                    description: '在特定事件发生时播放提示音。此开关只影响声音提示，不影响 Windows 系统通知。',
                     label: '启用'
                 },
                 volume: {
@@ -2022,12 +2030,14 @@ const zhCN: LanguageMessages = {
                     taskError: '试听：任务失败'
                 },
                 windowsAgentStopNotification: {
-                    title: 'Windows 系统通知',
+                    title: 'Windows Agent 停止系统通知',
                     description: '仅在 Windows 生效。通知只用于 Agent 停止场景。当前阶段会显示当前窗口的可识别标题，并按模板生成通知文案。',
+                    optionsTitle: '通知开关与规则',
                     enabled: '启用 Windows 系统通知',
                     onlyWhenWindowNotFocused: '仅在当前窗口不在前台时通知',
                     rawTextHint: '通知标题和正文由扩展按模板生成，不直接显示 Agent 原始文本。',
                     bestEffortClickHint: '点击通知仍为尽力而为，不作为当前阶段的精确窗口回跳保证。',
+                    casesTitle: '通知场景',
                     cases: {
                         error: '失败时通知',
                         awaitingUserAction: '需要用户动作时通知',

--- a/frontend/src/i18n/langs/zh-CN.ts
+++ b/frontend/src/i18n/langs/zh-CN.ts
@@ -2015,11 +2015,41 @@ const zhCN: LanguageMessages = {
                 },
                 test: {
                     title: '测试播放',
-                    description: '用于解锁浏览器音频策略，并试听提示音',
+                    description: '用于解锁浏览器音频策略并试听提示音',
                     warning: '试听：警告',
                     error: '试听：错误',
                     taskComplete: '试听：任务完成',
                     taskError: '试听：任务失败'
+                },
+                windowsAgentStopNotification: {
+                    title: 'Windows 系统通知',
+                    description: '仅在 Windows 生效。通知只用于 Agent 停止场景。当前阶段会显示当前窗口的可识别标题，并按模板生成通知文案。',
+                    enabled: '启用 Windows 系统通知',
+                    onlyWhenWindowNotFocused: '仅在当前窗口不在前台时通知',
+                    rawTextHint: '通知标题和正文由扩展按模板生成，不直接显示 Agent 原始文本。',
+                    bestEffortClickHint: '点击通知仍为尽力而为，不作为当前阶段的精确窗口回跳保证。',
+                    cases: {
+                        error: '失败时通知',
+                        awaitingUserAction: '需要用户动作时通知',
+                        continueRequired: '需要继续时通知'
+                    },
+                    templates: {
+                        title: '通知模板',
+                        description: '模板只支持扩展可控变量，用于生成通知标题和正文。',
+                        titleTemplate: '标题模板',
+                        errorBodyTemplate: '失败正文模板',
+                        awaitingUserActionBodyTemplate: '等待用户动作正文模板',
+                        continueRequiredBodyTemplate: '等待继续正文模板',
+                        variables: '可用变量',
+                        variablesHint: '可用变量：{appName}、{windowTitle}、{actionLabel}、{reasonLabel}'
+                    },
+                    preview: {
+                        title: '通知预览',
+                        description: '预览会使用当前编辑中的模板和当前窗口标题，由宿主渲染最终通知。',
+                        error: '预览失败通知',
+                        awaitingUserAction: '预览等待用户动作通知',
+                        continueRequired: '预览等待继续通知'
+                    }
                 },
                 testBlocked: '声音被浏览器策略阻止，请点击一次“试听”按钮解锁（或检查 VS Code 音频设置）',
                 testPlayed: '已播放',
@@ -2741,6 +2771,23 @@ const zhCN: LanguageMessages = {
             summarizing: '自动总结中…',
             manualSummarizing: '手动总结中…',
             cancelTooltip: '取消总结'
+        },
+        agentStopNotification: {
+            errorTitle: 'LimCode Agent 已停止',
+            errorMessage: '当前对话执行失败。点击通知可回到对应窗口继续处理。',
+            errorMessageWithConversation: '对话“{title}”执行失败。点击通知可回到对应窗口继续处理。',
+            awaitingUserActionTitle: 'LimCode 等待您的操作',
+            awaitingUserActionMessage: '当前对话需要您点击“{action}”。点击通知可回到对应窗口继续处理。',
+            awaitingUserActionMessageWithConversation: '对话“{title}”需要您点击“{action}”。点击通知可回到对应窗口继续处理。',
+            continueRequiredTitle: 'LimCode 等待继续',
+            continueRequiredMessage: '当前对话需要继续。点击通知可回到对应窗口继续处理。',
+            continueRequiredMessageWithConversation: '对话“{title}”需要继续。点击通知可回到对应窗口继续处理。',
+            actions: {
+                generatePlan: '生成计划',
+                executePlan: '执行计划',
+                continue: '继续',
+                genericConfirmation: '回到 LimCode 继续'
+            }
         }
     },
 

--- a/frontend/src/i18n/types.ts
+++ b/frontend/src/i18n/types.ts
@@ -2023,6 +2023,14 @@ export interface LanguageMessages {
                 saveFailed: string;
             };
             soundSettings: {
+                overview: {
+                    title: string;
+                    description: string;
+                };
+                sections: {
+                    sound: { title: string; description: string; };
+                    windowsNotification: { title: string; description: string; };
+                };
                 enabled: {
                     title: string;
                     description: string;
@@ -2070,6 +2078,7 @@ export interface LanguageMessages {
                     description: string;
                     enabled: string;
                     onlyWhenWindowNotFocused: string;
+                    optionsTitle: string;
                     rawTextHint: string;
                     bestEffortClickHint: string;
                     cases: {
@@ -2077,6 +2086,7 @@ export interface LanguageMessages {
                         awaitingUserAction: string;
                         continueRequired: string;
                     };
+                    casesTitle: string;
                     templates: {
                         title: string;
                         description: string;

--- a/frontend/src/i18n/types.ts
+++ b/frontend/src/i18n/types.ts
@@ -2065,6 +2065,36 @@ export interface LanguageMessages {
                 };
                 testBlocked: string;
                 testPlayed: string;
+                windowsAgentStopNotification: {
+                    title: string;
+                    description: string;
+                    enabled: string;
+                    onlyWhenWindowNotFocused: string;
+                    rawTextHint: string;
+                    bestEffortClickHint: string;
+                    cases: {
+                        error: string;
+                        awaitingUserAction: string;
+                        continueRequired: string;
+                    };
+                    templates: {
+                        title: string;
+                        description: string;
+                        titleTemplate: string;
+                        errorBodyTemplate: string;
+                        awaitingUserActionBodyTemplate: string;
+                        continueRequiredBodyTemplate: string;
+                        variables: string;
+                        variablesHint: string;
+                    };
+                    preview: {
+                        title: string;
+                        description: string;
+                        error: string;
+                        awaitingUserAction: string;
+                        continueRequired: string;
+                    };
+                };
                 testFailed: string;
                 saveSuccess: string;
                 saveFailed: string;
@@ -2829,6 +2859,23 @@ export interface LanguageMessages {
             summarizing: string;
             manualSummarizing: string;
             cancelTooltip: string;
+        };
+        agentStopNotification: {
+            errorTitle: string;
+            errorMessage: string;
+            errorMessageWithConversation: string;
+            awaitingUserActionTitle: string;
+            awaitingUserActionMessage: string;
+            awaitingUserActionMessageWithConversation: string;
+            continueRequiredTitle: string;
+            continueRequiredMessage: string;
+            continueRequiredMessageWithConversation: string;
+            actions: {
+                generatePlan: string;
+                executePlan: string;
+                continue: string;
+                genericConfirmation: string;
+            };
         };
     };
 

--- a/frontend/src/services/agentStopNotificationController.ts
+++ b/frontend/src/services/agentStopNotificationController.ts
@@ -1,0 +1,357 @@
+import { nextTick, watch, type WatchStopHandle } from 'vue'
+import type { ErrorInfo, Message, ToolUsage } from '../types'
+import { getSoundSettings, type NormalizedUISoundSettings } from './soundCues'
+import {
+  resolvePendingAgentAction,
+  type PendingAgentAction,
+  type PendingAgentActionType
+} from '../utils/pendingAgentAction'
+
+const LOG_PREFIX = '[agent-stop-notification][frontend]'
+
+export type AgentStopNotificationReason = 'error' | 'awaiting_user_action' | 'continue_required'
+
+export interface AgentStopNotificationPayload {
+  reason: AgentStopNotificationReason
+  dedupeKey: string
+  createdAt: number
+  conversationId?: string
+  actionType?: PendingAgentActionType
+  toolName?: string
+  toolId?: string
+  path?: string
+  errorCode?: string
+}
+
+export interface AgentStopNotificationControllerChatStore {
+  isStreaming: boolean
+  isWaitingForResponse: boolean
+  error: ErrorInfo | null
+  retryStatus?: { isRetrying?: boolean } | null
+  needsContinueButton: boolean
+  hasPendingToolConfirmation: boolean
+  pendingToolCalls: ToolUsage[]
+  allMessages: Message[]
+  currentConversationId: string | null
+  currentConversation?: { title?: string } | null
+}
+
+export interface AgentStopNotificationControllerOptions {
+  chatStore: AgentStopNotificationControllerChatStore
+  sendToExtension: <T = any>(type: string, data: any) => Promise<T>
+  getSoundSettings?: () => NormalizedUISoundSettings
+}
+
+function normalizeText(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
+function findLatestMessage(messages: Message[], predicate?: (message: Message) => boolean): Message | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (!message) continue
+    if (!predicate || predicate(message)) {
+      return message
+    }
+  }
+  return null
+}
+
+export class AgentStopNotificationController {
+  private readonly chatStore: AgentStopNotificationControllerChatStore
+  private readonly sendToExtension: <T = any>(type: string, data: any) => Promise<T>
+  private readonly getRuntimeSoundSettings: () => NormalizedUISoundSettings
+  private runningWatch?: WatchStopHandle
+  private suppressNextStop = false
+  private lastSentDedupeKey = ''
+
+  constructor(options: AgentStopNotificationControllerOptions) {
+    this.chatStore = options.chatStore
+    this.sendToExtension = options.sendToExtension
+    this.getRuntimeSoundSettings = options.getSoundSettings ?? getSoundSettings
+    console.log(LOG_PREFIX, 'controller initialized')
+
+    this.runningWatch = watch(
+      () => this.isAgentRunning(),
+      (isRunning, wasRunning) => {
+        console.log(LOG_PREFIX, 'running state changed', {
+          wasRunning,
+          isRunning,
+          isStreaming: this.chatStore.isStreaming,
+          isWaitingForResponse: this.chatStore.isWaitingForResponse,
+          hasError: !!this.chatStore.error,
+          isRetrying: !!this.chatStore.retryStatus?.isRetrying,
+          needsContinueButton: this.chatStore.needsContinueButton,
+          hasPendingToolConfirmation: this.chatStore.hasPendingToolConfirmation
+        })
+
+        if (isRunning) {
+          this.lastSentDedupeKey = ''
+          console.log(LOG_PREFIX, 'agent entered running state, reset last dedupe key')
+          return
+        }
+
+        if (wasRunning) {
+          void this.handleAgentStopped()
+        }
+      },
+      {
+        flush: 'post'
+      }
+    )
+  }
+
+  markUserCancelled(): void {
+    if (!this.isAgentRunning()) {
+      console.log(LOG_PREFIX, 'markUserCancelled ignored because agent is not running')
+      return
+    }
+
+    this.suppressNextStop = true
+    console.log(LOG_PREFIX, 'marked next stop as user-cancelled')
+  }
+
+  clearUserCancelled(): void {
+    this.suppressNextStop = false
+    console.log(LOG_PREFIX, 'cleared user-cancel suppression flag')
+  }
+
+  dispose(): void {
+    this.runningWatch?.()
+    this.runningWatch = undefined
+    this.suppressNextStop = false
+    this.lastSentDedupeKey = ''
+    console.log(LOG_PREFIX, 'controller disposed')
+  }
+
+  private isAgentRunning(): boolean {
+    return !!(this.chatStore.isStreaming || this.chatStore.isWaitingForResponse)
+  }
+
+  private getNotificationSettings() {
+    return this.getRuntimeSoundSettings().windowsAgentStopNotification
+  }
+
+  private shouldNotify(reason: AgentStopNotificationReason): boolean {
+    const settings = this.getNotificationSettings()
+
+    if (!settings.enabled) {
+      console.log(LOG_PREFIX, 'skip notify because Windows notifications are disabled', {
+        reason,
+        settings
+      })
+      return false
+    }
+
+    const enabled = reason === 'error'
+      ? settings.cases.error
+      : reason === 'awaiting_user_action'
+        ? settings.cases.awaitingUserAction
+        : settings.cases.continueRequired
+
+    if (!enabled) {
+      console.log(LOG_PREFIX, 'skip notify because notification case is disabled', {
+        reason,
+        settings
+      })
+    }
+
+    return enabled
+  }
+
+  private getCreatedAt(preferredMessage: Message | null): number {
+    if (preferredMessage && Number.isFinite(preferredMessage.timestamp)) {
+      return preferredMessage.timestamp
+    }
+
+    const latestMessage = findLatestMessage(this.chatStore.allMessages)
+    if (latestMessage && Number.isFinite(latestMessage.timestamp)) {
+      return latestMessage.timestamp
+    }
+
+    return Date.now()
+  }
+
+  private buildErrorPayload(): AgentStopNotificationPayload | null {
+    const error = this.chatStore.error
+    if (!error || !this.shouldNotify('error')) {
+      return null
+    }
+
+    const conversationId = this.chatStore.currentConversationId || undefined
+    const latestMessage = findLatestMessage(this.chatStore.allMessages)
+    const messageKey = latestMessage?.id || String(latestMessage?.backendIndex || '')
+
+    const payload: AgentStopNotificationPayload = {
+      reason: 'error',
+      dedupeKey: ['error', conversationId || '', error.code || '', error.message || '', messageKey].join(':'),
+      createdAt: this.getCreatedAt(latestMessage),
+      conversationId,
+      errorCode: normalizeText(error.code)
+    }
+
+    console.log(LOG_PREFIX, 'built error payload', {
+      reason: payload.reason,
+      dedupeKey: payload.dedupeKey,
+      errorCode: payload.errorCode,
+      conversationId: payload.conversationId
+    })
+    return payload
+  }
+
+  private buildAwaitingUserActionPayload(action: PendingAgentAction): AgentStopNotificationPayload | null {
+    if (!this.shouldNotify('awaiting_user_action')) {
+      return null
+    }
+
+    const latestMessage = findLatestMessage(this.chatStore.allMessages)
+
+    const payload: AgentStopNotificationPayload = {
+      reason: 'awaiting_user_action',
+      dedupeKey: action.actionKey,
+      createdAt: this.getCreatedAt(latestMessage),
+      conversationId: action.conversationId || this.chatStore.currentConversationId || undefined,
+      actionType: action.type,
+      toolName: action.toolName,
+      toolId: action.toolId,
+      path: action.path
+    }
+
+    console.log(LOG_PREFIX, 'built awaiting_user_action payload', {
+      reason: payload.reason,
+      dedupeKey: payload.dedupeKey,
+      actionType: payload.actionType,
+      toolName: payload.toolName,
+      path: payload.path
+    })
+    return payload
+  }
+
+  private buildContinueRequiredPayload(): AgentStopNotificationPayload | null {
+    if (!this.chatStore.needsContinueButton || !this.shouldNotify('continue_required')) {
+      return null
+    }
+
+    const conversationId = this.chatStore.currentConversationId || undefined
+    const latestFunctionResponse = findLatestMessage(this.chatStore.allMessages, (message) => message.isFunctionResponse)
+    const latestMessage = latestFunctionResponse || findLatestMessage(this.chatStore.allMessages)
+    const dedupeSource = latestFunctionResponse?.id || String(latestFunctionResponse?.backendIndex || latestMessage?.id || '')
+
+    const payload: AgentStopNotificationPayload = {
+      reason: 'continue_required',
+      dedupeKey: ['continue_required', conversationId || '', dedupeSource].join(':'),
+      createdAt: this.getCreatedAt(latestMessage),
+      conversationId,
+      actionType: 'continue'
+    }
+
+    console.log(LOG_PREFIX, 'built continue_required payload', {
+      reason: payload.reason,
+      dedupeKey: payload.dedupeKey,
+      actionType: payload.actionType,
+      conversationId: payload.conversationId
+    })
+    return payload
+  }
+
+  private buildPayload(): AgentStopNotificationPayload | null {
+    if (this.chatStore.retryStatus?.isRetrying) {
+      console.log(LOG_PREFIX, 'skip notification because retrying is active')
+      return null
+    }
+
+    const errorPayload = this.buildErrorPayload()
+    if (errorPayload) {
+      console.log(LOG_PREFIX, 'selected error payload')
+      return errorPayload
+    }
+
+    const pendingAction = resolvePendingAgentAction({
+      allMessages: this.chatStore.allMessages,
+      hasPendingToolConfirmation: this.chatStore.hasPendingToolConfirmation,
+      pendingToolCalls: this.chatStore.pendingToolCalls,
+      conversationId: this.chatStore.currentConversationId
+    })
+
+    console.log(LOG_PREFIX, 'resolved pending action', pendingAction)
+
+    if (pendingAction) {
+      const payload = this.buildAwaitingUserActionPayload(pendingAction)
+      if (payload) {
+        console.log(LOG_PREFIX, 'selected awaiting_user_action payload')
+      }
+      return payload
+    }
+
+    const continuePayload = this.buildContinueRequiredPayload()
+    if (continuePayload) {
+      console.log(LOG_PREFIX, 'selected continue_required payload')
+      return continuePayload
+    }
+
+    console.log(LOG_PREFIX, 'no notification payload matched current stop state', {
+      hasError: !!this.chatStore.error,
+      needsContinueButton: this.chatStore.needsContinueButton,
+      hasPendingToolConfirmation: this.chatStore.hasPendingToolConfirmation,
+      messages: this.chatStore.allMessages.length
+    })
+
+    return null
+  }
+
+  private async handleAgentStopped(): Promise<void> {
+    await nextTick()
+    await Promise.resolve()
+
+    console.log(LOG_PREFIX, 'handling agent stopped event after state settled', {
+      isStreaming: this.chatStore.isStreaming,
+      isWaitingForResponse: this.chatStore.isWaitingForResponse,
+      hasError: !!this.chatStore.error,
+      isRetrying: !!this.chatStore.retryStatus?.isRetrying,
+      needsContinueButton: this.chatStore.needsContinueButton,
+      hasPendingToolConfirmation: this.chatStore.hasPendingToolConfirmation
+    })
+
+    if (this.isAgentRunning()) {
+      console.log(LOG_PREFIX, 'stop handling aborted because agent resumed running')
+      return
+    }
+
+    if (this.suppressNextStop) {
+      this.suppressNextStop = false
+      console.log(LOG_PREFIX, 'skip notification because stop was marked as user-cancelled')
+      return
+    }
+
+    const payload = this.buildPayload()
+    if (!payload) {
+      console.log(LOG_PREFIX, 'skip notification because no payload was produced')
+      return
+    }
+
+    if (payload.dedupeKey === this.lastSentDedupeKey) {
+      console.log(LOG_PREFIX, 'skip notification because dedupe key already sent in current stop cycle', {
+        dedupeKey: payload.dedupeKey
+      })
+      return
+    }
+
+    this.lastSentDedupeKey = payload.dedupeKey
+
+    try {
+      console.log(LOG_PREFIX, 'sending notification payload to extension', payload)
+      const result = await this.sendToExtension('notifications.agentStop', payload)
+      console.log(LOG_PREFIX, 'extension responded to notification payload', result)
+    } catch (error) {
+      console.error('[agent-stop-notification] Failed to send notification payload:', error)
+    }
+  }
+}
+
+export function createAgentStopNotificationController(
+  options: AgentStopNotificationControllerOptions
+): AgentStopNotificationController {
+  return new AgentStopNotificationController(options)
+}

--- a/frontend/src/services/soundCues.ts
+++ b/frontend/src/services/soundCues.ts
@@ -74,6 +74,26 @@ export interface UISoundAsset {
   dataBase64: string
 }
 
+export interface WindowsAgentStopNotificationContentSettings {
+  titleTemplate?: string
+  bodyTemplates?: {
+    error?: string
+    awaitingUserAction?: string
+    continueRequired?: string
+  }
+}
+
+export interface WindowsAgentStopNotificationSettings {
+  enabled?: boolean
+  onlyWhenWindowNotFocused?: boolean
+  cases?: {
+    error?: boolean
+    awaitingUserAction?: boolean
+    continueRequired?: boolean
+  }
+  content?: WindowsAgentStopNotificationContentSettings
+}
+
 export interface UISoundSettings {
   /** 总开关（默认关闭，避免打扰） */
   enabled?: boolean
@@ -107,6 +127,9 @@ export interface UISoundSettings {
 
   /** 提示音风格 */
   theme?: 'beep' | 'soft'
+
+  /** Windows 专用 Agent 停止系统通知 */
+  windowsAgentStopNotification?: WindowsAgentStopNotificationSettings
 }
 
 export interface NormalizedUISoundSettings {
@@ -126,6 +149,23 @@ export interface NormalizedUISoundSettings {
     taskError?: UISoundAsset
   }
   theme: 'beep' | 'soft'
+  windowsAgentStopNotification: {
+    enabled: boolean
+    onlyWhenWindowNotFocused: boolean
+    cases: {
+      error: boolean
+      awaitingUserAction: boolean
+      continueRequired: boolean
+    }
+    content: {
+      titleTemplate: string
+      bodyTemplates: {
+        error: string
+        awaitingUserAction: string
+        continueRequired: string
+      }
+    }
+  }
 }
 
 export const DEFAULT_UI_SOUND_SETTINGS: NormalizedUISoundSettings = {
@@ -139,7 +179,24 @@ export const DEFAULT_UI_SOUND_SETTINGS: NormalizedUISoundSettings = {
     taskError: true
   },
   assets: {},
-  theme: 'beep'
+  theme: 'beep',
+  windowsAgentStopNotification: {
+    enabled: false,
+    onlyWhenWindowNotFocused: true,
+    cases: {
+      error: true,
+      awaitingUserAction: true,
+      continueRequired: true
+    },
+    content: {
+      titleTemplate: '{windowTitle} · LimCode',
+      bodyTemplates: {
+        error: 'LimCode 已停止，请返回处理。',
+        awaitingUserAction: 'LimCode 正在等待：{actionLabel}。',
+        continueRequired: 'LimCode 已暂停，可继续处理。'
+      }
+    }
+  }
 }
 
 let currentSettings: NormalizedUISoundSettings = { ...DEFAULT_UI_SOUND_SETTINGS }
@@ -163,6 +220,11 @@ const inFlightPlayByKey = new Map<string, { token: string; reservedAt: number }>
 function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
   const n = typeof value === 'number' && Number.isFinite(value) ? value : fallback
   return Math.min(max, Math.max(min, n))
+}
+
+function normalizeTemplateString(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback
+  return value.trim() || fallback
 }
 
 function normalizeSoundAsset(input: unknown): UISoundAsset | undefined {
@@ -225,13 +287,39 @@ export function normalizeUISoundSettings(input?: UISoundSettings | null): Normal
     taskError: normalizeSoundAsset(input?.assets?.taskError)
   }
 
+  const windowsAgentStopNotification = {
+    enabled: typeof input?.windowsAgentStopNotification?.enabled === 'boolean'
+      ? input.windowsAgentStopNotification.enabled
+      : DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.enabled,
+    onlyWhenWindowNotFocused: typeof input?.windowsAgentStopNotification?.onlyWhenWindowNotFocused === 'boolean'
+      ? input.windowsAgentStopNotification.onlyWhenWindowNotFocused
+      : DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.onlyWhenWindowNotFocused,
+    cases: {
+      error: typeof input?.windowsAgentStopNotification?.cases?.error === 'boolean' ? input.windowsAgentStopNotification.cases.error : DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.cases.error,
+      awaitingUserAction: typeof input?.windowsAgentStopNotification?.cases?.awaitingUserAction === 'boolean' ? input.windowsAgentStopNotification.cases.awaitingUserAction : DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.cases.awaitingUserAction,
+      continueRequired: typeof input?.windowsAgentStopNotification?.cases?.continueRequired === 'boolean' ? input.windowsAgentStopNotification.cases.continueRequired : DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.cases.continueRequired
+    },
+    content: {
+      titleTemplate: normalizeTemplateString(
+        input?.windowsAgentStopNotification?.content?.titleTemplate,
+        DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.content.titleTemplate
+      ),
+      bodyTemplates: {
+        error: normalizeTemplateString(input?.windowsAgentStopNotification?.content?.bodyTemplates?.error, DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.content.bodyTemplates.error),
+        awaitingUserAction: normalizeTemplateString(input?.windowsAgentStopNotification?.content?.bodyTemplates?.awaitingUserAction, DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.content.bodyTemplates.awaitingUserAction),
+        continueRequired: normalizeTemplateString(input?.windowsAgentStopNotification?.content?.bodyTemplates?.continueRequired, DEFAULT_UI_SOUND_SETTINGS.windowsAgentStopNotification.content.bodyTemplates.continueRequired)
+      }
+    }
+  }
+
   return {
     enabled,
     volume,
     cooldownMs,
     cues,
     assets,
-    theme
+    theme,
+    windowsAgentStopNotification
   }
 }
 

--- a/frontend/src/stores/chat/computed.ts
+++ b/frontend/src/stores/chat/computed.ts
@@ -4,7 +4,10 @@
 
 import { computed } from 'vue'
 import type { ChatStoreState, ChatStoreComputed } from './types'
-import { isAwaitingToolUserConfirmation } from '../../utils/toolContinuations'
+import {
+  getToolApprovalStopKind,
+  isAwaitingToolUserConfirmation
+} from '../../utils/toolContinuations'
 
 /**
  * 创建 Chat Store 计算属性
@@ -87,13 +90,16 @@ export function createChatComputed(state: ChatStoreState): ChatStoreComputed {
     // 检查是否有工具要求暂停等待用户确认（如 create_plan / create_design）
     // 此时卡片会显示对应操作按钮，不需要额外的"继续"提示
     const hasPendingUserConfirmation = lastMessage.parts?.some(p => {
-      const response = (p.functionResponse?.response as any)
+      const toolName = p.functionResponse?.name
+      const response = p.functionResponse?.response as any
       return isAwaitingToolUserConfirmation(response)
+        || (typeof toolName === 'string' && getToolApprovalStopKind(toolName, response) !== null)
     })
 
     if (hasPendingUserConfirmation) {
       return false
     }
+
 
     return true
   })

--- a/frontend/src/stores/chat/messageActions.ts
+++ b/frontend/src/stores/chat/messageActions.ts
@@ -62,6 +62,7 @@ export type CancelStreamCallback = () => Promise<void>
  */
 export interface HiddenFunctionResponsePayload {
   id?: string
+  approvalId?: string
   name: string
   response: Record<string, unknown>
 }
@@ -296,6 +297,8 @@ export async function sendMessage(
     state.pendingModelOverride.value = effectiveModelOverride || null
     const streamId = generateId()
     state.activeStreamId.value = streamId
+    state._lastApprovalGatedStreamId.value = null
+
     state._lastCancelledStreamId.value = null
     
     const attachmentData: AttachmentData[] | undefined = attachments && attachments.length > 0

--- a/frontend/src/stores/chat/parsers.ts
+++ b/frontend/src/stores/chat/parsers.ts
@@ -85,7 +85,7 @@ export function getExtensionFromMime(mimeType: string): string {
  * 检查 Content 是否只包含 functionResponse（工具执行结果）
  */
 export function isOnlyFunctionResponse(content: Content): boolean {
-  return content.parts.every(p => p.functionResponse !== undefined)
+  return content.parts.length > 0 && content.parts.every(p => p.functionResponse !== undefined)
 }
 
 /**

--- a/frontend/src/stores/chat/state.ts
+++ b/frontend/src/stores/chat/state.ts
@@ -133,6 +133,9 @@ export function createChatState(): ChatStoreState {
   /** 上一次被 cancelStream 取消的 streamingMessageId */
   const _lastCancelledStreamId = ref<string | null>(null)
 
+  /** 最近一个因审批门闸停止的 streamId */
+  const _lastApprovalGatedStreamId = ref<string | null>(null)
+
   /** 编辑器节点数组（包含文本和上下文徽章，用于对话级输入状态隔离） */
   const editorNodes = ref<EditorNode[]>([])
 
@@ -196,6 +199,7 @@ export function createChatState(): ChatStoreState {
     pendingModelOverride,
     messageQueue,
     _lastCancelledStreamId,
+    _lastApprovalGatedStreamId,
     openTabs,
     activeTabId,
     sessionSnapshots,

--- a/frontend/src/stores/chat/streamChunkHandlers.ts
+++ b/frontend/src/stores/chat/streamChunkHandlers.ts
@@ -16,6 +16,7 @@ import {
   handleFunctionCallPart
 } from './streamHelpers'
 import { syncTotalMessagesFromWindow, trimWindowFromTop } from './windowUtils'
+import { getToolApprovalStopKind } from '../../utils/toolContinuations'
 
 function getNextBackendIndex(state: ChatStoreState): number {
   return state.windowStartIndex.value + state.allMessages.value.length
@@ -578,6 +579,7 @@ export function handleAwaitingConfirmation(
   // 但 isStreaming 设为 false 允许用户操作
   state.isStreaming.value = false
   state.activeStreamId.value = null
+  state._lastApprovalGatedStreamId.value = null
   // isWaitingForResponse 保持 true 或设为特殊状态
 }
 
@@ -612,7 +614,9 @@ export function handleToolIteration(
   const hasUserConfirmation = chunk.toolResults?.some(
     r => (r.result as any)?.requiresUserConfirmation
   ) ?? false
-  
+
+  let restoredTools: ToolUsage[] | undefined
+
   if (messageIndex !== -1) {
     const message = state.allMessages.value[messageIndex]
     // 保存原有的 tools 信息和 modelVersion
@@ -635,7 +639,7 @@ export function handleToolIteration(
     }
     
     // 合并 tools：以 finalMessage.tools 顺序为基准，保留 existingTools 的运行态字段
-    let restoredTools = mergeToolsPreferExisting(existingTools, finalMessage.tools)
+    restoredTools = mergeToolsPreferExisting(existingTools, finalMessage.tools)
     if (!restoredTools || restoredTools.length === 0) {
       restoredTools = existingTools
     }
@@ -740,15 +744,36 @@ export function handleToolIteration(
     }
   }
   
+  const toolArgsById = new Map<string, Record<string, unknown>>()
+  for (const tool of restoredTools || []) {
+    const args = tool.args && typeof tool.args === 'object'
+      ? tool.args as Record<string, unknown>
+      : {}
+    toolArgsById.set(tool.id, args)
+  }
+
+  const hasApprovalStop = chunk.toolResults?.some(result => {
+    const args = typeof result.id === 'string'
+      ? toolArgsById.get(result.id)
+      : undefined
+    return getToolApprovalStopKind(result.name, result.result, args) !== null
+  }) ?? false
+
   // 如果有工具被取消 或 有工具要求用户确认后再继续，结束 streaming 状态
-  // requiresUserConfirmation: 工具执行后的门闸（如 create_plan），等待用户点击"执行计划"后才继续
-  if (hasCancelledTools || hasUserConfirmation) {
+  // requiresUserConfirmation: 工具执行后的门闸（如 create_plan）
+  // hasApprovalStop: 覆盖 review -> plan 这类不依赖 requiresUserConfirmation 的宿主审批停止
+  if (hasCancelledTools || hasUserConfirmation || hasApprovalStop) {
     state.streamingMessageId.value = null
     state.activeStreamId.value = null
     state.isStreaming.value = false
     state.isWaitingForResponse.value = false
+    state._lastApprovalGatedStreamId.value = hasApprovalStop && chunk.streamId
+      ? chunk.streamId
+      : null
     return
   }
+
+  state._lastApprovalGatedStreamId.value = null
   
   // 创建新的占位消息用于接收后续 AI 响应
   const newAssistantMessageId = generateId()
@@ -856,6 +881,7 @@ export function handleComplete(
   state.isWaitingForResponse.value = false  // 结束等待
   state.autoSummaryStatus.value = null
   state.pendingModelOverride.value = null
+  state._lastApprovalGatedStreamId.value = null
   state._lastCancelledStreamId.value = null
   
   // 流式完成后更新对话元数据
@@ -1072,6 +1098,7 @@ export function handleCancelled(chunk: StreamChunk, state: ChatStoreState): void
   state.isWaitingForResponse.value = false
   state.autoSummaryStatus.value = null
   state.pendingModelOverride.value = null
+  state._lastApprovalGatedStreamId.value = null
   state._lastCancelledStreamId.value = null
 }
 
@@ -1117,5 +1144,6 @@ export function handleError(chunk: StreamChunk, state: ChatStoreState): void {
   state.isWaitingForResponse.value = false  // 结束等待
   state.autoSummaryStatus.value = null
   state.pendingModelOverride.value = null
+  state._lastApprovalGatedStreamId.value = null
   state._lastCancelledStreamId.value = null
 }

--- a/frontend/src/stores/chat/streamHandler.ts
+++ b/frontend/src/stores/chat/streamHandler.ts
@@ -46,6 +46,19 @@ export interface StreamHandlerContext {
   processQueue: () => Promise<void>
 }
 
+function warnLateApprovalGatedChunk(chunk: StreamChunk, state: ChatStoreState): void {
+  if (!chunk.streamId || chunk.streamId !== state._lastApprovalGatedStreamId.value) {
+    return
+  }
+
+  console.warn('[streamHandler] Late chunk ignored for approval-gated stream', {
+    conversationId: chunk.conversationId,
+    streamId: chunk.streamId,
+    type: chunk.type
+  })
+  state._lastApprovalGatedStreamId.value = null
+}
+
 /**
  * 处理单条流式响应
  */
@@ -66,10 +79,12 @@ export function handleStreamChunk(
   // 通过 streamId 只接收“当前活跃请求”的 chunk，避免迟到 chunk 污染新请求状态。
   const activeStreamId = state.activeStreamId.value
   if (chunk.streamId && !activeStreamId) {
+    warnLateApprovalGatedChunk(chunk, state)
     return
   }
 
   if (activeStreamId && chunk.streamId !== activeStreamId) {
+    warnLateApprovalGatedChunk(chunk, state)
     return
   }
 

--- a/frontend/src/stores/chat/types.ts
+++ b/frontend/src/stores/chat/types.ts
@@ -206,6 +206,9 @@ export interface ChatStoreState {
   /** 上一次被 cancelStream 取消的 streamingMessageId（用于防止迟到的 cancelled/error chunk 误清新请求状态） */
   _lastCancelledStreamId: Ref<string | null>
 
+  /** 最近一个因审批门闸停止的 streamId（用于迟到 chunk 诊断） */
+  _lastApprovalGatedStreamId: Ref<string | null>
+
   // ============ 多对话标签页 ============
 
   /** 当前打开的标签页列表（有序） */

--- a/frontend/src/utils/pendingAgentAction.ts
+++ b/frontend/src/utils/pendingAgentAction.ts
@@ -1,0 +1,190 @@
+import type { Message, ToolUsage } from '../types'
+import { extractReviewCardData, isReviewToolName } from './reviewCards'
+import { isDesignDocPath, isPlanDocPath } from './taskCards'
+import {
+  getPlanExecutionPrompt,
+  getPlanGenerationPrompt,
+  getPlanUpdateMode,
+  isAwaitingToolUserConfirmation
+} from './toolContinuations'
+
+export type PendingAgentActionType = 'generate_plan' | 'execute_plan' | 'continue' | 'generic_confirmation'
+
+export interface PendingAgentAction {
+  type: PendingAgentActionType
+  actionKey: string
+  conversationId?: string
+  toolName?: string
+  toolId?: string
+  path?: string
+}
+
+export interface ResolvePendingAgentActionInput {
+  allMessages: Message[]
+  hasPendingToolConfirmation?: boolean
+  pendingToolCalls?: ToolUsage[]
+  conversationId?: string | null
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : null
+}
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
+function buildActionKey(
+  type: PendingAgentActionType,
+  conversationId?: string | null,
+  toolId?: string,
+  toolName?: string,
+  path?: string
+): string {
+  return [
+    type,
+    conversationId || '',
+    toolId || '',
+    toolName || '',
+    path || ''
+  ].join(':')
+}
+
+function getResultRecord(tool: ToolUsage): Record<string, unknown> | null {
+  return asRecord(tool.result)
+}
+
+function resolvePathCandidates(tool: ToolUsage, result: Record<string, unknown> | null): string | undefined {
+  const args = asRecord(tool.args)
+  const data = asRecord(result?.data)
+
+  return normalizeString(data?.path)
+    || normalizeString(result?.path)
+    || normalizeString(args?.path)
+}
+
+function resolveToolAwaitingAction(
+  tool: ToolUsage,
+  conversationId?: string | null
+): PendingAgentAction | null {
+  const result = getResultRecord(tool)
+  if (!result) return null
+
+  if (result.success === false) {
+    return null
+  }
+
+  const path = resolvePathCandidates(tool, result)
+
+  if (tool.name === 'create_design' || tool.name === 'update_design') {
+    const continuationPrompt = getPlanGenerationPrompt(result)
+    if (!isAwaitingToolUserConfirmation(result) || continuationPrompt) {
+      return null
+    }
+
+    if (path && !isDesignDocPath(path)) {
+      return null
+    }
+
+    return {
+      type: 'generate_plan',
+      actionKey: buildActionKey('generate_plan', conversationId, tool.id, tool.name, path),
+      conversationId: conversationId || undefined,
+      toolName: tool.name,
+      toolId: tool.id,
+      path
+    }
+  }
+
+  if (tool.name === 'create_plan' || tool.name === 'update_plan') {
+    if (tool.name === 'update_plan' && getPlanUpdateMode(result, tool.args) === 'progress_sync') {
+      return null
+    }
+
+    const continuationPrompt = getPlanExecutionPrompt(result)
+    if (!isAwaitingToolUserConfirmation(result) || continuationPrompt) {
+      return null
+    }
+
+    if (path && !isPlanDocPath(path)) {
+      return null
+    }
+
+    return {
+      type: 'execute_plan',
+      actionKey: buildActionKey('execute_plan', conversationId, tool.id, tool.name, path),
+      conversationId: conversationId || undefined,
+      toolName: tool.name,
+      toolId: tool.id,
+      path
+    }
+  }
+
+  if (isReviewToolName(tool.name)) {
+    const reviewCardData = extractReviewCardData(tool.name, asRecord(tool.args) || {}, result)
+    const continuationPrompt = getPlanGenerationPrompt(result)
+
+    if (!reviewCardData || reviewCardData.status !== 'completed' || continuationPrompt) {
+      return null
+    }
+
+    if (!reviewCardData.path) {
+      return null
+    }
+
+    return {
+      type: 'generate_plan',
+      actionKey: buildActionKey('generate_plan', conversationId, tool.id, tool.name, reviewCardData.path),
+      conversationId: conversationId || undefined,
+      toolName: tool.name,
+      toolId: tool.id,
+      path: reviewCardData.path
+    }
+  }
+
+  return null
+}
+
+export function resolvePendingAgentAction(input: ResolvePendingAgentActionInput): PendingAgentAction | null {
+  const conversationId = input.conversationId || undefined
+
+  if (input.hasPendingToolConfirmation && Array.isArray(input.pendingToolCalls) && input.pendingToolCalls.length > 0) {
+    const pendingTool = input.pendingToolCalls[0]
+    return {
+      type: 'generic_confirmation',
+      actionKey: buildActionKey('generic_confirmation', conversationId, pendingTool.id, pendingTool.name),
+      conversationId,
+      toolName: pendingTool.name,
+      toolId: pendingTool.id
+    }
+  }
+
+  const messages = Array.isArray(input.allMessages) ? input.allMessages : []
+  for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex -= 1) {
+    const message = messages[messageIndex]
+
+    if (message?.role === 'user' && !message.isFunctionResponse) {
+      break
+    }
+
+    if (message?.role === 'assistant' && !message.isFunctionResponse && (!Array.isArray(message.tools) || message.tools.length === 0)) {
+      break
+    }
+
+    if (!message || !Array.isArray(message.tools) || message.tools.length === 0) {
+      continue
+    }
+
+    for (let toolIndex = message.tools.length - 1; toolIndex >= 0; toolIndex -= 1) {
+      const tool = message.tools[toolIndex]
+      const action = resolveToolAwaitingAction(tool, conversationId)
+      if (action) {
+        return action
+      }
+    }
+  }
+
+  return null
+}

--- a/frontend/src/utils/toolContinuations.ts
+++ b/frontend/src/utils/toolContinuations.ts
@@ -1,6 +1,12 @@
+import {
+  extractReviewCardData,
+  isReviewToolName
+} from './reviewCards'
+
 export type ContinuationIntent = 'generate_plan_now' | 'implement_now'
 export type ContinuationSourceArtifactType = 'design' | 'review' | 'plan'
 export type PlanUpdateMode = 'revision' | 'progress_sync'
+export type ToolApprovalStopKind = 'generate_plan' | 'execute_plan'
 
 export interface ToolContinuationContext {
   continuationApproved: true
@@ -140,6 +146,36 @@ export function getPlanUpdateMode(response: unknown, args?: unknown): PlanUpdate
 
 export function isPlanProgressSync(response: unknown, args?: unknown): boolean {
   return getPlanUpdateMode(response, args) === 'progress_sync'
+}
+
+export function getToolApprovalStopKind(
+  toolName: string,
+  response: unknown,
+  args?: unknown
+): ToolApprovalStopKind | null {
+  const record = asRecord(response)
+  if (!record || record.success === false) return null
+
+  if (toolName === 'create_design' || toolName === 'update_design') {
+    return isAwaitingToolUserConfirmation(record) && !getPlanGenerationPrompt(record)
+      ? 'generate_plan'
+      : null
+  }
+
+  if (toolName === 'create_plan' || toolName === 'update_plan') {
+    if (toolName === 'update_plan' && isPlanProgressSync(record, args)) {
+      return null
+    }
+
+    return isAwaitingToolUserConfirmation(record) && !getPlanExecutionPrompt(record)
+      ? 'execute_plan'
+      : null
+  }
+
+  const reviewCardData = isReviewToolName(toolName) ? extractReviewCardData(toolName, asRecord(args) || {}, record) : null
+  return reviewCardData?.status === 'completed' && !getPlanGenerationPrompt(record)
+    ? 'generate_plan'
+    : null
 }
 
 export function hasApprovedContinuation(response: unknown, expectedIntent?: ContinuationIntent): boolean {

--- a/package.json
+++ b/package.json
@@ -266,6 +266,7 @@
     "fast-xml-parser": "^4.5.0",
     "ignore": "^7.0.5",
     "nanoid": "^5.1.6",
+    "node-notifier": "^10.0.1",
     "tree-kill": "^1.2.2",
     "typescript": "^5.9.3",
     "undici-types": "^6.21.0"

--- a/test/unit/stores/chat/parsers.test.ts
+++ b/test/unit/stores/chat/parsers.test.ts
@@ -1,0 +1,64 @@
+import type { Content } from '../../../../frontend/src/types'
+import {
+  contentToMessageEnhanced,
+  isOnlyFunctionResponse
+} from '../../../../frontend/src/stores/chat/parsers'
+
+describe('chat parsers function response visibility', () => {
+  it('does not treat empty parts as a pure functionResponse message', () => {
+    const content: Content = {
+      role: 'model',
+      parts: []
+    }
+
+    expect(isOnlyFunctionResponse(content)).toBe(false)
+    expect(contentToMessageEnhanced(content).isFunctionResponse).toBe(false)
+  })
+
+  it('treats non-empty pure functionResponse parts as hidden function responses', () => {
+    const content: Content = {
+      role: 'model',
+      parts: [
+        {
+          functionResponse: {
+            id: 'tool-1',
+            name: 'create_plan',
+            response: { success: true }
+          }
+        }
+      ]
+    }
+
+    expect(isOnlyFunctionResponse(content)).toBe(true)
+    expect(contentToMessageEnhanced(content).isFunctionResponse).toBe(true)
+  })
+
+  it('keeps mixed text and functionResponse parts visible', () => {
+    const content: Content = {
+      role: 'model',
+      parts: [
+        { text: 'visible text' },
+        {
+          functionResponse: {
+            id: 'tool-2',
+            name: 'update_plan',
+            response: { success: true }
+          }
+        }
+      ]
+    }
+
+    expect(isOnlyFunctionResponse(content)).toBe(false)
+    expect(contentToMessageEnhanced(content).isFunctionResponse).toBe(false)
+  })
+
+  it('still respects an explicit backend isFunctionResponse flag', () => {
+    const content: Content = {
+      role: 'model',
+      parts: [],
+      isFunctionResponse: true
+    }
+
+    expect(contentToMessageEnhanced(content).isFunctionResponse).toBe(true)
+  })
+})

--- a/webview/ChatViewProvider.ts
+++ b/webview/ChatViewProvider.ts
@@ -41,6 +41,7 @@ import { getDiffManager } from '../backend/tools/file/diffManager';
 import { MessageRouter } from './MessageRouter';
 import { initializeSubAgentsFromSettings } from './handlers/SubAgentsHandlers';
 import type { HandlerContext, DiffPreviewContentProvider as IDiffPreviewContentProvider } from './types';
+import { WindowsAgentStopNotificationService } from '../backend/modules/notifications/WindowsAgentStopNotificationService';
 
 /**
  * Diff 预览内容提供者
@@ -97,6 +98,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     private storagePathManager!: StoragePathManager;
     private diffStorageManager!: DiffStorageManager;
     private conversationStorageAdapter?: FileSystemStorageAdapter;
+    private windowsAgentStopNotificationService?: WindowsAgentStopNotificationService;
     
     // 消息路由器
     private messageRouter!: MessageRouter;
@@ -155,6 +157,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         });
         this.settingsManager = new SettingsManager(settingsStorage);
         await this.settingsManager.initialize();
+        this.windowsAgentStopNotificationService = new WindowsAgentStopNotificationService({ settingsManager: this.settingsManager });
         
         // 2. 初始化存储路径管理器
         this.storagePathManager = new StoragePathManager(this.settingsManager, this.context);
@@ -603,6 +606,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
             dependencyManager: this.dependencyManager,
             storagePathManager: this.storagePathManager,
             diffStorageManager: this.diffStorageManager,
+            windowsAgentStopNotificationService: this.windowsAgentStopNotificationService,
             streamAbortControllers: this.messageRouter.getAbortManager() as any,
             diffPreviewProvider: this.diffPreviewProvider,
             sendResponse: this.sendResponse.bind(this),
@@ -726,6 +730,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
 
         // 释放 Skills 管理器资源
         getSkillsManager()?.dispose();
+        this.windowsAgentStopNotificationService?.dispose();
 
         console.log('ChatViewProvider disposed');
     }

--- a/webview/MessageRouter.ts
+++ b/webview/MessageRouter.ts
@@ -120,7 +120,7 @@ export class MessageRouter {
    * 取消所有活跃的流
    */
   cancelAllStreams(): void {
-    this.abortManager.cancelAll(this.getView());
+    this.streamHandler.cancelAllStreams().catch(console.error);
   }
 
   /**

--- a/webview/handlers/DiffHandlers.ts
+++ b/webview/handlers/DiffHandlers.ts
@@ -383,18 +383,31 @@ async function openDiffView(
 /**
  * 接受 Diff 修改
  */
-export const acceptDiff: MessageHandler = async (data, requestId, _ctx) => {
+export const acceptDiff: MessageHandler = async (data, requestId, ctx) => {
   try {
     const { sessionId } = data;
     const diffManager = getDiffManager();
-    const success = await diffManager.acceptDiff(sessionId, true);
-    if (success) {
-      _ctx.sendResponse(requestId, { success: true });
-    } else {
-      _ctx.sendResponse(requestId, { success: false, error: 'Failed to accept diff' });
+
+    if (diffManager.isDiffActionInProgress(sessionId)) {
+      ctx.sendError(requestId, 'DIFF_ALREADY_PROCESSING', 'Diff action is already in progress.');
+      return;
     }
+
+    const diff = diffManager.getDiff(sessionId);
+    if (!diff || diff.status !== 'pending') {
+      ctx.sendError(requestId, 'DIFF_NOT_PENDING', 'Diff is no longer pending.');
+      return;
+    }
+
+    const success = await diffManager.acceptDiff(sessionId, true);
+    if (!success) {
+      ctx.sendError(requestId, 'DIFF_ACCEPT_FAILED', 'Failed to accept diff. The diff remains pending and can be retried.');
+      return;
+    }
+
+    ctx.sendResponse(requestId, { success: true, sessionId, status: 'accepted' });
   } catch (error: any) {
-    _ctx.sendError(requestId, 'ACCEPT_DIFF_ERROR', error.message || 'Failed to accept diff');
+    ctx.sendError(requestId, 'DIFF_ACCEPT_FAILED', error.message || 'Failed to accept diff');
   }
 };
 
@@ -405,6 +418,18 @@ export const rejectDiff: MessageHandler = async (data, requestId, ctx) => {
   try {
     const { sessionId } = data;
     const diffManager = getDiffManager();
+
+    if (diffManager.isDiffActionInProgress(sessionId)) {
+      ctx.sendError(requestId, 'DIFF_ALREADY_PROCESSING', 'Diff action is already in progress.');
+      return;
+    }
+
+    const diff = diffManager.getDiff(sessionId);
+    if (!diff || diff.status !== 'pending') {
+      ctx.sendError(requestId, 'DIFF_NOT_PENDING', 'Diff is no longer pending.');
+      return;
+    }
+
     const success = await diffManager.rejectDiff(sessionId);
 
     // 注意：这里不要调用 conversationManager.rejectToolCalls。
@@ -412,13 +437,14 @@ export const rejectDiff: MessageHandler = async (data, requestId, ctx) => {
     // 用户点击“Reject”应当被视为“拒绝应用修改”，而不是“拒绝执行工具”。
     // 让工具本身在收到 diffManager 状态变更后返回正确的 functionResponse（status=rejected, results 等）。
 
-    if (success) {
-      ctx.sendResponse(requestId, { success: true });
-    } else {
-      ctx.sendResponse(requestId, { success: false, error: 'Failed to reject diff' });
+    if (!success) {
+      ctx.sendError(requestId, 'DIFF_REJECT_FAILED', 'Failed to reject diff. The diff remains pending and can be retried.');
+      return;
     }
+
+    ctx.sendResponse(requestId, { success: true, sessionId, status: 'rejected' });
   } catch (error: any) {
-    ctx.sendError(requestId, 'REJECT_DIFF_ERROR', error.message || 'Failed to reject diff');
+    ctx.sendError(requestId, 'DIFF_REJECT_FAILED', error.message || 'Failed to reject diff');
   }
 };
 

--- a/webview/handlers/FileHandlers.ts
+++ b/webview/handlers/FileHandlers.ts
@@ -13,6 +13,11 @@ import { validateFileInWorkspace, checkFileExists, getRelativePathFromAbsolute }
 import { extractPlanTodoListFromContent } from '../../backend/tools/plan/todoListSection';
 import { getPlanSourceStatusFromContent, type PlanSourceStatusResult } from '../../backend/tools/plan/sourceArtifactSection';
 import type { PinnedFileItem } from '../../backend/modules/settings/types';
+import {
+  getPendingApprovalGate,
+  getPendingApprovalGateMismatchReason,
+  type PendingApprovalGateExpectation
+} from '../../backend/modules/conversation/pendingApprovalGate';
 
 // ========== 工作区信息 ==========
 
@@ -1232,17 +1237,71 @@ function buildPlanSourceBlockedError(sourceStatus: PlanSourceStatusResult): stri
   return 'The plan source artifact is not executable in its current state.';
 }
 
+async function validatePendingApprovalGateForContinuation(
+  ctx: HandlerContext,
+  options: {
+    conversationId: unknown;
+    toolId: unknown;
+    expectation: PendingApprovalGateExpectation;
+  }
+): Promise<{ success: true; approvalId: string } | { success: false; error: string }> {
+  const conversationId = typeof options.conversationId === 'string' ? options.conversationId.trim() : '';
+  if (!conversationId) {
+    return { success: false, error: 'conversationId is required for approval-gated continuation.' };
+  }
+
+  const toolId = typeof options.toolId === 'string' ? options.toolId.trim() : '';
+  if (!toolId) {
+    return { success: false, error: 'toolId is required for approval-gated continuation.' };
+  }
+
+  const gate = await getPendingApprovalGate(ctx.conversationManager, conversationId);
+  if (!gate) {
+    return { success: false, error: 'No pending approval gate exists for this conversation.' };
+  }
+
+  const mismatch = getPendingApprovalGateMismatchReason(gate, {
+    ...options.expectation,
+    sourceToolCallId: toolId
+  });
+
+  if (mismatch) {
+    return { success: false, error: mismatch };
+  }
+
+  return {
+    success: true,
+    approvalId: gate.id
+  };
+}
+
 export const designConfirmPlanGeneration: MessageHandler = async (data, requestId, ctx) => {
   try {
-    const { path: designPathRaw, originalContent } = data || {};
+    const { path: designPathRaw, originalContent, conversationId, toolId } = data || {};
     const designPath = typeof designPathRaw === 'string' ? designPathRaw.trim() : '';
     const originalText = typeof originalContent === 'string' ? originalContent : '';
     const confirmedPrompt = buildPlanGenerationPrompt('design', false);
     const modifiedPrompt = buildPlanGenerationPrompt('design', true);
 
+    const gateCheck = await validatePendingApprovalGateForContinuation(ctx, {
+      conversationId,
+      toolId,
+      expectation: {
+        kind: 'generate_plan',
+        continuationIntent: 'generate_plan_now',
+        sourceArtifactType: 'design',
+        sourcePath: designPath || undefined
+      }
+    });
+    if (gateCheck.success === false) {
+      ctx.sendResponse(requestId, { success: false, error: gateCheck.error });
+      return;
+    }
+
     const replyWithDesign = async (prompt: string, designContent: string) => {
       ctx.sendResponse(requestId, {
         success: true,
+        approvalId: gateCheck.approvalId,
         prompt,
         designContent,
         designPath
@@ -1286,15 +1345,31 @@ export const designConfirmPlanGeneration: MessageHandler = async (data, requestI
 
 export const reviewConfirmPlanGeneration: MessageHandler = async (data, requestId, ctx) => {
   try {
-    const { path: reviewPathRaw, originalContent } = data || {};
+    const { path: reviewPathRaw, originalContent, conversationId, toolId } = data || {};
     const reviewPath = typeof reviewPathRaw === 'string' ? reviewPathRaw.trim() : '';
     const originalText = typeof originalContent === 'string' ? originalContent : '';
     const confirmedPrompt = buildPlanGenerationPrompt('review', false);
     const modifiedPrompt = buildPlanGenerationPrompt('review', true);
 
+    const gateCheck = await validatePendingApprovalGateForContinuation(ctx, {
+      conversationId,
+      toolId,
+      expectation: {
+        kind: 'generate_plan',
+        continuationIntent: 'generate_plan_now',
+        sourceArtifactType: 'review',
+        sourcePath: reviewPath || undefined
+      }
+    });
+    if (gateCheck.success === false) {
+      ctx.sendResponse(requestId, { success: false, error: gateCheck.error });
+      return;
+    }
+
     const replyWithReview = async (prompt: string, reviewContent: string) => {
       ctx.sendResponse(requestId, {
         success: true,
+        approvalId: gateCheck.approvalId,
         prompt,
         reviewContent,
         reviewPath
@@ -1375,10 +1450,26 @@ export const planGetSourceStatus: MessageHandler = async (data, requestId, ctx) 
 
 export const planConfirmExecution: MessageHandler = async (data, requestId, ctx) => {
   try {
-    const { path: planPath, originalContent, conversationId } = data || {};
+    const { path: planPath, originalContent, conversationId, toolId } = data || {};
     const confirmedPrompt = buildPlanExecutionPrompt(false);
     const originalText = typeof originalContent === 'string' ? originalContent : '';
     const modifiedPrompt = buildPlanExecutionPrompt(true);
+
+    const normalizedPlanPath = typeof planPath === 'string' ? planPath.trim() : '';
+    const gateCheck = await validatePendingApprovalGateForContinuation(ctx, {
+      conversationId,
+      toolId,
+      expectation: {
+        kind: 'execute_plan',
+        continuationIntent: 'implement_now',
+        sourceArtifactType: 'plan',
+        sourcePath: normalizedPlanPath || undefined
+      }
+    });
+    if (gateCheck.success === false) {
+      ctx.sendResponse(requestId, { success: false, error: gateCheck.error });
+      return;
+    }
 
     let latestSourceStatus: PlanSourceStatusResult = { sourceStatus: 'untracked' };
 
@@ -1415,6 +1506,7 @@ export const planConfirmExecution: MessageHandler = async (data, requestId, ctx)
       const todos = await syncTodosFromPlanContent(planContent);
       ctx.sendResponse(requestId, {
         success: true,
+        approvalId: gateCheck.approvalId,
         prompt,
         planContent,
         todos,

--- a/webview/handlers/NotificationHandlers.ts
+++ b/webview/handlers/NotificationHandlers.ts
@@ -1,0 +1,209 @@
+import type {
+  AgentStopNotificationPayload,
+  PendingAgentActionType,
+  WindowsNotificationPreviewPayload
+} from '../../backend/modules/notifications/types'
+import type { MessageHandler } from '../types'
+
+const LOG_PREFIX = '[windows-agent-stop-notification][handler]'
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : null
+}
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
+function normalizeReason(value: unknown): AgentStopNotificationPayload['reason'] | undefined {
+  if (value === 'error' || value === 'awaiting_user_action' || value === 'continue_required') {
+    return value
+  }
+  return undefined
+}
+
+function normalizeActionType(value: unknown): PendingAgentActionType | undefined {
+  if (
+    value === 'generate_plan'
+    || value === 'execute_plan'
+    || value === 'continue'
+    || value === 'generic_confirmation'
+  ) {
+    return value
+  }
+  return undefined
+}
+
+function normalizePayload(data: unknown): AgentStopNotificationPayload | null {
+  const record = asRecord(data)
+  if (!record) return null
+
+  const reason = normalizeReason(record.reason)
+  const dedupeKey = normalizeString(record.dedupeKey)
+  const createdAt = typeof record.createdAt === 'number' && Number.isFinite(record.createdAt)
+    ? record.createdAt
+    : Date.now()
+
+  if (!reason || !dedupeKey) {
+    return null
+  }
+
+  return {
+    reason,
+    dedupeKey,
+    createdAt,
+    title: normalizeString(record.title),
+    message: normalizeString(record.message),
+    conversationId: normalizeString(record.conversationId),
+    conversationTitle: normalizeString(record.conversationTitle),
+    actionType: normalizeActionType(record.actionType),
+    actionLabel: normalizeString(record.actionLabel),
+    toolName: normalizeString(record.toolName),
+    toolId: normalizeString(record.toolId),
+    path: normalizeString(record.path),
+    errorCode: normalizeString(record.errorCode),
+    errorMessage: normalizeString(record.errorMessage)
+  }
+}
+
+function normalizeContentOverride(value: unknown): WindowsNotificationPreviewPayload['content'] | undefined {
+  const record = asRecord(value)
+  if (!record) return undefined
+
+  const bodyTemplates = asRecord(record.bodyTemplates)
+  const normalizedBodyTemplates = {
+    error: normalizeString(bodyTemplates?.error),
+    awaitingUserAction: normalizeString(bodyTemplates?.awaitingUserAction),
+    continueRequired: normalizeString(bodyTemplates?.continueRequired)
+  }
+
+  const hasBodyTemplate = !!(
+    normalizedBodyTemplates.error
+    || normalizedBodyTemplates.awaitingUserAction
+    || normalizedBodyTemplates.continueRequired
+  )
+
+  const titleTemplate = normalizeString(record.titleTemplate)
+  if (!titleTemplate && !hasBodyTemplate) {
+    return undefined
+  }
+
+  return {
+    titleTemplate,
+    bodyTemplates: hasBodyTemplate ? normalizedBodyTemplates : undefined
+  }
+}
+
+function normalizePreviewPayload(data: unknown): WindowsNotificationPreviewPayload | null {
+  const record = asRecord(data)
+  if (!record) return null
+
+  const reason = normalizeReason(record.reason)
+  if (!reason) return null
+
+  return {
+    reason,
+    actionType: normalizeActionType(record.actionType),
+    actionLabel: normalizeString(record.actionLabel),
+    content: normalizeContentOverride(record.content)
+  }
+}
+
+export const notifyAgentStop: MessageHandler = async (data, requestId, ctx) => {
+  const payload = normalizePayload(data)
+  if (!payload) {
+    console.log(LOG_PREFIX, 'invalid notifications.agentStop payload', data)
+    ctx.sendResponse(requestId, {
+      success: true,
+      shown: false,
+      skipped: true,
+      reason: 'invalid_payload'
+    })
+    return
+  }
+
+  if (!ctx.windowsAgentStopNotificationService) {
+    console.log(LOG_PREFIX, 'notifications.agentStop skipped because service is unavailable')
+    ctx.sendResponse(requestId, {
+      success: true,
+      shown: false,
+      skipped: true,
+      reason: 'service_unavailable'
+    })
+    return
+  }
+
+  try {
+    console.log(LOG_PREFIX, 'dispatching notifications.agentStop', payload)
+    const result = await ctx.windowsAgentStopNotificationService.notify(payload)
+    console.log(LOG_PREFIX, 'notifications.agentStop finished', {
+      payload,
+      result
+    })
+    ctx.sendResponse(requestId, {
+      success: true,
+      ...result
+    })
+  } catch (error) {
+    console.error('[notifications.agentStop] Failed to dispatch notification:', error)
+    ctx.sendResponse(requestId, {
+      success: true,
+      shown: false,
+      skipped: true,
+      reason: 'handler_error'
+    })
+  }
+}
+
+export const previewWindowsNotification: MessageHandler = async (data, requestId, ctx) => {
+  const payload = normalizePreviewPayload(data)
+  if (!payload) {
+    console.log(LOG_PREFIX, 'invalid notifications.preview payload', data)
+    ctx.sendResponse(requestId, {
+      success: true,
+      shown: false,
+      skipped: true,
+      reason: 'invalid_payload'
+    })
+    return
+  }
+
+  if (!ctx.windowsAgentStopNotificationService) {
+    console.log(LOG_PREFIX, 'notifications.preview skipped because service is unavailable')
+    ctx.sendResponse(requestId, {
+      success: true,
+      shown: false,
+      skipped: true,
+      reason: 'service_unavailable'
+    })
+    return
+  }
+
+  try {
+    console.log(LOG_PREFIX, 'dispatching notifications.preview', payload)
+    const result = await ctx.windowsAgentStopNotificationService.preview(payload)
+    console.log(LOG_PREFIX, 'notifications.preview finished', {
+      payload,
+      result
+    })
+    ctx.sendResponse(requestId, {
+      success: true,
+      ...result
+    })
+  } catch (error) {
+    console.error('[notifications.preview] Failed to dispatch preview notification:', error)
+    ctx.sendResponse(requestId, {
+      success: true,
+      shown: false,
+      skipped: true,
+      reason: 'handler_error'
+    })
+  }
+}
+
+export function registerNotificationHandlers(registry: Map<string, MessageHandler>): void {
+  registry.set('notifications.agentStop', notifyAgentStop)
+  registry.set('notifications.preview', previewWindowsNotification)
+}

--- a/webview/handlers/index.ts
+++ b/webview/handlers/index.ts
@@ -18,6 +18,7 @@ import { registerDiffHandlers } from './DiffHandlers';
 import { registerChatHandlers } from './ChatHandlers';
 import { registerSkillsHandlers } from './SkillsHandlers';
 import { registerSubAgentsHandlers } from './SubAgentsHandlers';
+import { registerNotificationHandlers } from './NotificationHandlers';
 
 // 重新导出各个模块
 export * from './ConversationHandlers';
@@ -34,6 +35,7 @@ export * from './DiffHandlers';
 export * from './ChatHandlers';
 export * from './SkillsHandlers';
 export * from './SubAgentsHandlers';
+export * from './NotificationHandlers';
 
 /**
  * 创建并注册所有消息处理器
@@ -56,6 +58,7 @@ export function createMessageHandlerRegistry(): Map<string, MessageHandler> {
   registerChatHandlers(registry);
   registerSkillsHandlers(registry);
   registerSubAgentsHandlers(registry);
+  registerNotificationHandlers(registry);
   
   return registry;
 }

--- a/webview/stream/StreamAbortManager.ts
+++ b/webview/stream/StreamAbortManager.ts
@@ -55,6 +55,13 @@ export class StreamAbortManager {
   }
 
   /**
+   * 获取当前仍有活跃主流请求的对话 ID 列表
+   */
+  listConversationIds(): string[] {
+    return Array.from(this.controllers.keys());
+  }
+
+  /**
    * 删除指定对话的 AbortController
    */
   delete(conversationId: string): void {

--- a/webview/stream/StreamRequestHandler.ts
+++ b/webview/stream/StreamRequestHandler.ts
@@ -84,6 +84,33 @@ export class StreamRequestHandler {
     return requestId
   }
 
+  private async cleanupAbortedConversations(conversationIds: string[]): Promise<void> {
+    try {
+      const diffManager = getDiffManager();
+      await diffManager.cancelAllPending();
+    } catch (err) {
+      console.error('Failed to cancel pending diffs:', err);
+    }
+
+    if (conversationIds.length === 0) {
+      return;
+    }
+
+    await Promise.all(conversationIds.map(async (conversationId) => {
+      try {
+        await this.deps.conversationManager.rejectAllPendingToolCalls(conversationId);
+      } catch (err) {
+        console.error(`Failed to reject pending tool calls for conversation ${conversationId}:`, err);
+      }
+    }));
+  }
+
+  async cancelAllStreams(): Promise<void> {
+    const conversationIds = this.deps.abortManager.listConversationIds();
+    this.deps.abortManager.cancelAll(this.deps.getView());
+    await this.cleanupAbortedConversations(conversationIds);
+  }
+
   /**
    * 处理普通聊天流
    */
@@ -281,22 +308,9 @@ export class StreamRequestHandler {
   async cancelStream(conversationId: string, requestId: string): Promise<void> {
     // 1. 取消流式请求
     this.deps.abortManager.cancel(conversationId);
-    
-    // 2. 取消所有待处理的 diff（关闭编辑器并恢复文件）
-    try {
-      const diffManager = getDiffManager();
-      await diffManager.cancelAllPending();
-    } catch (err) {
-      console.error('Failed to cancel pending diffs:', err);
-    }
-    
-    // 3. 拒绝所有未响应的工具调用
-    try {
-      await this.deps.conversationManager.rejectAllPendingToolCalls(conversationId);
-    } catch (err) {
-      console.error('Failed to reject pending tool calls:', err);
-    }
-    
+
+    await this.cleanupAbortedConversations([conversationId]);
+
     this.deps.sendResponse(requestId, { cancelled: true });
   }
 

--- a/webview/types.ts
+++ b/webview/types.ts
@@ -15,6 +15,7 @@ import type { McpManager } from '../backend/modules/mcp';
 import type { DependencyManager } from '../backend/modules/dependencies';
 import type { DiffStorageManager } from '../backend/modules/conversation';
 import type { ToolRegistry } from '../backend/tools';
+import type { WindowsAgentStopNotificationService } from '../backend/modules/notifications/WindowsAgentStopNotificationService';
 
 /**
  * 消息处理器上下文
@@ -39,6 +40,7 @@ export interface HandlerContext {
   storagePathManager: StoragePathManager;
   diffStorageManager: DiffStorageManager;
   toolRegistry?: ToolRegistry;
+  windowsAgentStopNotificationService?: WindowsAgentStopNotificationService;
   
   // 流式请求控制
   streamAbortControllers: Map<string, AbortController>;


### PR DESCRIPTION
## 概要
- 稳定手动应用和拒绝后的 diff 生命周期闭合
- 在保存失败时保持 pending diff 可重试，并避免非手动保存误确认手动审阅中的 diff
- 按独立 pending diff session 渲染手动应用操作，并将每个操作准确绑定到对应 session
- 修复 plan 工具输出后后续消息的前端可见性问题
- 为 plan、review、progress、task-card 等工具产物预览引入 `artifactSafe` Markdown 渲染，阻断原生 HTML 影响布局
- 将 Build/TODO 吸顶面板改为默认折叠，并为展开内容增加高度上限与内部滚动
- 修复空 `parts` 消息被误判为隐藏 `functionResponse` 的问题
- 为 design/review -> plan 与 plan -> code continuation 引入宿主侧 NoAct 审批门闸
- 统一普通工具循环、流式提前执行、工具确认续跑与 orphaned tool replay 的 post-tool approval stop 收口
- 要求受覆盖 continuation 必须匹配持久化 `pendingApprovalGate + approvalId`，并保持现有按钮卡片 UX
- 对齐 reload/dispose 与 `cancelStream` 的清理语义，并补充同一 stream 迟到输出诊断与回归测试
- 将设置页“声音提醒”收敛为“提示系统”，并按“声音提示 / Windows Agent 停止系统通知”两个功能区重组界面
- 调整中英日文案，明确声音开关只控制声音提示，不混淆 Windows 系统通知职责

## 验证
- `pnpm test -- --runInBand test/unit/api/chat/services/ChatFlowService.approvalGate.test.ts test/unit/api/chat/services/postToolStopState.test.ts test/unit/frontend/streamHandler.approvalGate.test.ts test/unit/webview/handlers/FileHandlers.designConfirmPlanGeneration.test.ts test/unit/webview/handlers/FileHandlers.reviewConfirmPlanGeneration.test.ts test/unit/webview/handlers/FileHandlers.planConfirmExecution.test.ts test/unit/webview/handlers/StreamRequestHandler.test.ts`
- `pnpm test -- --runInBand test/unit/settings/soundSettings.test.ts test/unit/backend/modules/notifications/WindowsAgentStopNotificationService.test.ts test/unit/webview/handlers/NotificationHandlers.test.ts test/unit/frontend/services/agentStopNotificationController.test.ts`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir frontend build`
- 已手工回归确认 `apply_diff`、`write_file`、`search_in_files` replace、`insert_code`、`delete_code` 正常
- 已手工验证 plan 卡片、Build/TODO sticky 条与后续消息可见性无明显问题
- 已人工复验最核心的 NoAct 场景：未点击按钮不会继续推进，也不会在重载后越权出现后续回复