### PR TITLE
fix(openai): 支持 content 前缀思考标签折叠

### DIFF
--- a/backend/__tests__/channel/thinkTagParser.test.ts
+++ b/backend/__tests__/channel/thinkTagParser.test.ts
@@ -1,0 +1,137 @@
+import { StreamAccumulator } from '../../modules/channel/StreamAccumulator'
+import { OpenAIFormatter } from '../../modules/channel/formatters/openai'
+import { ThinkTagParser, splitThinkTagsFromText } from '../../modules/channel/thinkTagParser'
+
+describe('leading think tag extraction', () => {
+  it('splits a leading <think> block into a thought part', () => {
+    expect(splitThinkTagsFromText('<think>reasoning</think>final answer')).toEqual([
+      { text: 'reasoning', thought: true },
+      { text: 'final answer' }
+    ])
+  })
+
+  it('allows whitespace before the leading proxy think block', () => {
+    expect(splitThinkTagsFromText('\n\n<think>reasoning</think>final answer')).toEqual([
+      { text: 'reasoning', thought: true },
+      { text: 'final answer' }
+    ])
+  })
+
+  it('parses multiple leading think blocks before the normal answer starts', () => {
+    expect(splitThinkTagsFromText('<think>first</think>\n<think>second</think>answer')).toEqual([
+      { text: 'first\nsecond', thought: true },
+      { text: 'answer' }
+    ])
+  })
+
+  it('preserves <think> tags that appear after normal text has started', () => {
+    expect(splitThinkTagsFromText('before <think>example</think> after')).toEqual([
+      { text: 'before <think>example</think> after' }
+    ])
+  })
+
+  it('preserves markdown/code examples instead of folding them', () => {
+    const markdown = 'Example:\n```xml\n<think>demo</think>\n```'
+    expect(splitThinkTagsFromText(markdown)).toEqual([{ text: markdown }])
+  })
+
+  it('does not leak partial leading tags while streaming', () => {
+    const parser = new ThinkTagParser()
+
+    expect(parser.process('<th')).toEqual([])
+    expect(parser.process('ink>reason')).toEqual([{ text: 'reason', thought: true }])
+    expect(parser.process('</thi')).toEqual([])
+    expect(parser.process('nk>answer')).toEqual([{ text: 'answer' }])
+  })
+
+  it('does not hide similar but non-tag text forever', () => {
+    const parser = new ThinkTagParser()
+
+    expect(parser.process('<thi')).toEqual([])
+    expect(parser.process('s is ordinary text')).toEqual([{ text: '<this is ordinary text' }])
+  })
+
+  it('treats an unfinished leading think block as thought content when finalized', () => {
+    const parser = new ThinkTagParser()
+
+    expect(parser.process('<think>reason')).toEqual([{ text: 'reason', thought: true }])
+    expect(parser.finalize()).toEqual([])
+  })
+})
+
+describe('OpenAI formatter think-tag compatibility', () => {
+  it('parses non-stream leading content with <think> tags into collapsible thought parts', () => {
+    const formatter = new OpenAIFormatter()
+    const response = formatter.parseResponse({
+      model: 'relay-model',
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: '<think>relay reasoning</think>visible answer'
+          },
+          finish_reason: 'stop'
+        }
+      ]
+    })
+
+    expect(response.content.parts).toEqual([
+      { text: 'relay reasoning', thought: true },
+      { text: 'visible answer' }
+    ])
+  })
+
+  it('leaves non-leading <think> tags in normal text', () => {
+    const formatter = new OpenAIFormatter()
+    const response = formatter.parseResponse({
+      model: 'relay-model',
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: 'Here is an example: <think>demo</think>'
+          },
+          finish_reason: 'stop'
+        }
+      ]
+    })
+
+    expect(response.content.parts).toEqual([
+      { text: 'Here is an example: <think>demo</think>' }
+    ])
+  })
+})
+
+describe('StreamAccumulator think-tag compatibility', () => {
+  it('normalizes streamed leading <think> tags before they reach the UI', () => {
+    const accumulator = new StreamAccumulator('function_call', () => 'tool-id')
+
+    expect(accumulator.add({ delta: [{ text: '<thi' }], done: false })).toEqual([])
+    expect(accumulator.add({ delta: [{ text: 'nk>streamed reasoning' }], done: false })).toEqual([
+      { text: 'streamed reasoning', thought: true }
+    ])
+    expect(accumulator.add({ delta: [{ text: '</think>streamed answer' }], done: true })).toEqual([
+      { text: 'streamed answer' }
+    ])
+
+    expect(accumulator.getContent().parts).toEqual([
+      { text: 'streamed reasoning', thought: true },
+      { text: 'streamed answer' }
+    ])
+  })
+
+  it('does not fold streamed <think> tags after normal text has started', () => {
+    const accumulator = new StreamAccumulator('function_call', () => 'tool-id')
+
+    expect(accumulator.add({ delta: [{ text: 'Example: ' }], done: false })).toEqual([
+      { text: 'Example: ' }
+    ])
+    expect(accumulator.add({ delta: [{ text: '<think>demo</think>' }], done: true })).toEqual([
+      { text: '<think>demo</think>' }
+    ])
+
+    expect(accumulator.getContent().parts).toEqual([
+      { text: 'Example: <think>demo</think>' }
+    ])
+  })
+})

--- a/backend/modules/channel/StreamAccumulator.ts
+++ b/backend/modules/channel/StreamAccumulator.ts
@@ -10,6 +10,7 @@ import type { StreamChunk, StreamUsageMetadata } from './types';
 import type { ToolMode } from '../config/configs/base';
 import { parseXMLToolCalls } from '../../tools/xmlFormatter';
 import { IncrementalPromptToolParser } from '../../tools/promptToolParser';
+import { ThinkTagParser } from './thinkTagParser';
 
 // JSON 工具调用边界标记
 const TOOL_CALL_START = '<<<TOOL_CALL>>>';
@@ -92,6 +93,9 @@ export class StreamAccumulator {
 
     /** Prompt 模式下的增量工具解析器 */
     private promptToolParser?: IncrementalPromptToolParser;
+
+    /** 将内容中的 <think>...</think> 标签流式转换为 thought parts */
+    private readonly thinkTagParser = new ThinkTagParser();
     
     constructor(
         toolMode: ToolMode = 'function_call',
@@ -195,10 +199,24 @@ export class StreamAccumulator {
             }
         }
 
+        if (chunk.done) {
+            const trailingThinkParts = this.thinkTagParser.finalize();
+            for (const part of trailingThinkParts) {
+                this.addPart(part, {
+                    skipThinkTagParser: true,
+                    visibleDelta
+                });
+            }
+        }
+
         if (chunk.done && this.promptToolParser) {
             const trailingParts = this.promptToolParser.flushIncompleteAsText();
             for (const part of trailingParts) {
-                this.addPart(part, { skipPromptParser: true, visibleDelta });
+                this.addPart(part, {
+                    skipPromptParser: true,
+                    skipThinkTagParser: true,
+                    visibleDelta
+                });
             }
         }
         
@@ -252,14 +270,27 @@ export class StreamAccumulator {
         part: ContentPart,
         options?: {
             skipPromptParser?: boolean;
+            skipThinkTagParser?: boolean;
             visibleDelta?: ContentPart[];
         }
     ): void {
+        if (!options?.skipThinkTagParser && part.text && !part.thought) {
+            const parsedThinkParts = this.thinkTagParser.process(part.text);
+            for (const parsedPart of parsedThinkParts) {
+                this.addPart(parsedPart, {
+                    ...options,
+                    skipThinkTagParser: true
+                });
+            }
+            return;
+        }
+
         if (!options?.skipPromptParser && this.promptToolParser && part.text && !part.thought) {
             const parsedParts = this.promptToolParser.appendText(part.text);
             for (const parsedPart of parsedParts) {
                 this.addPart(parsedPart, {
                     skipPromptParser: true,
+                    skipThinkTagParser: true,
                     visibleDelta: options?.visibleDelta
                 });
             }

--- a/backend/modules/channel/formatters/openai.ts
+++ b/backend/modules/channel/formatters/openai.ts
@@ -50,6 +50,7 @@ import type {
     ChannelError,
     ErrorType
 } from '../types';
+import { splitThinkTagsFromText } from '../thinkTagParser';
 
 /**
  * OpenAI 格式转换器
@@ -623,7 +624,10 @@ export class OpenAIFormatter extends BaseFormatter {
     private parseResponseFunctionCallMode(message: any, parts: ContentPart[]): ContentPart[] {
         // 添加主要内容
         if (message.content) {
-            parts.push({ text: message.content });
+            parts.push(...splitThinkTagsFromText(message.content as string).filter(part => {
+                if (!('text' in part)) return true;
+                return (part.text || '').trim().length > 0;
+            }));
         }
         
         // 处理 tool_calls（函数调用）
@@ -663,16 +667,38 @@ export class OpenAIFormatter extends BaseFormatter {
         
         const contentText = message.content as string;
 
-        const promptMode = detectPromptToolMode(contentText);
-        if (!promptMode) {
-            if (contentText.trim()) {
-                parts.push({ text: contentText });
+        return [...parts, ...this.parseTextContentParts(contentText)];
+    }
+
+    /**
+     * 解析普通文本内容：
+     * 1. 先将 <think>...</think> 标签转换为 thought parts；
+     * 2. 再仅对非思考文本检测 XML/JSON 工具调用。
+     */
+    private parseTextContentParts(contentText: string): ContentPart[] {
+        const parsedParts: ContentPart[] = [];
+
+        for (const part of splitThinkTagsFromText(contentText)) {
+            if (!('text' in part) || !(part.text || '').trim()) {
+                continue;
             }
-            return parts;
+
+            if (part.thought) {
+                parsedParts.push(part);
+                continue;
+            }
+
+            const promptMode = detectPromptToolMode(part.text || '');
+            if (!promptMode) {
+                parsedParts.push({ text: part.text });
+                continue;
+            }
+
+            const extracted = extractPromptToolParts(part.text || '', promptMode, { flushIncompleteTailAsText: true });
+            parsedParts.push(...extracted.parts);
         }
 
-        const extracted = extractPromptToolParts(contentText, promptMode, { flushIncompleteTailAsText: true });
-        return [...parts, ...extracted.parts];
+        return parsedParts;
     }
     
     /**

--- a/backend/modules/channel/thinkTagParser.ts
+++ b/backend/modules/channel/thinkTagParser.ts
@@ -1,0 +1,189 @@
+/**
+ * Utilities for extracting a leading <think>...</think> block from model text.
+ *
+ * Some OpenAI-compatible proxy services do not expose reasoning_content as a
+ * dedicated field. Instead they prepend it to content as:
+ *
+ *   <think>reasoning...</think>final answer...
+ *
+ * LimCode's UI already knows how to render ContentPart objects with
+ * `thought: true` as collapsible thinking blocks. This parser converts only
+ * those leading proxy-style tags into that internal representation. Later
+ * <think> tags in Markdown/code/plain text are preserved as ordinary text.
+ */
+
+import type { ContentPart } from '../conversation/types';
+
+const OPENING_THINK_TAG = '<think>';
+const CLOSING_THINK_TAG = '</think>';
+
+type ParserState = 'beforePrefix' | 'insideThink' | 'afterThink' | 'plainText';
+
+function startsWithTag(source: string, tag: string): boolean {
+    return source.toLowerCase().startsWith(tag);
+}
+
+function isPotentialTagPrefix(source: string, tag: string): boolean {
+    return source.length > 0 && tag.startsWith(source.toLowerCase());
+}
+
+/**
+ * Case-insensitive indexOf for fixed ASCII tags.
+ */
+function indexOfTag(source: string, tag: string): number {
+    return source.toLowerCase().indexOf(tag);
+}
+
+/**
+ * Returns the longest suffix length of `source` that may be the beginning of
+ * `tag`. Used to avoid leaking partial streaming tags such as "</thi".
+ */
+function potentialTagPrefixLength(source: string, tag: string): number {
+    const lowerSource = source.toLowerCase();
+    const maxLen = Math.min(lowerSource.length, tag.length - 1);
+
+    for (let len = maxLen; len > 0; len--) {
+        if (tag.startsWith(lowerSource.slice(lowerSource.length - len))) {
+            return len;
+        }
+    }
+
+    return 0;
+}
+
+function leadingWhitespaceLength(text: string): number {
+    return text.match(/^\s*/)?.[0].length ?? 0;
+}
+
+function appendTextPart(parts: ContentPart[], text: string, thought: boolean): void {
+    if (!text) return;
+
+    const lastPart = parts[parts.length - 1];
+    if (
+        lastPart &&
+        'text' in lastPart &&
+        !lastPart.functionCall &&
+        (lastPart.thought === true) === thought
+    ) {
+        lastPart.text = `${lastPart.text || ''}${text}`;
+        return;
+    }
+
+    parts.push(thought ? { text, thought: true } : { text });
+}
+
+/**
+ * Streaming-safe leading <think> tag extractor.
+ *
+ * It only parses <think> blocks before the first non-whitespace normal answer
+ * token. Once normal text starts, the parser switches to plainText mode and
+ * preserves any later <think> tags exactly as text, which prevents Markdown or
+ * code examples from being folded accidentally.
+ */
+export class ThinkTagParser {
+    private buffer = '';
+    private state: ParserState = 'beforePrefix';
+    private hasParsedThinkPrefix = false;
+
+    process(text: string): ContentPart[] {
+        if (!text) return [];
+
+        this.buffer += text;
+        return this.drain(false);
+    }
+
+    finalize(): ContentPart[] {
+        return this.drain(true);
+    }
+
+    reset(): void {
+        this.buffer = '';
+        this.state = 'beforePrefix';
+        this.hasParsedThinkPrefix = false;
+    }
+
+    private drain(final: boolean): ContentPart[] {
+        const parts: ContentPart[] = [];
+
+        while (this.buffer.length > 0) {
+            if (this.state === 'plainText') {
+                appendTextPart(parts, this.buffer, false);
+                this.buffer = '';
+                break;
+            }
+
+            if (this.state === 'insideThink') {
+                const closingIndex = indexOfTag(this.buffer, CLOSING_THINK_TAG);
+
+                if (closingIndex >= 0) {
+                    appendTextPart(parts, this.buffer.slice(0, closingIndex), true);
+                    this.buffer = this.buffer.slice(closingIndex + CLOSING_THINK_TAG.length);
+                    this.state = 'afterThink';
+                    continue;
+                }
+
+                if (final) {
+                    appendTextPart(parts, this.buffer, true);
+                    this.buffer = '';
+                    this.state = 'afterThink';
+                    break;
+                }
+
+                const keepLen = potentialTagPrefixLength(this.buffer, CLOSING_THINK_TAG);
+                const emitLen = this.buffer.length - keepLen;
+
+                if (emitLen > 0) {
+                    appendTextPart(parts, this.buffer.slice(0, emitLen), true);
+                    this.buffer = this.buffer.slice(emitLen);
+                }
+
+                break;
+            }
+
+            const whitespaceLen = leadingWhitespaceLength(this.buffer);
+            const afterWhitespace = this.buffer.slice(whitespaceLen);
+
+            if (afterWhitespace.length === 0) {
+                if (final && !this.hasParsedThinkPrefix) {
+                    appendTextPart(parts, this.buffer, false);
+                }
+                if (final) this.buffer = '';
+                break;
+            }
+
+            if (startsWithTag(afterWhitespace, OPENING_THINK_TAG)) {
+                // Drop whitespace before the first leading think block, but keep
+                // separators between multiple leading think blocks as thought
+                // content so separate reasoning chunks do not get glued together.
+                if (this.hasParsedThinkPrefix && whitespaceLen > 0) {
+                    appendTextPart(parts, this.buffer.slice(0, whitespaceLen), true);
+                }
+                this.buffer = afterWhitespace.slice(OPENING_THINK_TAG.length);
+                this.state = 'insideThink';
+                this.hasParsedThinkPrefix = true;
+                continue;
+            }
+
+            if (!final && isPotentialTagPrefix(afterWhitespace, OPENING_THINK_TAG)) {
+                // Wait for more chunks before deciding whether this is really a
+                // leading <think> tag or ordinary text starting with similar chars.
+                break;
+            }
+
+            appendTextPart(parts, this.buffer, false);
+            this.buffer = '';
+            this.state = 'plainText';
+            break;
+        }
+
+        return parts;
+    }
+}
+
+/**
+ * Non-stream helper for complete content strings.
+ */
+export function splitThinkTagsFromText(text: string): ContentPart[] {
+    const parser = new ThinkTagParser();
+    return [...parser.process(text), ...parser.finalize()];
+}


### PR DESCRIPTION
## 背景

部分 OpenAI-compatible API 中转服务不会把推理内容作为独立的 `reasoning_content` 字段返回，而是会将前缀思考块拼接到 `message.content` 的开头。

标准前缀格式示例：

```text
<think>reasoning content</think>final answer
```

当前 Lim Code 对原生 `reasoning_content` 已有 `thought: true` 支持，但对这种被拼入 `content` 的前缀思考块只会按普通 Markdown 文本渲染，导致标签直接暴露，无法折叠为思考过程。

## 修复内容

### 1. 新增前缀思考标签解析器

新增：

- `backend/modules/channel/thinkTagParser.ts`

实现流式安全的前缀思考块解析：

- 只解析 assistant 内容开头的标准前缀思考块
- 允许前置空白
- 支持多个连续前缀思考块
- 流式输出时会暂存半截标签，避免半截 opening / closing tag 暴露到 UI
- 一旦普通正文开始，后续出现的同类标签会保留为普通文本

这样可以避免误伤 Markdown / 代码示例中的同类标签。

### 2. 接入流式响应累加器

修改：

- `backend/modules/channel/StreamAccumulator.ts`

在普通文本进入 prompt tool parser 之前，先处理前缀思考块，并将其转换为：

```ts
{ text: '...', thought: true }
```

这样前端可以复用现有的思考内容折叠渲染逻辑。

### 3. 接入 OpenAI 非流式响应解析

修改：

- `backend/modules/channel/formatters/openai.ts`

在非流式 OpenAI-compatible 响应中：

- 保留原有 `message.reasoning_content` 解析逻辑
- 对 `message.content` 开头的标准前缀思考块进行拆分
- 仅对非思考正文继续检测 XML / JSON prompt tool call

### 4. 补充测试

新增：

- `backend/__tests__/channel/thinkTagParser.test.ts`

覆盖：

- 标准前缀思考块
- 前置空白
- 多个连续前缀思考块
- 流式半截标签不泄露
- 普通正文中的同类标签不折叠
- Markdown / 代码示例中的同类标签不折叠
- OpenAI formatter 非流式解析
- StreamAccumulator 流式解析

## 验证

已本地执行：

```bash
npm run compile
```

通过。

```bash
npm test -- backend/__tests__/channel/thinkTagParser.test.ts --runInBand
```

结果：

- 1 个 test suite 通过
- 12 个 tests 通过

```bash
npm --prefix frontend run build
```

通过。

## 影响范围

- 仅影响模型响应内容解析阶段
- 不修改前端思考块 UI
- 不影响原生 `reasoning_content` 字段处理
- 不自动迁移或修改历史消息

## 兼容性说明

本 PR 有意只处理标准前缀格式：

```text
<think>...</think>answer
```

不会处理以下变体：

```text
<thinking>...</thinking>
<think class="..."></think>
```

这是为了避免误判普通 Markdown / 代码示例。