### PR TITLE
修复聊天历史完整性与消息可见性问题

### DIFF
--- a/backend/modules/api/chat/services/ContextTrimService.ts
+++ b/backend/modules/api/chat/services/ContextTrimService.ts
@@ -30,6 +30,7 @@ import type { TokenEstimationService } from './TokenEstimationService';
 import type { MessageBuilderService } from './MessageBuilderService';
 
 import { Logger } from '../../../../core/logger';
+import { validateHistoryIntegrity } from '../../../channel/HistoryIntegrityValidator';
 const CONVERSATION_PINNED_FILES_KEY = 'inputPinnedFiles';
 const CONVERSATION_SKILLS_KEY = 'inputSkills';
 const DEFAULT_MAX_CONTEXT_TOKENS = 128000;
@@ -79,6 +80,14 @@ interface MaxContextResolution {
     configMaxContextTokens?: unknown;
     modelId?: string;
     modelContextWindow?: unknown;
+}
+
+interface NormalizedTrimStartResult {
+    startIndex: number;
+    valid: boolean;
+    reason: 'unchanged' | 'clamped_minimum' | 'moved_to_next_round' | 'moved_to_current_round' | 'advanced_to_valid_round' | 'no_legal_round_boundary';
+    issueKind?: string;
+    issueCallId?: string;
 }
 
 export class ContextTrimService {
@@ -137,6 +146,119 @@ export class ContextTrimService {
             return undefined;
         }
         return Math.floor(numericValue);
+    }
+
+    /**
+     * trim 起点只允许落在非 functionResponse 的 user 消息上。
+     */
+    private isLegalTrimStart(history: Content[], index: number): boolean {
+        const message = history[index];
+        return !!message && message.role === 'user' && !message.isFunctionResponse;
+    }
+
+    private collectLegalTrimStartIndices(history: Content[], minimumStartIndex: number): number[] {
+        const starts: number[] = [];
+        for (let i = Math.max(0, minimumStartIndex); i < history.length; i++) {
+            if (this.isLegalTrimStart(history, i)) {
+                starts.push(i);
+            }
+        }
+        return starts;
+    }
+
+    private normalizeTrimStartIndex(
+        fullHistory: Content[],
+        minimumStartIndex: number,
+        candidateStartIndex: number
+    ): NormalizedTrimStartResult {
+        if (fullHistory.length === 0) {
+            return {
+                startIndex: 0,
+                valid: true,
+                reason: 'unchanged'
+            };
+        }
+
+        const maxIndex = Math.max(0, fullHistory.length - 1);
+        const safeMinimumStartIndex = Math.max(0, Math.min(Math.floor(minimumStartIndex), maxIndex));
+        const rawCandidate = Number.isFinite(candidateStartIndex) ? Math.floor(candidateStartIndex) : safeMinimumStartIndex;
+        const clampedCandidate = Math.max(safeMinimumStartIndex, Math.min(rawCandidate, maxIndex));
+        const legalStartIndices = this.collectLegalTrimStartIndices(fullHistory, safeMinimumStartIndex);
+
+        if (legalStartIndices.length === 0) {
+            return {
+                startIndex: clampedCandidate,
+                valid: false,
+                reason: 'no_legal_round_boundary'
+            };
+        }
+
+        let normalizedStartIndex = clampedCandidate;
+        let reason: NormalizedTrimStartResult['reason'] = rawCandidate === clampedCandidate ? 'unchanged' : 'clamped_minimum';
+
+        if (!this.isLegalTrimStart(fullHistory, clampedCandidate)) {
+            const nextLegalStartIndex = legalStartIndices.find(index => index > clampedCandidate);
+            if (nextLegalStartIndex !== undefined) {
+                normalizedStartIndex = nextLegalStartIndex;
+                reason = 'moved_to_next_round';
+            } else {
+                let currentRoundStartIndex = legalStartIndices[legalStartIndices.length - 1];
+                for (let i = legalStartIndices.length - 1; i >= 0; i--) {
+                    if (legalStartIndices[i] <= clampedCandidate) {
+                        currentRoundStartIndex = legalStartIndices[i];
+                        break;
+                    }
+                }
+                normalizedStartIndex = currentRoundStartIndex;
+                reason = 'moved_to_current_round';
+            }
+        }
+
+        const candidateStarts = [normalizedStartIndex, ...legalStartIndices.filter(index => index > normalizedStartIndex)];
+        let firstIssue: ReturnType<typeof validateHistoryIntegrity>['issues'][number] | undefined;
+
+        for (let i = 0; i < candidateStarts.length; i++) {
+            const startIndex = candidateStarts[i];
+            const validation = validateHistoryIntegrity(fullHistory.slice(startIndex));
+            if (validation.valid) {
+                return {
+                    startIndex,
+                    valid: true,
+                    reason: i === 0 ? reason : 'advanced_to_valid_round'
+                };
+            }
+            if (!firstIssue && validation.issues.length > 0) {
+                firstIssue = validation.issues[0];
+            }
+        }
+
+        return {
+            startIndex: normalizedStartIndex,
+            valid: false,
+            reason,
+            issueKind: firstIssue?.kind,
+            issueCallId: firstIssue?.callId
+        };
+    }
+
+    private async getNormalizedHistoryForStartIndex(
+        conversationId: string,
+        fullHistory: Content[],
+        historyOptions: GetHistoryOptions,
+        minimumStartIndex: number,
+        candidateStartIndex: number
+    ): Promise<ContextTrimInfo & { normalization: NormalizedTrimStartResult }> {
+        const normalization = this.normalizeTrimStartIndex(fullHistory, minimumStartIndex, candidateStartIndex);
+        const history = await this.conversationManager.getHistoryForAPI(conversationId, {
+            ...historyOptions,
+            startIndex: normalization.startIndex
+        });
+
+        return {
+            history,
+            trimStartIndex: normalization.startIndex,
+            normalization
+        };
     }
 
     /**
@@ -435,10 +557,46 @@ export class ContextTrimService {
         // 从持久化存储获取裁剪状态
         let savedState = await this.getTrimState(conversationId);
         
-        // 检测回退：如果保存的 trimStartIndex 超出了当前历史长度，清除状态
-        if (savedState && savedState.trimStartIndex >= fullHistory.length) {
-            await this.clearTrimState(conversationId);
-            savedState = null;
+        if (savedState) {
+            // 检测回退：如果保存的 trimStartIndex 超出了当前历史长度，清除状态
+            if (savedState.trimStartIndex >= fullHistory.length) {
+                this.log.warn('trim_state_cleared_invalid', {
+                    conversationId,
+                    savedTrimStartIndex: savedState.trimStartIndex,
+                    reason: 'out_of_bounds',
+                    fullHistoryLength: fullHistory.length
+                });
+                await this.clearTrimState(conversationId);
+                savedState = null;
+            } else {
+                const normalizedSavedState = this.normalizeTrimStartIndex(fullHistory, summaryStartIndex, savedState.trimStartIndex);
+                if (!normalizedSavedState.valid) {
+                    this.log.warn('trim_state_cleared_invalid', {
+                        conversationId,
+                        savedTrimStartIndex: savedState.trimStartIndex,
+                        reason: normalizedSavedState.reason,
+                        issueKind: normalizedSavedState.issueKind,
+                        callId: normalizedSavedState.issueCallId
+                    });
+                    await this.clearTrimState(conversationId);
+                    savedState = null;
+                } else if (normalizedSavedState.startIndex !== savedState.trimStartIndex) {
+                    this.log.info('trim_state_normalized', {
+                        conversationId,
+                        savedTrimStartIndex: savedState.trimStartIndex,
+                        normalizedStartIndex: normalizedSavedState.startIndex,
+                        cleared: normalizedSavedState.startIndex <= summaryStartIndex,
+                        reason: normalizedSavedState.reason
+                    });
+                    if (normalizedSavedState.startIndex > summaryStartIndex) {
+                        savedState = { trimStartIndex: normalizedSavedState.startIndex };
+                        await this.saveTrimState(conversationId, savedState);
+                    } else {
+                        await this.clearTrimState(conversationId);
+                        savedState = null;
+                    }
+                }
+            }
         }
         
         // 加载 runtime 元数据以便正确生成系统提示词和动态上下文
@@ -537,11 +695,14 @@ export class ContextTrimService {
         // 检查是否启用上下文阈值检测（上下文裁剪和自动总结互斥）
         if (!config.contextThresholdEnabled && !config.autoSummarizeEnabled) {
             // 未启用阈值检测，直接返回从 summary 开始的历史
-            const history = await this.conversationManager.getHistoryForAPI(conversationId, {
-                ...historyOptions,
-                startIndex: summaryStartIndex
-            });
-            return { history, trimStartIndex: summaryStartIndex };
+            const normalizedHistory = await this.getNormalizedHistoryForStartIndex(
+                conversationId,
+                fullHistory,
+                historyOptions,
+                summaryStartIndex,
+                summaryStartIndex
+            );
+            return { history: normalizedHistory.history, trimStartIndex: normalizedHistory.trimStartIndex };
         }
         
         // 获取最大上下文和阈值
@@ -587,10 +748,13 @@ export class ContextTrimService {
         // 自动总结模式下不做裁剪，而是返回完整历史 + needsAutoSummarize 标记
         // 由 ToolIterationLoopService 在发送请求前触发总结
         if (config.autoSummarizeEnabled) {
-            const history = await this.conversationManager.getHistoryForAPI(conversationId, {
-                ...historyOptions,
-                startIndex: summaryStartIndex
-            });
+            const normalizedHistory = await this.getNormalizedHistoryForStartIndex(
+                conversationId,
+                fullHistory,
+                historyOptions,
+                summaryStartIndex,
+                summaryStartIndex
+            );
             
             // 估算当前 token 总量来判断是否需要总结
             const fullTokenResult = this.accumulateTokens(
@@ -624,7 +788,7 @@ export class ContextTrimService {
                 this.log.info('auto_summarize_needed', { conversationId, estimatedTotalTokens: fullTokenResult.estimatedTotalTokens, threshold });
             }
             
-            return { history, trimStartIndex: summaryStartIndex, needsAutoSummarize };
+            return { history: normalizedHistory.history, trimStartIndex: normalizedHistory.trimStartIndex, needsAutoSummarize };
         }
         
         // ========== 上下文裁剪模式（原有逻辑） ==========
@@ -657,16 +821,19 @@ export class ContextTrimService {
         // 如果完整历史不超过阈值，清除裁剪状态，返回完整历史
         if (fullTokenResult.estimatedTotalTokens <= threshold) {
             await this.clearTrimState(conversationId);
-            const history = await this.conversationManager.getHistoryForAPI(conversationId, {
-                ...historyOptions,
-                startIndex: summaryStartIndex
-            });
+            const normalizedHistory = await this.getNormalizedHistoryForStartIndex(
+                conversationId,
+                fullHistory,
+                historyOptions,
+                summaryStartIndex,
+                summaryStartIndex
+            );
             this.logDebug('trim.not_needed', {
                 conversationId,
                 estimatedTotalTokens: fullTokenResult.estimatedTotalTokens,
                 threshold
             });
-            return { history, trimStartIndex: summaryStartIndex };
+            return { history: normalizedHistory.history, trimStartIndex: normalizedHistory.trimStartIndex };
         }
         
         // 完整历史超过阈值，需要裁剪
@@ -697,33 +864,27 @@ export class ContextTrimService {
             
             // 如果使用保存的状态后不超过阈值，直接使用
             if (trimmedTokenResult.estimatedTotalTokens <= threshold) {
-                let trimmedHistory = await this.conversationManager.getHistoryForAPI(conversationId, {
-                    ...historyOptions,
-                    startIndex: savedState.trimStartIndex
-                });
-                
-                // 确保历史以 user 消息开始
-                let finalTrimStartIndex = savedState.trimStartIndex;
-                if (trimmedHistory.length > 0 && trimmedHistory[0].role !== 'user') {
-                    const firstUserIndex = trimmedHistory.findIndex(m => m.role === 'user');
-                    if (firstUserIndex > 0) {
-                        trimmedHistory = trimmedHistory.slice(firstUserIndex);
-                        finalTrimStartIndex = savedState.trimStartIndex + firstUserIndex;
-                    }
-                }
+                const normalizedHistory = await this.getNormalizedHistoryForStartIndex(
+                    conversationId,
+                    fullHistory,
+                    historyOptions,
+                    summaryStartIndex,
+                    savedState.trimStartIndex
+                );
                 
                 this.logDebug('trim.saved_state_reused', {
                     conversationId,
-                    finalTrimStartIndex
+                    finalTrimStartIndex: normalizedHistory.trimStartIndex
                 });
 
-                return { history: trimmedHistory, trimStartIndex: finalTrimStartIndex };
+                return { history: normalizedHistory.history, trimStartIndex: normalizedHistory.trimStartIndex };
             }
             
             // 使用保存的状态后仍然超过阈值，需要进一步裁剪
             // 使用 trimmedTokenResult 的回合信息进行裁剪
             return await this.performContextTrim(
                 conversationId,
+                fullHistory,
                 config,
                 historyOptions,
                 savedState.trimStartIndex,
@@ -738,6 +899,7 @@ export class ContextTrimService {
         // 没有保存的状态，或者状态无效，从 summaryStartIndex 开始裁剪
         return await this.performContextTrim(
             conversationId,
+            fullHistory,
             config,
             historyOptions,
             summaryStartIndex,
@@ -911,6 +1073,7 @@ export class ContextTrimService {
      */
     private async performContextTrim(
         conversationId: string,
+        fullHistory: Content[],
         config: BaseChannelConfig,
         historyOptions: GetHistoryOptions,
         effectiveStartIndex: number,
@@ -922,17 +1085,20 @@ export class ContextTrimService {
     ): Promise<ContextTrimInfo> {
         // 至少需要保留当前回合（最后一个回合）
         if (roundsAfterStart.length <= 1) {
-            const history = await this.conversationManager.getHistoryForAPI(conversationId, {
-                ...historyOptions,
-                startIndex: effectiveStartIndex
-            });
+            const normalizedHistory = await this.getNormalizedHistoryForStartIndex(
+                conversationId,
+                fullHistory,
+                historyOptions,
+                effectiveStartIndex,
+                effectiveStartIndex
+            );
             this.logDebug('trim.perform.no_additional_cut', {
                 conversationId,
-                effectiveStartIndex,
+                effectiveStartIndex: normalizedHistory.trimStartIndex,
                 estimatedTotalTokens,
                 reason: 'only_one_round'
             });
-            return { history, trimStartIndex: effectiveStartIndex };
+            return { history: normalizedHistory.history, trimStartIndex: normalizedHistory.trimStartIndex };
         }
         
         // 计算额外裁剪的 token 数
@@ -987,45 +1153,53 @@ export class ContextTrimService {
         
         if (roundsToSkip === 0) {
             // 不需要额外裁剪，返回从起始索引开始的历史
-            const history = await this.conversationManager.getHistoryForAPI(conversationId, {
-                ...historyOptions,
-                startIndex: effectiveStartIndex
-            });
+            const normalizedHistory = await this.getNormalizedHistoryForStartIndex(
+                conversationId,
+                fullHistory,
+                historyOptions,
+                effectiveStartIndex,
+                effectiveStartIndex
+            );
             this.logDebug('trim.perform.no_additional_cut', {
                 conversationId,
-                effectiveStartIndex,
+                effectiveStartIndex: normalizedHistory.trimStartIndex,
                 estimatedTotalTokens,
                 threshold,
                 targetTokens,
                 remainingEstimatedTokensAfterTrim,
                 roundEvaluation
             });
-            return { history, trimStartIndex: effectiveStartIndex };
+            return { history: normalizedHistory.history, trimStartIndex: normalizedHistory.trimStartIndex };
         }
         
         // 计算在原始历史中的起始索引
         const trimStartIndex = roundsAfterStart[roundsToSkip].startIndex;
         
-        // 使用 startIndex 选项获取裁剪后的历史
-        let trimmedHistory = await this.conversationManager.getHistoryForAPI(conversationId, {
-            ...historyOptions,
-            startIndex: trimStartIndex
-        });
-        let finalTrimStartIndex = trimStartIndex;
-        
-        // 确保历史以 user 消息开始（Gemini API 要求）
-        if (trimmedHistory.length > 0 && trimmedHistory[0].role !== 'user') {
-            const firstUserIndex = trimmedHistory.findIndex(m => m.role === 'user');
-            if (firstUserIndex > 0) {
-                trimmedHistory = trimmedHistory.slice(firstUserIndex);
-                finalTrimStartIndex = trimStartIndex + firstUserIndex;
-            }
-        }
+        const normalizedTrimmedHistory = await this.getNormalizedHistoryForStartIndex(
+            conversationId,
+            fullHistory,
+            historyOptions,
+            effectiveStartIndex,
+            trimStartIndex
+        );
+        const trimmedHistory = normalizedTrimmedHistory.history;
+        const finalTrimStartIndex = normalizedTrimmedHistory.trimStartIndex;
         
         // 保存裁剪状态到持久化存储
-        await this.saveTrimState(conversationId, {
-            trimStartIndex: finalTrimStartIndex
-        });
+        if (normalizedTrimmedHistory.normalization.valid) {
+            await this.saveTrimState(conversationId, {
+                trimStartIndex: finalTrimStartIndex
+            });
+        } else {
+            this.log.warn('trim_state_cleared_invalid', {
+                conversationId,
+                savedTrimStartIndex: trimStartIndex,
+                reason: normalizedTrimmedHistory.normalization.reason,
+                issueKind: normalizedTrimmedHistory.normalization.issueKind,
+                callId: normalizedTrimmedHistory.normalization.issueCallId
+            });
+            await this.clearTrimState(conversationId);
+        }
 
         this.logDebug('trim.perform.applied', {
             conversationId,

--- a/backend/modules/channel/ChannelManager.ts
+++ b/backend/modules/channel/ChannelManager.ts
@@ -23,6 +23,8 @@ import type {
 } from './types';
 import { ChannelError, ErrorType } from './types';
 import { createProxyFetch, proxyStreamFetch } from './proxyFetch';
+import { Logger } from '../../core/logger';
+import { validateHistoryIntegrity } from './HistoryIntegrityValidator';
 
 /**
  * 重试状态回调类型
@@ -52,6 +54,7 @@ export type RetryStatusCallback = (status: {
 export class ChannelManager {
     private mcpManager?: McpManager;
     private retryStatusCallback?: RetryStatusCallback;
+    private readonly log = Logger.get('ChannelManager');
     
     constructor(
         private configManager: ConfigManager,
@@ -167,6 +170,37 @@ export class ChannelManager {
         // 网络错误可重试
         return true;
     }
+
+    /**
+     * 在请求发送前验证工具调用与工具结果的配对完整性
+     */
+    private validateHistoryBeforeRequest(request: GenerateRequest, channelType: string): void {
+        const validation = validateHistoryIntegrity(request.history);
+        if (validation.valid) {
+            return;
+        }
+
+        const issue = validation.issues[0];
+        const firstMessage = request.history[0];
+        const details = {
+            conversationId: request.conversationId,
+            channelType,
+            callId: issue.callId,
+            issueKind: issue.kind,
+            firstMessageRole: firstMessage?.role ?? null,
+            firstMessageIsFunctionResponse: firstMessage?.isFunctionResponse === true,
+            issueCount: validation.issues.length,
+            issues: validation.issues
+        };
+
+        this.log.warn('tool_pair_validation_failed', details);
+
+        throw new ChannelError(
+            ErrorType.VALIDATION_ERROR,
+            `Invalid tool history: ${issue.kind} (call_id: ${issue.callId})`,
+            details
+        );
+    }
     
     /**
      * 生成内容（非流式）- 内部实现
@@ -207,6 +241,9 @@ export class ChannelManager {
                 t('modules.channel.errors.configValidationFailed', { configId: request.configId })
             );
         }
+
+        // 5. 请求发送前校验工具调用历史完整性
+        this.validateHistoryBeforeRequest(request, config.type);
         
         // 5. 获取过滤后的工具声明（除非请求指定跳过工具）
         // 传递配置信息以便动态生成工具描述
@@ -382,6 +419,9 @@ export class ChannelManager {
                 t('modules.channel.errors.unsupportedChannelType', { type: config.type })
             );
         }
+
+        // 4. 请求发送前校验工具调用历史完整性
+        this.validateHistoryBeforeRequest(request, config.type);
         
         // 4. 获取过滤后的工具声明（除非请求指定跳过工具）
         // 传递配置信息以便动态生成工具描述
@@ -541,10 +581,14 @@ export class ChannelManager {
             
             // 解析响应体
             const responseBody = await response.json();
+            const responseHeaders: Record<string, string> = {};
+            response.headers.forEach((value, key) => {
+                responseHeaders[key] = value;
+            });
             
             return {
                 status: response.status,
-                headers: Object.fromEntries(response.headers.entries()),
+                headers: responseHeaders,
                 body: responseBody
             };
         } catch (error) {

--- a/backend/modules/channel/HistoryIntegrityValidator.ts
+++ b/backend/modules/channel/HistoryIntegrityValidator.ts
@@ -1,0 +1,84 @@
+import type { Content } from '../conversation/types';
+
+export type HistoryIntegrityIssueKind =
+    | 'orphan_function_response'
+    | 'duplicate_function_call_id'
+    | 'duplicate_function_response_id';
+
+export interface HistoryIntegrityIssue {
+    kind: HistoryIntegrityIssueKind;
+    callId: string;
+    messageIndex: number;
+    partIndex: number;
+    functionName?: string;
+}
+
+export interface HistoryIntegrityValidationResult {
+    valid: boolean;
+    issues: HistoryIntegrityIssue[];
+}
+
+function normalizeCallId(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+export function validateHistoryIntegrity(history: Content[]): HistoryIntegrityValidationResult {
+    const issues: HistoryIntegrityIssue[] = [];
+    const seenFunctionCallIds = new Set<string>();
+    const seenFunctionResponseIds = new Set<string>();
+
+    for (let messageIndex = 0; messageIndex < history.length; messageIndex++) {
+        const message = history[messageIndex];
+        const parts = Array.isArray(message?.parts) ? message.parts : [];
+
+        for (let partIndex = 0; partIndex < parts.length; partIndex++) {
+            const part = parts[partIndex];
+            const functionCallId = normalizeCallId(part.functionCall?.id);
+            if (functionCallId) {
+                if (seenFunctionCallIds.has(functionCallId)) {
+                    issues.push({
+                        kind: 'duplicate_function_call_id',
+                        callId: functionCallId,
+                        messageIndex,
+                        partIndex,
+                        functionName: part.functionCall?.name
+                    });
+                } else {
+                    seenFunctionCallIds.add(functionCallId);
+                }
+            }
+
+            const functionResponseId = normalizeCallId(part.functionResponse?.id);
+            if (!functionResponseId) {
+                continue;
+            }
+
+            if (seenFunctionResponseIds.has(functionResponseId)) {
+                issues.push({
+                    kind: 'duplicate_function_response_id',
+                    callId: functionResponseId,
+                    messageIndex,
+                    partIndex,
+                    functionName: part.functionResponse?.name
+                });
+            } else {
+                seenFunctionResponseIds.add(functionResponseId);
+            }
+
+            if (!seenFunctionCallIds.has(functionResponseId)) {
+                issues.push({
+                    kind: 'orphan_function_response',
+                    callId: functionResponseId,
+                    messageIndex,
+                    partIndex,
+                    functionName: part.functionResponse?.name
+                });
+            }
+        }
+    }
+
+    return {
+        valid: issues.length === 0,
+        issues
+    };
+}

--- a/frontend/src/components/message/MessageList.vue
+++ b/frontend/src/components/message/MessageList.vue
@@ -18,6 +18,7 @@ import {
   type TodoStatus as BuildTodoStatus
 } from '../../utils/todoList'
 import { getPlanExecutionPrompt, getPlanUpdateMode } from '../../utils/toolContinuations'
+import { computeVirtualRows, resolveLoadedVisibleMessages } from './messageListUtils'
 
 const { t } = useI18n()
 
@@ -413,12 +414,12 @@ function toggleTodoExpanded() {
 const VISIBLE_INCREMENT = 40
 const visibleCount = ref(VISIBLE_INCREMENT)
 
-// 是否还有更多“已加载但未展示”的消息
-const hasMoreVisible = computed(() => props.messages.length > visibleCount.value)
-// 是否还有更多“未加载到窗口”的历史消息（真分页）
+// 是否还需要继续向前补拉历史，以满足当前目标可见消息数
+const hasMoreVisible = computed(() => props.messages.length < visibleCount.value && chatStore.windowStartIndex > 0)
+// 是否还有更多“未加载到窗口”的历史消息
 const hasMoreHistory = computed(() => chatStore.windowStartIndex > 0)
-// 顶部加载指示器：任一维度有更多都显示
-const hasMore = computed(() => hasMoreVisible.value || hasMoreHistory.value)
+// 顶部加载指示器：只要仍有更早历史就显示
+const hasMore = computed(() => hasMoreHistory.value)
 
 // 增强的消息对象接口
 interface EnhancedMessage {
@@ -453,15 +454,10 @@ const mergeableCheckpointKeys = computed(() => {
 })
 
 const enhancedVisibleMessages = computed<EnhancedMessage[]>(() => {
-  const count = visibleCount.value
-  const total = props.messages.length
-  const startIndex = Math.max(0, total - count)
-  
-  // 仅对可见的消息进行切片
-  const visibleSlice = props.messages.slice(startIndex)
+  const visibleMessages = resolveLoadedVisibleMessages(props.messages, visibleCount.value)
 
   // 预先按消息索引对检查点进行分组
-  return visibleSlice.map(message => {
+  return visibleMessages.map(message => {
     const backendIndex = typeof message.backendIndex === 'number' ? message.backendIndex : -1
     const cpGroup = backendIndex !== -1 ? checkpointsByMsgIndex.value.get(backendIndex) : null
     
@@ -525,23 +521,33 @@ const ESTIMATED_ROW_HEIGHT = 112
 const VIRTUAL_OVERSCAN = 10
 const viewportHeight = ref(0)
 const scrollTop = ref(0)
+const lastVirtualizationLogKey = ref('')
 
 const virtualRows = computed(() => {
-  const rows = messageRenderRows.value
-  if (rows.length <= VIRTUALIZATION_ROW_THRESHOLD) {
-    return { rows, topPadding: 0, bottomPadding: 0 }
+  const result = computeVirtualRows(messageRenderRows.value, {
+    threshold: VIRTUALIZATION_ROW_THRESHOLD,
+    estimatedRowHeight: ESTIMATED_ROW_HEIGHT,
+    overscan: VIRTUAL_OVERSCAN,
+    viewportHeight: viewportHeight.value,
+    scrollTop: scrollTop.value
+  })
+
+  if (result.fallback && messageRenderRows.value.length > VIRTUALIZATION_ROW_THRESHOLD) {
+    const logKey = `${result.reason}:${messageRenderRows.value.length}:${result.startIndex}:${result.endIndex}`
+    if (lastVirtualizationLogKey.value !== logKey) {
+      lastVirtualizationLogKey.value = logKey
+      console.warn('message_list_virtualization_fallback', {
+        reason: result.reason,
+        totalRows: messageRenderRows.value.length,
+        startIndex: result.startIndex,
+        endIndex: result.endIndex
+      })
+    }
+  } else if (!result.fallback) {
+    lastVirtualizationLogKey.value = ''
   }
 
-  const safeViewportHeight = viewportHeight.value > 0 ? viewportHeight.value : 800
-  const visibleRows = Math.ceil(safeViewportHeight / ESTIMATED_ROW_HEIGHT)
-  const startIndex = Math.max(0, Math.floor(scrollTop.value / ESTIMATED_ROW_HEIGHT) - VIRTUAL_OVERSCAN)
-  const endIndex = Math.min(rows.length, startIndex + visibleRows + VIRTUAL_OVERSCAN * 2)
-
-  return {
-    rows: rows.slice(startIndex, endIndex),
-    topPadding: startIndex * ESTIMATED_ROW_HEIGHT,
-    bottomPadding: Math.max(0, (rows.length - endIndex) * ESTIMATED_ROW_HEIGHT)
-  }
+  return result
 })
 
 const isLoadingMore = ref(false)
@@ -558,21 +564,21 @@ async function loadMore() {
   const oldScrollTop = container.scrollTop
   
   try {
-    if (hasMoreVisible.value) {
-      // 仅展示更多“已加载到窗口”的消息
-      visibleCount.value += VISIBLE_INCREMENT
-      await nextTick()
-    } else if (hasMoreHistory.value) {
-      // 窗口已经展示到头了：向后端拉取更早一页
+    if (!hasMoreHistory.value) return
+
+    visibleCount.value += VISIBLE_INCREMENT
+    await nextTick()
+
+    while (hasMoreVisible.value && hasMoreHistory.value) {
       const prevLen = props.messages.length
       await chatStore.loadOlderMessagesPage()
       await nextTick()
-      const added = props.messages.length - prevLen
-      if (added > 0) {
-        // 让新拉取到的更早消息立刻可见
-        visibleCount.value += added
-        await nextTick()
+
+      if (props.messages.length <= prevLen) {
+        break
       }
+
+      await nextTick()
     }
   } finally {
     // 保持滚动位置：顶部插入内容会导致滚动跳动，这里手动修正

--- a/frontend/src/components/message/messageListUtils.ts
+++ b/frontend/src/components/message/messageListUtils.ts
@@ -1,0 +1,110 @@
+export interface ComputeVirtualRowsOptions {
+  threshold: number
+  estimatedRowHeight: number
+  overscan: number
+  viewportHeight: number
+  scrollTop: number
+}
+
+export interface ComputeVirtualRowsResult<T> {
+  rows: T[]
+  topPadding: number
+  bottomPadding: number
+  startIndex: number
+  endIndex: number
+  virtualized: boolean
+  fallback: boolean
+  reason?: 'below_threshold' | 'invalid_estimate' | 'invalid_viewport' | 'empty_slice' | 'clamped'
+}
+
+export function resolveLoadedVisibleMessages<T>(messages: T[], _visibleCount: number): T[] {
+  return Array.isArray(messages) ? messages : []
+}
+
+export function computeVirtualRows<T>(rows: T[], options: ComputeVirtualRowsOptions): ComputeVirtualRowsResult<T> {
+  const totalRows = Array.isArray(rows) ? rows.length : 0
+  if (totalRows === 0) {
+    return {
+      rows: [],
+      topPadding: 0,
+      bottomPadding: 0,
+      startIndex: 0,
+      endIndex: 0,
+      virtualized: false,
+      fallback: false,
+      reason: 'below_threshold'
+    }
+  }
+
+  if (totalRows <= options.threshold) {
+    return {
+      rows,
+      topPadding: 0,
+      bottomPadding: 0,
+      startIndex: 0,
+      endIndex: totalRows,
+      virtualized: false,
+      fallback: false,
+      reason: 'below_threshold'
+    }
+  }
+
+  if (!Number.isFinite(options.estimatedRowHeight) || options.estimatedRowHeight <= 0) {
+    return {
+      rows,
+      topPadding: 0,
+      bottomPadding: 0,
+      startIndex: 0,
+      endIndex: totalRows,
+      virtualized: false,
+      fallback: true,
+      reason: 'invalid_estimate'
+    }
+  }
+
+  if (!Number.isFinite(options.viewportHeight) || options.viewportHeight <= 0) {
+    return {
+      rows,
+      topPadding: 0,
+      bottomPadding: 0,
+      startIndex: 0,
+      endIndex: totalRows,
+      virtualized: false,
+      fallback: true,
+      reason: 'invalid_viewport'
+    }
+  }
+
+  const overscan = Math.max(0, Math.floor(options.overscan))
+  const visibleRows = Math.max(1, Math.ceil(options.viewportHeight / options.estimatedRowHeight))
+  const sliceLength = visibleRows + overscan * 2
+  const rawStartIndex = Math.max(0, Math.floor((Number.isFinite(options.scrollTop) ? options.scrollTop : 0) / options.estimatedRowHeight) - overscan)
+  const maxStartIndex = Math.max(0, totalRows - sliceLength)
+  const startIndex = Math.min(rawStartIndex, maxStartIndex)
+  const endIndex = Math.min(totalRows, startIndex + sliceLength)
+  const visibleSlice = rows.slice(startIndex, endIndex)
+
+  if (visibleSlice.length === 0) {
+    return {
+      rows,
+      topPadding: 0,
+      bottomPadding: 0,
+      startIndex: 0,
+      endIndex: totalRows,
+      virtualized: false,
+      fallback: true,
+      reason: 'empty_slice'
+    }
+  }
+
+  return {
+    rows: visibleSlice,
+    topPadding: Math.max(0, startIndex * options.estimatedRowHeight),
+    bottomPadding: Math.max(0, (totalRows - endIndex) * options.estimatedRowHeight),
+    startIndex,
+    endIndex,
+    virtualized: true,
+    fallback: false,
+    reason: rawStartIndex !== startIndex ? 'clamped' : undefined
+  }
+}

--- a/frontend/src/stores/chat/computed.ts
+++ b/frontend/src/stores/chat/computed.ts
@@ -8,6 +8,7 @@ import {
   getToolApprovalStopKind,
   isAwaitingToolUserConfirmation
 } from '../../utils/toolContinuations'
+import { filterVisibleChatMessages } from './visibilityUtils'
 
 /**
  * 创建 Chat Store 计算属性
@@ -39,7 +40,7 @@ export function createChatComputed(state: ChatStoreState): ChatStoreComputed {
    * 用于显示的消息列表（过滤掉纯 functionResponse 消息）
    */
   const messages = computed(() =>
-    state.allMessages.value.filter(m => !m.isFunctionResponse)
+    filterVisibleChatMessages(state.allMessages.value)
   )
   
   /** 是否有消息 */

--- a/frontend/src/stores/chat/conversationActions.ts
+++ b/frontend/src/stores/chat/conversationActions.ts
@@ -7,7 +7,7 @@
 import type { ChatStoreState, Conversation, CheckpointRecord, BuildSession } from './types'
 import { sendToExtension } from '../../utils/vscode'
 import { contentToMessageEnhanced } from './parsers'
-import type { Content } from '../../types'
+import type { Content, Message } from '../../types'
 import { perfLog, perfMeasureAsync } from '../../utils/perf'
 import { trimWindowFromTop, syncTotalMessagesFromWindow } from './windowUtils'
 import {
@@ -16,6 +16,7 @@ import {
   type ConversationModelConfig,
   type ConversationPromptModeConfig
 } from './configActions'
+import { countVisibleChatMessages } from './visibilityUtils'
 
 // ============ 对话列表分页加载配置 ============
 
@@ -24,6 +25,9 @@ export const CONVERSATIONS_PAGE_SIZE = 30
 
 /** 当前对话消息分页大小（窗口初始加载 / 上拉加载） */
 export const MESSAGES_PAGE_SIZE = 120
+
+/** 首屏至少应保证的可见消息数 */
+export const MIN_INITIAL_VISIBLE_MESSAGES = 40
 
 /** 拉取元数据时的并发数（避免一次性打爆 IPC / IO） */
 const METADATA_FETCH_CONCURRENCY = 30
@@ -108,6 +112,74 @@ export function parsePersistedBuildSession(raw: any, conversationId: string): Bu
     startedAt,
     anchorBackendIndex,
     status
+  }
+}
+
+interface InitialVisibleMessageWindowResult {
+  messages: Message[]
+  totalMessages: number
+  windowStartIndex: number
+}
+
+export async function buildInitialVisibleMessageWindow(
+  initialPage: Content[],
+  initialTotalMessages: number,
+  fetchOlderPage: (beforeIndex: number) => Promise<{ total: number; messages: Content[] } | null | undefined>
+): Promise<InitialVisibleMessageWindowResult> {
+  let totalMessages = initialTotalMessages ?? initialPage.length
+  let messages = initialPage.map(content => contentToMessageEnhanced(content))
+  let windowStartIndex = initialPage[0]?.index ?? Math.max(0, totalMessages - initialPage.length)
+  let visibleCount = countVisibleChatMessages(messages)
+
+  perfLog('conversation_initial_visible_backfill', {
+    phase: 'initial',
+    rawCount: initialPage.length,
+    visibleCount,
+    totalMessages,
+    windowStartIndex,
+    satisfied: visibleCount >= MIN_INITIAL_VISIBLE_MESSAGES
+  })
+
+  while (visibleCount < MIN_INITIAL_VISIBLE_MESSAGES && windowStartIndex > 0) {
+    const previousStartIndex = windowStartIndex
+    const result = await fetchOlderPage(previousStartIndex)
+    const olderPage = result?.messages || []
+    totalMessages = result?.total ?? totalMessages
+
+    if (olderPage.length === 0) {
+      windowStartIndex = 0
+      break
+    }
+
+    const olderMessages = olderPage.map(content => contentToMessageEnhanced(content))
+    messages = [...olderMessages, ...messages]
+
+    const nextStartIndex = olderPage[0]?.index
+    windowStartIndex = typeof nextStartIndex === 'number'
+      ? nextStartIndex
+      : Math.max(0, previousStartIndex - olderPage.length)
+    visibleCount = countVisibleChatMessages(messages)
+
+    perfLog('conversation_initial_visible_backfill', {
+      phase: 'backfill',
+      beforeIndex: previousStartIndex,
+      rawCount: messages.length,
+      olderRawCount: olderPage.length,
+      visibleCount,
+      totalMessages,
+      windowStartIndex,
+      satisfied: visibleCount >= MIN_INITIAL_VISIBLE_MESSAGES
+    })
+
+    if (windowStartIndex >= previousStartIndex) {
+      break
+    }
+  }
+
+  return {
+    messages,
+    totalMessages,
+    windowStartIndex
   }
 }
 
@@ -362,23 +434,37 @@ export async function loadHistory(state: ChatStoreState): Promise<void> {
   if (!state.currentConversationId.value) return
   
   try {
+    const conversationId = state.currentConversationId.value
+
     // 重置折叠提示（重新加载最后一页）
     state.historyFolded.value = false
     state.foldedMessageCount.value = 0
 
     const result = await perfMeasureAsync('conversation.loadHistoryPaged', () =>
       sendToExtension<{ total: number; messages: Content[] }>('conversation.getMessagesPaged', {
-        conversationId: state.currentConversationId.value,
+        conversationId,
         limit: MESSAGES_PAGE_SIZE
       })
     )
 
     const page = result?.messages || []
-    state.totalMessages.value = result?.total ?? page.length
+    const initialWindow = await buildInitialVisibleMessageWindow(
+      page,
+      result?.total ?? page.length,
+      async (beforeIndex) => perfMeasureAsync('conversation.loadHistoryPaged.backfill', () =>
+        sendToExtension<{ total: number; messages: Content[] }>('conversation.getMessagesPaged', {
+          conversationId,
+          beforeIndex,
+          limit: MESSAGES_PAGE_SIZE
+        })
+      )
+    )
+
+    state.totalMessages.value = initialWindow.totalMessages
 
     // 转换所有消息，包括 functionResponse 消息
-    state.allMessages.value = page.map(content => contentToMessageEnhanced(content))
-    state.windowStartIndex.value = page[0]?.index ?? 0
+    state.allMessages.value = initialWindow.messages
+    state.windowStartIndex.value = initialWindow.windowStartIndex
     syncTotalMessagesFromWindow(state)
 
     perfLog('conversation.window', {
@@ -534,9 +620,21 @@ export async function switchConversation(
       ])
 
       const page = view?.messages || []
-      state.totalMessages.value = view?.totalMessages ?? page.length
-      state.allMessages.value = page.map(content => contentToMessageEnhanced(content))
-      state.windowStartIndex.value = page[0]?.index ?? 0
+      const initialWindow = await buildInitialVisibleMessageWindow(
+        page,
+        view?.totalMessages ?? page.length,
+        async (beforeIndex) => perfMeasureAsync('conversation.loadConversationForView.backfill', () =>
+          sendToExtension<{ total: number; messages: Content[] }>('conversation.getMessagesPaged', {
+            conversationId: id,
+            beforeIndex,
+            limit: MESSAGES_PAGE_SIZE
+          })
+        )
+      )
+
+      state.totalMessages.value = initialWindow.totalMessages
+      state.allMessages.value = initialWindow.messages
+      state.windowStartIndex.value = initialWindow.windowStartIndex
       syncTotalMessagesFromWindow(state)
 
       state.checkpoints.value = Array.isArray(view?.checkpoints) ? view.checkpoints : []

--- a/frontend/src/stores/chat/visibilityUtils.ts
+++ b/frontend/src/stores/chat/visibilityUtils.ts
@@ -1,0 +1,16 @@
+export interface ChatVisibilityLike {
+  isFunctionResponse?: boolean | null
+}
+
+export function isVisibleChatMessage<T extends ChatVisibilityLike>(message: T): boolean {
+  return message?.isFunctionResponse !== true
+}
+
+export function filterVisibleChatMessages<T extends ChatVisibilityLike>(messages: T[]): T[] {
+  if (!Array.isArray(messages) || messages.length === 0) return []
+  return messages.filter(isVisibleChatMessage)
+}
+
+export function countVisibleChatMessages<T extends ChatVisibilityLike>(messages: T[]): number {
+  return filterVisibleChatMessages(messages).length
+}

--- a/frontend/src/stores/chat/windowUtils.ts
+++ b/frontend/src/stores/chat/windowUtils.ts
@@ -1,8 +1,97 @@
 import type { ChatStoreState } from './types'
+import type { Message } from '../../types'
 import { perfLog } from '../../utils/perf'
 
-/** 默认消息窗口上限（包含 functionResponse 等隐藏消息） */
+/** 默认消息窗口上限（按可见消息预算计算，保留完整轮次） */
 export const MAX_WINDOW_MESSAGES = 800
+
+interface WindowRound {
+  startIndex: number
+  endIndex: number
+  visibleCount: number
+}
+
+function isVisibleWindowMessage(message: Message): boolean {
+  return message.isFunctionResponse !== true
+}
+
+function getMessageAbsoluteIndex(message: Message | undefined, fallbackIndex: number): number {
+  if (typeof message?.backendIndex === 'number' && Number.isFinite(message.backendIndex)) {
+    return message.backendIndex
+  }
+  return fallbackIndex
+}
+
+function collectWindowRounds(messages: Message[]): WindowRound[] {
+  const rounds: WindowRound[] = []
+  let currentRoundStartIndex = -1
+  let currentRoundVisibleCount = 0
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]
+    const isRoundStart = message.role === 'user' && !message.isFunctionResponse
+
+    if (isRoundStart) {
+      if (currentRoundStartIndex !== -1) {
+        rounds.push({
+          startIndex: currentRoundStartIndex,
+          endIndex: i,
+          visibleCount: currentRoundVisibleCount
+        })
+      }
+      currentRoundStartIndex = i
+      currentRoundVisibleCount = 0
+    }
+
+    if (currentRoundStartIndex !== -1 && isVisibleWindowMessage(message)) {
+      currentRoundVisibleCount += 1
+    }
+  }
+
+  if (currentRoundStartIndex !== -1) {
+    rounds.push({
+      startIndex: currentRoundStartIndex,
+      endIndex: messages.length,
+      visibleCount: currentRoundVisibleCount
+    })
+  }
+
+  if (rounds.length === 0 && messages.length > 0) {
+    rounds.push({
+      startIndex: 0,
+      endIndex: messages.length,
+      visibleCount: messages.filter(isVisibleWindowMessage).length
+    })
+  }
+
+  return rounds
+}
+
+export function calculateTrimWindowStartIndex(messages: Message[], maxVisibleCount = MAX_WINDOW_MESSAGES): number {
+  if (!Array.isArray(messages) || messages.length === 0) return 0
+
+  const rounds = collectWindowRounds(messages)
+  if (rounds.length === 0) {
+    return getMessageAbsoluteIndex(messages[0], 0)
+  }
+
+  let keepStartIndex = rounds[rounds.length - 1].startIndex
+  let keptVisibleCount = 0
+
+  for (let i = rounds.length - 1; i >= 0; i--) {
+    const round = rounds[i]
+    const nextVisibleCount = keptVisibleCount + round.visibleCount
+
+    if (keptVisibleCount > 0 && nextVisibleCount > maxVisibleCount) {
+      break
+    }
+
+    keepStartIndex = round.startIndex
+    keptVisibleCount = nextVisibleCount
+  }
+
+  return getMessageAbsoluteIndex(messages[keepStartIndex], keepStartIndex)
+}
 
 /**
  * 用窗口推导并同步“已知总消息数”
@@ -25,27 +114,41 @@ export function setTotalMessagesFromWindow(state: ChatStoreState): void {
  */
 export function trimWindowFromTop(state: ChatStoreState, maxCount = MAX_WINDOW_MESSAGES): number {
   const all = state.allMessages.value
-  const overflow = all.length - maxCount
-  if (overflow <= 0) return 0
+  if (!Array.isArray(all) || all.length === 0) return 0
 
-  state.allMessages.value = all.slice(overflow)
-  state.windowStartIndex.value += overflow
+  const currentWindowStartIndex = getMessageAbsoluteIndex(all[0], state.windowStartIndex.value)
+  const nextWindowStartIndex = calculateTrimWindowStartIndex(all, maxCount)
+  if (nextWindowStartIndex <= currentWindowStartIndex) return 0
+
+  let removeCount = 0
+  while (removeCount < all.length) {
+    const absoluteIndex = getMessageAbsoluteIndex(all[removeCount], currentWindowStartIndex + removeCount)
+    if (absoluteIndex >= nextWindowStartIndex) {
+      break
+    }
+    removeCount += 1
+  }
+
+  if (removeCount <= 0) return 0
+
+  state.allMessages.value = all.slice(removeCount)
+  state.windowStartIndex.value = nextWindowStartIndex
 
   // 清理窗口外的检查点，避免长期累积
   state.checkpoints.value = state.checkpoints.value.filter(cp => cp.messageIndex >= state.windowStartIndex.value)
 
   // 标记已发生折叠（用于 UI 提示）
   state.historyFolded.value = true
-  state.foldedMessageCount.value += overflow
+  state.foldedMessageCount.value += removeCount
 
   syncTotalMessagesFromWindow(state)
 
   perfLog('conversation.window.trim', {
-    removed: overflow,
+    removed: removeCount,
     start: state.windowStartIndex.value,
     count: state.allMessages.value.length,
     total: state.totalMessages.value
   })
 
-  return overflow
+  return removeCount
 }


### PR DESCRIPTION
﻿## 概要
本 PR 按照 `.limcode/design/chat-history-integrity-and-message-visibility-fix-design.md` 与 `.limcode/plans/chat-history-integrity-and-message-visibility-fix-plan.md` 完成聊天历史完整性与消息可见性修复。

## 严重性
**高**

- 后端在工具调用历史不完整时，可能向 provider 发送非法上下文，触发 provider `400`，并出现 `No tool call found for function call output with call_id ...` 一类错误。
- 前端在应用重启、会话切换、长会话增长和虚拟列表边界场景下，可能出现首屏接近空白、旧消息被静默挤出、消息列表空白等问题。
- 该问题同时影响历史一致性、消息可见性和会话连续性，应当优先修复。

## 修复方案

### 后端历史完整性
- 新增 `backend/modules/channel/HistoryIntegrityValidator.ts`
- 实现 `validateHistoryIntegrity(history: Content[])`
- 检测：
  - `orphan_function_response`
  - `duplicate_function_call_id`
  - `duplicate_function_response_id`
- 在 `backend/modules/channel/ChannelManager.ts` 中新增 `validateHistoryBeforeRequest(...)`
- 在 `generateNonStream(...)` 和 `generateStream(...)` 中，于 provider 请求发送前完成校验并阻断非法历史
- 记录 `tool_pair_validation_failed` 日志，并返回 `ChannelError(ErrorType.VALIDATION_ERROR, ...)`

### 上下文裁剪与 trimState 自修复
- 在 `backend/modules/api/chat/services/ContextTrimService.ts` 中新增 trim 起点规范化逻辑
- `trimStartIndex` 现在只允许落在 `role === 'user' && !isFunctionResponse`
- 对非法持久化 `trimState` 进行规范化；无法修复时清除
- 若某个候选起点会破坏工具配对关系，则继续向后寻找合法轮次
- 新增 `trim_state_normalized` 与 `trim_state_cleared_invalid` 日志

### 前端消息可见性
- 新增 `frontend/src/stores/chat/visibilityUtils.ts`
- 统一 `computed.messages` 与其它流程的可见消息过滤语义
- 在 `frontend/src/stores/chat/conversationActions.ts` 中为 `loadHistory(...)` 与 `switchConversation(...)` 增加初始可见消息回填
- 当可见消息不足时，按页继续回取历史，直到达到 `MIN_INITIAL_VISIBLE_MESSAGES = 40` 或无更早消息
- 记录 `conversation_initial_visible_backfill` 日志

### MessageList 展示与虚拟化安全
- 新增 `frontend/src/components/message/messageListUtils.ts`
- `VISIBLE_INCREMENT = 40` 保留，但改为“增加需要加载的可见历史目标量”，不再对已加载可见消息做尾部切片
- `MessageList.vue` 现在渲染当前已加载的全部可见消息，并修正 `hasMoreVisible` 语义
- 在虚拟化估算值异常、视口异常或切片结果为空时，自动回退为完整渲染，避免空白列表
- 记录 `message_list_virtualization_fallback` 日志

### 窗口裁剪预算语义
- 重写 `frontend/src/stores/chat/windowUtils.ts`
- 按“可见消息预算”裁剪，并保留完整轮次
- 隐藏的 `isFunctionResponse` 不再单独挤占主可见预算

## 保持不变的关键常量
- `MAX_WINDOW_MESSAGES = 800`
- `MESSAGES_PAGE_SIZE = 120`
- `VISIBLE_INCREMENT = 40`
- `MIN_INITIAL_VISIBLE_MESSAGES = 40`
- `VIRTUALIZATION_ROW_THRESHOLD = 180`
- `ESTIMATED_ROW_HEIGHT = 112`

## 测试与验证
已完成以下验证：
- `npm test -- --runInBand test/frontend/chat/conversationActions.test.ts test/frontend/chat/windowUtils.test.ts test/frontend/message/messageListUtils.test.ts test/unit/channel/ChannelManager.historyIntegrity.test.ts test/unit/chat/ContextTrimService.historyIntegrity.test.ts`
- `npm test -- --runInBand`
- `npm run compile`
- `cd frontend && npm run build`

结果：
- `78` 个 test suites 通过
- `322` 个 tests 通过
- 后端编译通过
- 前端构建通过

## 备注
- 未引入第三方库
- 变更依据：
  - `.limcode/design/chat-history-integrity-and-message-visibility-fix-design.md`
  - `.limcode/plans/chat-history-integrity-and-message-visibility-fix-plan.md`
